### PR TITLE
Add tests for config tokens and manifest environment formats

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Config;
+
+class ConfigTest extends TestCase
+{
+    public function test_ci_token_priority_order(): void
+    {
+        putenv('GHOSTABLE_CI_TOKEN=envtoken');
+        $_ENV['GHOSTABLE_CI_TOKEN'] = 'envsuper';
+        $_SERVER['GHOSTABLE_CI_TOKEN'] = 'servertoken';
+
+        $this->assertSame('envtoken', Config::getCiToken());
+
+        putenv('GHOSTABLE_CI_TOKEN');
+        unset($_ENV['GHOSTABLE_CI_TOKEN'], $_SERVER['GHOSTABLE_CI_TOKEN']);
+    }
+
+    public function test_ci_token_from_server_when_no_other_sources(): void
+    {
+        putenv('GHOSTABLE_CI_TOKEN');
+        unset($_ENV['GHOSTABLE_CI_TOKEN']);
+        $_SERVER['GHOSTABLE_CI_TOKEN'] = 'servertoken';
+
+        $this->assertSame('servertoken', Config::getCiToken());
+
+        unset($_SERVER['GHOSTABLE_CI_TOKEN']);
+    }
+
+    public function test_api_version_prefers_environment_variable(): void
+    {
+        $home = sys_get_temp_dir().'/cfgtest'.uniqid();
+        $_SERVER['HOME'] = $home;
+
+        Config::setApiVersion('v2');
+
+        putenv('GHOSTABLE_API_VERSION=v3');
+
+        $this->assertSame('v3', Config::getApiVersion());
+
+        putenv('GHOSTABLE_API_VERSION');
+    }
+
+    public function test_api_version_defaults_to_v1_when_not_set(): void
+    {
+        $home = sys_get_temp_dir().'/cfgtest'.uniqid();
+        $_SERVER['HOME'] = $home;
+
+        putenv('GHOSTABLE_API_VERSION');
+
+        $this->assertSame('v1', Config::getApiVersion());
+    }
+}

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Manifest;
+use Illuminate\Container\Container;
+use Symfony\Component\Yaml\Yaml;
+
+class ManifestTest extends TestCase
+{
+    protected function createManifest(array $contents): void
+    {
+        $dir = sys_get_temp_dir().'/manifesttest'.uniqid();
+        mkdir($dir);
+        $path = $dir.'/ghostable.yml';
+        file_put_contents($path, Yaml::dump($contents));
+
+        Container::setInstance(new Container);
+        Container::getInstance()->offsetSet('manifest', $path);
+    }
+
+    public function test_environment_names_from_old_list_format(): void
+    {
+        $this->createManifest([
+            'id' => 'p1',
+            'name' => 'Demo',
+            'environments' => ['prod', 'stage'],
+        ]);
+
+        $this->assertSame(['prod', 'stage'], Manifest::environmentNames());
+    }
+
+    public function test_environment_type_from_old_array_format(): void
+    {
+        $this->createManifest([
+            'id' => 'p1',
+            'name' => 'Demo',
+            'environments' => [
+                ['name' => 'prod', 'type' => 'production'],
+                ['name' => 'stage'],
+            ],
+        ]);
+
+        $this->assertSame('production', Manifest::environmentType('prod'));
+        $this->assertNull(Manifest::environmentType('stage'));
+    }
+}


### PR DESCRIPTION
## Summary
- add ConfigTest covering CI token and API version behavior
- add ManifestTest covering legacy environment formats

## Testing
- `composer pint`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ec7fca548333ac26011aaf062b1f