### PR TITLE
Add format selection to env pull command

### DIFF
--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -30,6 +30,21 @@ class EnvPullCommand extends Command
             ? $this->resolveEnvFromOption($option, $envNames)
             : $this->promptForEnv($envNames);
 
+        $formats = $this->ghostable->envFormats();
+        $formatOptions = collect($formats)
+            ->mapWithKeys(fn ($f) => [$f['value'] => $f['label']])
+            ->prepend('Default', 'default')
+            ->all();
+
+        $format = select(
+            label: 'Which format would you like to pull?',
+            options: $formatOptions,
+            default: 'default',
+            scroll: 12,
+        );
+
+        $format = $format === 'default' ? null : $format;
+
         Helpers::info("You're about to pull the <comment>{$env}</comment> environment from Ghostable.");
         Helpers::warn('This will overwrite the existing environment file (if present).'.PHP_EOL);
         if (! confirm('Are you sure you want to continue?')) {
@@ -38,7 +53,7 @@ class EnvPullCommand extends Command
             return Command::SUCCESS;
         }
 
-        $file = $this->ghostable->pull(Manifest::id(), $env);
+        $file = $this->ghostable->pull(Manifest::id(), $env, $format);
 
         $this->env->save($env, $file);
 

--- a/src/GhostableConsoleClient.php
+++ b/src/GhostableConsoleClient.php
@@ -86,6 +86,14 @@ class GhostableConsoleClient
     /**
      * @return array<string,mixed>
      */
+    public function envFormats(): array
+    {
+        return $this->requestJson(self::GET, '/environment-formats')['data'] ?? [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
     public function environments(string $projectId): array
     {
         return $this->requestJson(
@@ -138,12 +146,15 @@ class GhostableConsoleClient
         );
     }
 
-    public function pull(string $projectId, string $name): string
+    public function pull(string $projectId, string $name, ?string $format = null): string
     {
-        return $this->requestRaw(
-            self::GET,
-            "/projects/{$projectId}/environments/{$name}/pull"
-        );
+        $uri = "/projects/{$projectId}/environments/{$name}/pull";
+
+        if ($format) {
+            $uri .= "?format={$format}";
+        }
+
+        return $this->requestRaw(self::GET, $uri);
     }
 
     public function deploy(): string


### PR DESCRIPTION
## Summary
- allow users to choose environment file format when pulling
- support fetching available environment formats from API

## Testing
- `composer pint`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689df7da56288333899499c628e02257