### PR TITLE
feat: add API version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,16 @@ Ghostable stores and organizes your `.env` variables, validates them, and integr
 
 Read the [official documentation](https://docs.ghostable.dev) or try it out at [Ghostable.dev](https://ghostable.dev).
 
+## API Versioning
+
+The Ghostable API is versioned. The CLI targets `v1` by default and prefixes all requests with `/api/v1`.
+
+If you need to communicate with a newer API version you can override this default using the `--api-version` flag:
+
+```bash
+ghostable --api-version=v2 <command>
+```
+
+Alternatively, set the `GHOSTABLE_API_VERSION` environment variable or configure `api_version` in `~/.ghostable/config.json`.
+
 See [SECURITY.md](./SECURITY.md) for our security policy.

--- a/src/Api/Adapter.php
+++ b/src/Api/Adapter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ghostable\Api;
+
+interface Adapter
+{
+    /**
+     * Get the fully-qualified URI for the given endpoint, including the API version prefix.
+     */
+    public function uri(string $endpoint): string;
+
+    /**
+     * Get the API version string (e.g., "v1").
+     */
+    public function version(): string;
+}

--- a/src/Api/V1Adapter.php
+++ b/src/Api/V1Adapter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ghostable\Api;
+
+class V1Adapter implements Adapter
+{
+    public function uri(string $endpoint): string
+    {
+        return '/api/v1'.'/'.ltrim($endpoint, '/');
+    }
+
+    public function version(): string
+    {
+        return 'v1';
+    }
+}

--- a/src/Api/V2Adapter.php
+++ b/src/Api/V2Adapter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ghostable\Api;
+
+class V2Adapter implements Adapter
+{
+    public function uri(string $endpoint): string
+    {
+        return '/api/v2'.'/'.ltrim($endpoint, '/');
+    }
+
+    public function version(): string
+    {
+        return 'v2';
+    }
+}

--- a/src/Application.php
+++ b/src/Application.php
@@ -21,6 +21,15 @@ class Application extends SymfonyConsoleApplication
             )
         );
 
+        $definition->addOption(
+            new InputOption(
+                'api-version',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override the Ghostable API version (default: v1)'
+            )
+        );
+
         return $definition;
     }
 }

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -4,6 +4,8 @@ namespace Ghostable\Commands;
 
 use DateTime;
 use Exception;
+use Ghostable\Api\V1Adapter;
+use Ghostable\Api\V2Adapter;
 use Ghostable\Config;
 use Ghostable\Env\Env;
 use Ghostable\GhostableConsoleClient;
@@ -40,9 +42,16 @@ abstract class Command extends SymfonyCommand
         );
     }
 
-    protected function makeGhostableClient(string $token): GhostableConsoleClient
+    protected function makeGhostableClient(string $token, ?string $version = null): GhostableConsoleClient
     {
-        return new GhostableConsoleClient(token: $token);
+        $version = $version ?? Config::getApiVersion();
+
+        $adapter = match ($version) {
+            'v2' => new V2Adapter,
+            default => new V1Adapter,
+        };
+
+        return new GhostableConsoleClient(adapter: $adapter, token: $token);
     }
 
     protected function execute(
@@ -55,6 +64,13 @@ abstract class Command extends SymfonyCommand
         Helpers::app()->instance('output', $this->output = $output);
 
         $this->configureManifestPath($input);
+
+        if ($version = $input->getOption('api-version')) {
+            $this->ghostable = $this->makeGhostableClient(
+                token: $this->config->getAccessToken(),
+                version: $version,
+            );
+        }
 
         return (int) ($this->handle() ?? 0);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,6 +10,8 @@ class Config
 
     const TEAM = 'team';
 
+    const API_VERSION = 'api_version';
+
     /**
      * Get the access token.
      */
@@ -24,6 +26,28 @@ class Config
     public static function getTeam(): ?string
     {
         return self::get(self::TEAM, null);
+    }
+
+    /**
+     * Get the API version to use for requests.
+     */
+    public static function getApiVersion(): string
+    {
+        $envVersion = getenv('GHOSTABLE_API_VERSION');
+
+        if ($envVersion !== false && trim($envVersion) !== '') {
+            return $envVersion;
+        }
+
+        return self::get(self::API_VERSION, 'v1');
+    }
+
+    /**
+     * Persist the preferred API version.
+     */
+    public static function setApiVersion(string $version): void
+    {
+        self::set(self::API_VERSION, $version);
     }
 
     /**

--- a/src/GhostableConsoleClient.php
+++ b/src/GhostableConsoleClient.php
@@ -2,8 +2,11 @@
 
 namespace Ghostable;
 
+use Ghostable\Api\Adapter;
+use Ghostable\Api\V1Adapter;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use Psr\Http\Message\ResponseInterface;
 
 class GhostableConsoleClient
 {
@@ -15,9 +18,13 @@ class GhostableConsoleClient
 
     private const GET = 'GET';
 
+    protected array $supportedVersions = [];
+
     public function __construct(
-        protected string $baseUrl = 'https://ghostable.dev/api/',
-        protected ?string $token = null
+        protected Adapter $adapter = new V1Adapter,
+        protected string $baseUrl = 'https://ghostable.dev',
+        protected ?string $token = null,
+        protected ?Client $httpClient = null
     ) {}
 
     /**
@@ -224,12 +231,18 @@ class GhostableConsoleClient
     protected function requestRaw(string $method, string $uri): string
     {
         try {
-            $response = $this->client()->request($method, ltrim($uri, '/'), [
-                'headers' => array_filter([
-                    'Accept' => self::TYPE_PLAIN,
-                    'Authorization' => $this->authorizationHeader(),
-                ]),
-            ]);
+            $response = $this->client()->request(
+                $method,
+                ltrim($this->adapter->uri($uri), '/'),
+                [
+                    'headers' => array_filter([
+                        'Accept' => self::TYPE_PLAIN,
+                        'Authorization' => $this->authorizationHeader(),
+                    ]),
+                ]
+            );
+
+            $this->handleResponseHeaders($response);
 
             return (string) $response->getBody();
         } catch (ClientException $e) {
@@ -251,14 +264,20 @@ class GhostableConsoleClient
         array $json = []
     ): array {
         try {
-            $response = $this->client()->request($method, ltrim($uri, '/'), [
-                'json' => $json,
-                'headers' => array_filter([
-                    'Accept' => $acceptType,
-                    'Content-Type' => $acceptType,
-                    'Authorization' => $this->authorizationHeader(),
-                ]),
-            ]);
+            $response = $this->client()->request(
+                $method,
+                ltrim($this->adapter->uri($uri), '/'),
+                [
+                    'json' => $json,
+                    'headers' => array_filter([
+                        'Accept' => $acceptType,
+                        'Content-Type' => $acceptType,
+                        'Authorization' => $this->authorizationHeader(),
+                    ]),
+                ]
+            );
+
+            $this->handleResponseHeaders($response);
 
             return json_decode((string) $response->getBody(), true) ?? [];
         } catch (ClientException $e) {
@@ -290,6 +309,20 @@ class GhostableConsoleClient
     }
 
     /**
+     * Handle version-related response headers.
+     */
+    protected function handleResponseHeaders(ResponseInterface $response): void
+    {
+        if ($versions = $response->getHeaderLine('X-Ghostable-Api-Versions')) {
+            $this->supportedVersions = array_map('trim', explode(',', $versions));
+        }
+
+        if ($deprecated = $response->getHeaderLine('X-Ghostable-Deprecation')) {
+            echo "⚠️ API version {$this->adapter->version()} is deprecated. {$deprecated}\n";
+        }
+    }
+
+    /**
      * Get the Authorization header for the current CLI user.
      */
     protected function authorizationHeader(): ?string
@@ -298,11 +331,25 @@ class GhostableConsoleClient
     }
 
     /**
+     * Expose the supported API versions provided by the server.
+     *
+     * @return array<int, string>
+     */
+    public function supportedVersions(): array
+    {
+        return $this->supportedVersions;
+    }
+
+    /**
      * Create the configured Guzzle client.
      */
     protected function client(): Client
     {
-        return new Client([
+        if ($this->httpClient) {
+            return $this->httpClient;
+        }
+
+        return $this->httpClient = new Client([
             'base_uri' => $this->baseUrl,
             'timeout' => 10,
         ]);

--- a/tests/ApiVersionTest.php
+++ b/tests/ApiVersionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Api\V2Adapter;
+use Ghostable\GhostableConsoleClient;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+
+class ApiVersionTest extends TestCase
+{
+    public function test_default_version_is_v1(): void
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $mock = new MockHandler([new Response(200, [])]);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+
+        $client = new Client(['handler' => $handler, 'base_uri' => 'https://ghostable.dev']);
+
+        $ghostable = new GhostableConsoleClient(httpClient: $client);
+        $ghostable->user();
+
+        $this->assertSame('/api/v1/user', $container[0]['request']->getUri()->getPath());
+    }
+
+    public function test_can_explicitly_use_v2(): void
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $mock = new MockHandler([new Response(200, [])]);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+
+        $client = new Client(['handler' => $handler, 'base_uri' => 'https://ghostable.dev']);
+
+        $ghostable = new GhostableConsoleClient(adapter: new V2Adapter, httpClient: $client);
+        $ghostable->user();
+
+        $this->assertSame('/api/v2/user', $container[0]['request']->getUri()->getPath());
+    }
+}


### PR DESCRIPTION
## Summary
- support versioned API via adapters with default v1
- allow overriding API version through flag, env variable, or config
- warn when using deprecated API versions and document versioning

## Testing
- `composer pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d3c1f9348333a2695e6a4821fa8f