### PR TITLE
Improve failed login messaging

### DIFF
--- a/src/GhostableConsoleClient.php
+++ b/src/GhostableConsoleClient.php
@@ -293,9 +293,14 @@ class GhostableConsoleClient
     {
         $status = $e->getResponse()->getStatusCode();
         $body = (string) $e->getResponse()->getBody();
+        $path = $e->getRequest()->getUri()->getPath();
 
         if ($status === 401) {
-            echo "❌ Unauthorized. Run `ghostable login` first.\n";
+            if (str_contains($path, '/cli/login')) {
+                echo "❌ Authentication failed.\n";
+            } else {
+                echo "❌ Unauthorized. Run `ghostable login` first.\n";
+            }
         } elseif ($status === 422) {
             $data = json_decode($body, true);
             foreach (($data['errors'] ?? []) as $field => $messages) {


### PR DESCRIPTION
## Summary
- Show an authentication failure message when login requests return 401 instead of the generic unauthorized prompt

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e14832a88333a221094293fd4332