### PR TITLE
Secure config and env file permissions

### DIFF
--- a/src/Commands/EnvDeployCommand.php
+++ b/src/Commands/EnvDeployCommand.php
@@ -37,7 +37,8 @@ class EnvDeployCommand extends Command
 
         }
 
-        file_put_contents('.env', $contents);
+        file_put_contents('.env', $contents, LOCK_EX);
+        chmod('.env', 0600);
 
         Helpers::info('✅ Environment variables successfully written to .env');
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -108,7 +108,8 @@ class Config
 
         Arr::set($config, $key, $value);
 
-        file_put_contents(static::path(), json_encode($config, JSON_PRETTY_PRINT));
+        file_put_contents(static::path(), json_encode($config, JSON_PRETTY_PRINT), LOCK_EX);
+        chmod(static::path(), 0600);
     }
 
     /**
@@ -117,7 +118,7 @@ class Config
     public static function load(): array
     {
         if (! is_dir(dirname(static::path()))) {
-            mkdir(dirname(static::path()), 0755, true);
+            mkdir(dirname(static::path()), 0700, true);
         }
 
         if (file_exists(static::path())) {

--- a/src/Env/Env.php
+++ b/src/Env/Env.php
@@ -79,7 +79,8 @@ class Env
     {
         $path = $this->resolvePathForEnv($name);
 
-        file_put_contents($path, $contents);
+        file_put_contents($path, $contents, LOCK_EX);
+        chmod($path, 0600);
     }
 
     /**


### PR DESCRIPTION
## Summary
- lock config file writes with exclusive access and restrict permissions
- save .env files with LOCK_EX and chmod 0600

## Testing
- `composer test`
- `composer pint`


------
https://chatgpt.com/codex/tasks/task_e_68a5f34130d8833382951806b4721ee9