### PR TITLE
Store environment type in manifest

### DIFF
--- a/src/Commands/EnvInitCommand.php
+++ b/src/Commands/EnvInitCommand.php
@@ -49,7 +49,10 @@ class EnvInitCommand extends Command
 
         Helpers::info("✅ Environment <comment>$name</comment> created successfully.");
 
-        Manifest::addEnvironment($env['name']);
+        Manifest::addEnvironment([
+            'name' => $env['name'] ?? $name,
+            'type' => $env['type'] ?? $selectedType,
+        ]);
 
         return Command::SUCCESS;
     }

--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -22,13 +22,13 @@ class EnvPullCommand extends Command
     {
         $this->ensureAccessTokenIsAvailable();
 
-        $project = Manifest::current();
+        $envNames = Manifest::environmentNames();
 
         $option = $this->option('environment');
 
         $env = $option
-            ? $this->resolveEnvFromOption($option, $project['environments'])
-            : $this->promptForEnv($project['environments']);
+            ? $this->resolveEnvFromOption($option, $envNames)
+            : $this->promptForEnv($envNames);
 
         Helpers::info("You're about to pull the <comment>{$env}</comment> environment from Ghostable.");
         Helpers::warn('This will overwrite the existing environment file (if present).'.PHP_EOL);

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -23,13 +23,13 @@ class EnvPushCommand extends Command
     {
         $this->ensureAccessTokenIsAvailable();
 
-        $project = Manifest::current();
+        $envNames = Manifest::environmentNames();
 
         $option = $this->option('environment');
 
         $env = $option
-            ? $this->resolveEnvFromOption($option, $project['environments'])
-            : $this->promptForEnv($project['environments']);
+            ? $this->resolveEnvFromOption($option, $envNames)
+            : $this->promptForEnv($envNames);
 
         try {
             $lines = $this->env->getRaw($env);

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -54,27 +54,50 @@ class Manifest
             'id' => $project['id'],
             'name' => $project['name'],
             'environments' => collect($project['environments'])
-                ->map(fn ($env) => $env['name'])
+                ->map(function ($env) {
+                    return [
+                        'name' => $env['name'],
+                        'type' => $env['type'] ?? null,
+                    ];
+                })
                 ->values()
                 ->toArray(),
         ]));
     }
 
-    public static function addEnvironment(string $environment): void
+    public static function addEnvironment(array $environment): void
     {
         $manifest = static::current();
 
         $environments = collect($manifest['environments'] ?? [])
-            ->filter(fn ($e) => is_string($e)) // Ensure list format
-            ->push($environment)
-            ->unique()
-            ->sort()
+            ->map(function ($e) {
+                return is_string($e)
+                    ? ['name' => $e, 'type' => null]
+                    : $e;
+            })
+            ->push([
+                'name' => $environment['name'],
+                'type' => $environment['type'] ?? null,
+            ])
+            ->unique('name')
+            ->sortBy('name')
             ->values()
             ->all();
 
         $manifest['environments'] = $environments;
 
         static::write($manifest);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function environmentNames(): array
+    {
+        return collect(static::current()['environments'] ?? [])
+            ->map(fn ($env) => is_array($env) ? $env['name'] : $env)
+            ->values()
+            ->toArray();
     }
 
     protected static function write(array $manifest, $path = null): void

--- a/tests/EnvInitCommandTest.php
+++ b/tests/EnvInitCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Application;
+use Ghostable\Commands\EnvInitCommand;
+use Ghostable\GhostableConsoleClient;
+use Illuminate\Container\Container;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Yaml\Yaml;
+
+class EnvInitCommandTest extends TestCase
+{
+    protected function command(): EnvInitCommand
+    {
+        $client = new class extends GhostableConsoleClient
+        {
+            public function envTypes(): array
+            {
+                return [
+                    ['value' => 'laravel', 'label' => 'Laravel'],
+                ];
+            }
+
+            public function createEnvironment(string $projectId, string $name, string $type): array
+            {
+                return [
+                    'name' => $name,
+                    'type' => $type,
+                ];
+            }
+        };
+
+        $command = new class($client) extends EnvInitCommand
+        {
+            public function __construct(GhostableConsoleClient $client)
+            {
+                parent::__construct();
+                $this->ghostable = $client;
+            }
+
+            protected function ensureAccessTokenIsAvailable(): void
+            {
+                // Skip token check in tests
+            }
+        };
+
+        $app = new Application;
+        $app->add($command);
+
+        return $app->find('env:init');
+    }
+
+    public function test_environment_is_added_with_type(): void
+    {
+        Container::setInstance(new Container);
+
+        $manifest = tempnam(sys_get_temp_dir(), 'manifest').'.yml';
+        file_put_contents($manifest, Yaml::dump([
+            'id' => 'p1',
+            'name' => 'Demo',
+            'environments' => [
+                ['name' => 'local', 'type' => 'laravel'],
+            ],
+        ]));
+
+        Prompt::fake([
+            Key::ENTER, // select first env type
+            's', 't', 'a', 'g', 'i', 'n', 'g', Key::ENTER,
+        ]);
+
+        $tester = new CommandTester($this->command());
+
+        $status = $tester->execute(['--manifest' => $manifest]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+
+        $data = Yaml::parse(file_get_contents($manifest));
+
+        $this->assertContains([
+            'name' => 'staging',
+            'type' => 'laravel',
+        ], $data['environments']);
+    }
+}

--- a/tests/EnvPushCommandTest.php
+++ b/tests/EnvPushCommandTest.php
@@ -88,7 +88,9 @@ class EnvPushCommandTest extends TestCase
         file_put_contents($manifest, Yaml::dump([
             'id' => 'p1',
             'name' => 'Test',
-            'environments' => ['local'],
+            'environments' => [
+                ['name' => 'local', 'type' => 'laravel'],
+            ],
         ]));
 
         Prompt::fake([Key::ENTER]);


### PR DESCRIPTION
## Summary
- support storing environment name and type in `ghostable.yml`
- update `EnvInitCommand` to capture the environment type from the API
- adapt `EnvPushCommand` and `EnvPullCommand` to use new manifest structure
- adjust manifest helper methods
- update tests and add new `EnvInitCommandTest`

## Testing
- `./vendor/bin/pint -v`
- `./vendor/bin/phpstan analyse --memory-limit=2G`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687944b086d483338ed39c70ee3b30bb