### PR TITLE
Sanitize environment type to prevent path traversal

### DIFF
--- a/src/Env/Env.php
+++ b/src/Env/Env.php
@@ -94,7 +94,12 @@ class Env
     {
         $type = Manifest::environmentType($name) ?? $name;
 
-        $sanitized = ltrim(str($type)->trim()->lower(), '.');
+        $normalized = ltrim(str($type)->trim()->lower(), '.');
+        $sanitized = basename($normalized);
+
+        if ($sanitized !== $normalized || str_contains($sanitized, '..') || ! preg_match('/^[a-z0-9._-]+$/', $sanitized)) {
+            throw new \InvalidArgumentException("Invalid environment type: {$type}");
+        }
 
         $path = "{$this->basePath}/.env";
 

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -33,4 +33,48 @@ class EnvTest extends TestCase
             $env->resolvePathForEnv('prod')
         );
     }
+
+    public function test_resolve_path_rejects_directory_traversal(): void
+    {
+        Container::setInstance(new Container);
+
+        $dir = sys_get_temp_dir().'/envtest'.uniqid();
+        mkdir($dir);
+
+        $manifest = $dir.'/ghostable.yml';
+        file_put_contents($manifest, Yaml::dump([
+            'id' => 'p1',
+            'name' => 'Demo',
+            'environments' => [],
+        ]));
+
+        Container::getInstance()->offsetSet('manifest', $manifest);
+
+        $env = new Env($dir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $env->resolvePathForEnv('../evil');
+    }
+
+    public function test_resolve_path_rejects_dot_segments(): void
+    {
+        Container::setInstance(new Container);
+
+        $dir = sys_get_temp_dir().'/envtest'.uniqid();
+        mkdir($dir);
+
+        $manifest = $dir.'/ghostable.yml';
+        file_put_contents($manifest, Yaml::dump([
+            'id' => 'p1',
+            'name' => 'Demo',
+            'environments' => [],
+        ]));
+
+        Container::getInstance()->offsetSet('manifest', $manifest);
+
+        $env = new Env($dir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $env->resolvePathForEnv('..');
+    }
 }


### PR DESCRIPTION
## Summary
- sanitize environment type using basename and regex
- reject names containing directory traversal segments
- cover invalid names with new tests

## Testing
- `composer pint`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f3a67ecc8333973deb19c1713ce9