### PR TITLE
feat: store team info in manifest

### DIFF
--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -22,7 +22,15 @@ class InitCommand extends Command
 
         $project = $this->determineProject();
 
-        Manifest::fresh($project);
+        $team = collect($this->ghostable->teams())
+            ->where('id', $this->config->getTeam())
+            ->first();
+
+        if (! $team) {
+            Helpers::abort('Unable to determine current team.');
+        }
+
+        Manifest::fresh($project, $team);
 
         Helpers::info("✅ {$project['name']} initialized. ghostable.yaml created.");
 

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -24,6 +24,24 @@ class Manifest
         return static::current()['name'];
     }
 
+    public static function teamId(): string
+    {
+        if (! array_key_exists('team_id', static::current())) {
+            Helpers::abort(sprintf('Invalid team ID. Please verify your Ghostable manifest at [%s].', self::resolve()));
+        }
+
+        return static::current()['team_id'];
+    }
+
+    public static function teamName(): string
+    {
+        if (! array_key_exists('team_name', static::current())) {
+            Helpers::abort(sprintf('Invalid team name. Please verify your Ghostable manifest at [%s].', self::resolve()));
+        }
+
+        return static::current()['team_name'];
+    }
+
     public static function resolve(): string
     {
         return Helpers::app('manifest');
@@ -48,11 +66,13 @@ class Manifest
         return Yaml::parse(file_get_contents(self::resolve()));
     }
 
-    public static function fresh(array $project): void
+    public static function fresh(array $project, array $team = []): void
     {
         static::write(array_filter([
             'id' => $project['id'],
             'name' => $project['name'],
+            'team_id' => $team['id'] ?? null,
+            'team_name' => $team['name'] ?? null,
             'environments' => collect($project['environments'])
                 ->map(function ($env) {
                     return [

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Manifest;
+use Illuminate\Container\Container;
+use Symfony\Component\Yaml\Yaml;
+
+class ManifestTest extends TestCase
+{
+    public function test_reads_team_information_from_manifest(): void
+    {
+        Container::setInstance(new Container);
+
+        $dir = sys_get_temp_dir().'/manifesttest'.uniqid();
+        mkdir($dir);
+
+        $manifest = $dir.'/ghostable.yml';
+        file_put_contents($manifest, Yaml::dump([
+            'id' => 'p1',
+            'name' => 'Demo',
+            'team_id' => 't1',
+            'team_name' => 'Team One',
+            'environments' => [],
+        ]));
+
+        Container::getInstance()->offsetSet('manifest', $manifest);
+
+        $this->assertSame('t1', Manifest::teamId());
+        $this->assertSame('Team One', Manifest::teamName());
+    }
+}


### PR DESCRIPTION
## Summary
- include team ID and name in `ghostable.yml` manifest and expose helpers
- capture current team during `init`
- test retrieving team details from manifest

## Testing
- `composer pint`
- `composer phpstan`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e315e26c8333b8e5eb3afd048797