### PR TITLE
Prompt for team after login

### DIFF
--- a/src/Commands/LoginCommand.php
+++ b/src/Commands/LoginCommand.php
@@ -6,6 +6,7 @@ use Ghostable\Helpers;
 use GuzzleHttp\Exception\ClientException;
 
 use function Laravel\Prompts\form;
+use function Laravel\Prompts\select;
 
 class LoginCommand extends Command
 {
@@ -76,8 +77,31 @@ class LoginCommand extends Command
     {
         $teams = $this->ghostable->teams();
 
-        $this->config->setTeam(collect($teams)->first(function ($team) {
-            return isset($team['id']);
-        })['id']);
+        if (count($teams) === 1) {
+            /** @var array{id: string, name?: string} $team */
+            $team = collect($teams)->first();
+
+            $this->config->setTeam($team['id']);
+
+            $teamName = $team['name'] ?? $team['id'];
+
+            Helpers::info("Using team: <comment>{$teamName}</comment>");
+
+            return;
+        }
+
+        $teamId = select(
+            'Which team would you like to use?',
+            collect($teams)
+                ->sortBy('name')
+                ->mapWithKeys(fn ($team) => [$team['id'] => $team['name']])
+                ->all(),
+        );
+
+        $this->config->setTeam($teamId);
+
+        $teamName = collect($teams)->firstWhere('id', $teamId)['name'] ?? $teamId;
+
+        Helpers::info("Using team: <comment>{$teamName}</comment>");
     }
 }


### PR DESCRIPTION
## Summary
- prompt user to select a team on login when multiple teams exist
- automatically use and display the single available team after login

## Testing
- `composer pint`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e216c92c83339478c0d6e98821d6