### PR TITLE
Use Composer version in ghostable and add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run tests
+        run: composer test
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          prerelease: false

--- a/ghostable
+++ b/ghostable
@@ -9,6 +9,7 @@ use Dotenv\Repository\Adapter\EnvConstAdapter as V4orV5EnvConstAdapter;
 use Dotenv\Repository\Adapter\ServerConstAdapter as V4orV5ServerConstAdapter;
 use Dotenv\Repository\RepositoryBuilder;
 use Illuminate\Container\Container;
+use Composer\InstalledVersions;
 use Ghostable\Application;
 use Ghostable\Commands;
 
@@ -66,7 +67,8 @@ Container::setInstance($container = new Container);
 /**
  * Start the console application.
  */
-$app = new Application('Ghostable', '1.0.0');
+$version = InstalledVersions::getPrettyVersion('ghostable-dev/cli') ?? 'dev';
+$app = new Application('Ghostable', $version);
 
 // Authentication...
 $app->add(new Commands\LoginCommand);


### PR DESCRIPTION
## Summary
- derive CLI version from Composer metadata rather than a hard-coded string
- add release workflow that runs tests and publishes GitHub releases without manual bumps

## Testing
- `composer test`
- `composer phpstan`
- `./vendor/bin/pint --test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f3a9453c833397d651170a9670d7