### PR TITLE
Use env type for local path

### DIFF
--- a/src/Env/Env.php
+++ b/src/Env/Env.php
@@ -3,6 +3,7 @@
 namespace Ghostable\Env;
 
 use Dotenv\Parser\Parser;
+use Ghostable\Manifest;
 
 class Env
 {
@@ -91,7 +92,9 @@ class Env
      */
     public function resolvePathForEnv(string $name): string
     {
-        $sanitized = ltrim(str($name)->trim()->lower(), '.');
+        $type = Manifest::environmentType($name) ?? $name;
+
+        $sanitized = ltrim(str($type)->trim()->lower(), '.');
 
         $path = "{$this->basePath}/.env";
 

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -100,6 +100,19 @@ class Manifest
             ->toArray();
     }
 
+    public static function environmentType(string $name): ?string
+    {
+        $env = collect(static::current()['environments'] ?? [])
+            ->map(function ($env) {
+                return is_array($env)
+                    ? $env
+                    : ['name' => $env, 'type' => null];
+            })
+            ->firstWhere('name', $name);
+
+        return $env['type'] ?? null;
+    }
+
     protected static function write(array $manifest, $path = null): void
     {
         file_put_contents(

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Env\Env;
+use Illuminate\Container\Container;
+use Symfony\Component\Yaml\Yaml;
+
+class EnvTest extends TestCase
+{
+    public function test_resolve_path_uses_environment_type(): void
+    {
+        Container::setInstance(new Container);
+
+        $dir = sys_get_temp_dir().'/envtest'.uniqid();
+        mkdir($dir);
+
+        $manifest = $dir.'/ghostable.yml';
+        file_put_contents($manifest, Yaml::dump([
+            'id' => 'p1',
+            'name' => 'Demo',
+            'environments' => [
+                ['name' => 'prod', 'type' => 'production'],
+            ],
+        ]));
+
+        Container::getInstance()->offsetSet('manifest', $manifest);
+
+        $env = new Env($dir);
+
+        $this->assertSame(
+            "$dir/.env.production",
+            $env->resolvePathForEnv('prod')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- derive environment file paths from the `type` defined in `ghostable.yml`
- expose `Manifest::environmentType()` helper
- add regression test for resolving the path using the environment type

## Testing
- `vendor/bin/pint -v`
- `composer phpstan`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68794ab435e08333b12d48945fed2f03