### PR TITLE
Add deploy command

### DIFF
--- a/ghostable
+++ b/ghostable
@@ -40,5 +40,6 @@ $app->add(new Commands\ProjectListCommand);
 $app->add(new Commands\EnvInitCommand);
 $app->add(new Commands\EnvPushCommand);
 $app->add(new Commands\EnvPullCommand);
+$app->add(new Commands\DeployCommand);
 
 $app->run();

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Ghostable\Commands;
+
+use Ghostable\GhostableConsoleClient;
+use Ghostable\Helpers;
+use Ghostable\Manifest;
+use GuzzleHttp\Exception\ClientException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class DeployCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('deploy')
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment to deploy')
+            ->addOption('output', null, InputOption::VALUE_OPTIONAL, 'Where to write the env file', '.env')
+            ->addOption('validate', null, InputOption::VALUE_NONE, 'Validate the environment after pulling')
+            ->setDescription('Fetch environment variables for deployment.');
+    }
+
+    public function handle(): ?int
+    {
+        $token = getenv('GHOSTABLE_CI_TOKEN');
+
+        if (! $token) {
+            Helpers::danger('GHOSTABLE_CI_TOKEN environment variable is not set.');
+
+            return Command::FAILURE;
+        }
+
+        $this->ghostable = $this->createClient($token);
+
+        $projectId = Manifest::id();
+        $env = $this->argument('environment');
+
+        try {
+            $contents = $this->ghostable->pull($projectId, $env);
+        } catch (ClientException $e) {
+            return Command::FAILURE;
+        }
+
+        if ($this->option('validate')) {
+            try {
+                $result = $this->ghostable->validateEnvironment($projectId, $env);
+            } catch (ClientException $e) {
+                return Command::FAILURE;
+            }
+
+            if (($result['valid'] ?? true) === false) {
+                Helpers::danger('Environment validation failed:');
+                foreach ((array) ($result['errors'] ?? []) as $message) {
+                    Helpers::line('  - '.$message);
+                }
+
+                return Command::FAILURE;
+            }
+        }
+
+        $output = $this->option('output') ?? '.env';
+
+        file_put_contents($output, $contents);
+
+        Helpers::info("✅ Environment <comment>{$env}</comment> written to {$output}.");
+
+        return Command::SUCCESS;
+    }
+
+    protected function createClient(string $token): GhostableConsoleClient
+    {
+        return new class($token) extends GhostableConsoleClient
+        {
+            public function __construct(private string $token)
+            {
+                parent::__construct();
+            }
+
+            protected function authorizationHeader(): string
+            {
+                return 'Bearer '.$this->token;
+            }
+        };
+    }
+}

--- a/src/GhostableConsoleClient.php
+++ b/src/GhostableConsoleClient.php
@@ -118,6 +118,19 @@ class GhostableConsoleClient
     }
 
     /**
+     * Validate an environment and return the API response.
+     *
+     * @return array<string,mixed>
+     */
+    public function validateEnvironment(string $projectId, string $name): array
+    {
+        return $this->requestJson(
+            self::POST,
+            "/projects/{$projectId}/environments/{$name}/validate"
+        );
+    }
+
+    /**
      * Perform a JSON API request.
      *
      * @return array<string,mixed>

--- a/tests/DeployCommandTest.php
+++ b/tests/DeployCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Application;
+use Ghostable\Commands\DeployCommand;
+use Ghostable\GhostableConsoleClient;
+use Illuminate\Container\Container;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Yaml\Yaml;
+
+class DeployCommandTest extends TestCase
+{
+    protected function command(GhostableConsoleClient $client): DeployCommand
+    {
+        $command = new class($client) extends DeployCommand
+        {
+            public function __construct(private GhostableConsoleClient $client)
+            {
+                parent::__construct();
+            }
+
+            protected function createClient(string $token): GhostableConsoleClient
+            {
+                return $this->client;
+            }
+        };
+
+        $app = new Application;
+        $app->add($command);
+
+        return $app->find('deploy');
+    }
+
+    protected function makeManifest(): string
+    {
+        $manifest = tempnam(sys_get_temp_dir(), 'manifest').'.yml';
+        file_put_contents($manifest, Yaml::dump([
+            'id' => 'p1',
+            'name' => 'Demo',
+            'environments' => [
+                ['name' => 'prod', 'type' => 'production'],
+            ],
+        ]));
+
+        return $manifest;
+    }
+
+    public function test_fails_when_token_missing(): void
+    {
+        Container::setInstance(new Container);
+
+        $manifest = $this->makeManifest();
+
+        putenv('GHOSTABLE_CI_TOKEN');
+
+        $client = new class extends GhostableConsoleClient
+        {
+            public function pull(string $projectId, string $name): string
+            {
+                return '';
+            }
+        };
+
+        $tester = new CommandTester($this->command($client));
+
+        $status = $tester->execute(['environment' => 'prod', '--manifest' => $manifest]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('GHOSTABLE_CI_TOKEN environment variable is not set', $tester->getDisplay());
+    }
+
+    public function test_fetches_and_writes_environment(): void
+    {
+        Container::setInstance(new Container);
+
+        $manifest = $this->makeManifest();
+
+        putenv('GHOSTABLE_CI_TOKEN=abc');
+
+        $client = new class extends GhostableConsoleClient
+        {
+            public function pull(string $projectId, string $name): string
+            {
+                return "FOO=bar\n";
+            }
+
+            public function validateEnvironment(string $projectId, string $name): array
+            {
+                return ['valid' => true];
+            }
+        };
+
+        $output = tempnam(sys_get_temp_dir(), 'env');
+
+        $tester = new CommandTester($this->command($client));
+
+        $status = $tester->execute([
+            'environment' => 'prod',
+            '--manifest' => $manifest,
+            '--output' => $output,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertSame("FOO=bar\n", file_get_contents($output));
+    }
+
+    public function test_validation_failure_outputs_errors(): void
+    {
+        Container::setInstance(new Container);
+
+        $manifest = $this->makeManifest();
+
+        putenv('GHOSTABLE_CI_TOKEN=tok');
+
+        $client = new class extends GhostableConsoleClient
+        {
+            public function pull(string $projectId, string $name): string
+            {
+                return "FOO=bar\n";
+            }
+
+            public function validateEnvironment(string $projectId, string $name): array
+            {
+                return ['valid' => false, 'errors' => ['bad']];
+            }
+        };
+
+        $tester = new CommandTester($this->command($client));
+
+        $status = $tester->execute([
+            'environment' => 'prod',
+            '--manifest' => $manifest,
+            '--validate' => true,
+        ]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Environment validation failed', $output);
+        $this->assertStringContainsString('  - bad', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- add CI-based `deploy` command to fetch & validate envs
- support environment validation API in the console client
- register the command in the executable
- test deploy command scenarios

## Testing
- `composer run-script pint`
- `composer phpstan`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687a572936fc8333bcc5fe977cc8f569