### PR TITLE
feat: add debug option and safer API error output

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -30,6 +30,15 @@ class Application extends SymfonyConsoleApplication
             )
         );
 
+        $definition->addOption(
+            new InputOption(
+                'debug',
+                null,
+                InputOption::VALUE_NONE,
+                'Display detailed API responses'
+            )
+        );
+
         return $definition;
     }
 }

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -72,6 +72,8 @@ abstract class Command extends SymfonyCommand
             );
         }
 
+        $this->ghostable->setDebug((bool) $input->getOption('debug'));
+
         return (int) ($this->handle() ?? 0);
     }
 

--- a/src/GhostableConsoleClient.php
+++ b/src/GhostableConsoleClient.php
@@ -20,6 +20,8 @@ class GhostableConsoleClient
 
     protected array $supportedVersions = [];
 
+    protected bool $debug = false;
+
     public function __construct(
         protected Adapter $adapter = new V1Adapter,
         protected string $baseUrl = 'https://ghostable.dev',
@@ -309,7 +311,17 @@ class GhostableConsoleClient
                 }
             }
         } else {
-            echo "❌ API Error ({$status}): {$body}\n";
+            $requestId = $e->getResponse()->getHeaderLine('X-Request-Id');
+
+            if ($this->debug) {
+                echo "❌ API Error ({$status}): {$body}\n";
+            } else {
+                $message = "❌ API Error ({$status})";
+                if ($requestId) {
+                    $message .= " - Request ID: {$requestId}";
+                }
+                echo $message."\n";
+            }
         }
     }
 
@@ -343,6 +355,11 @@ class GhostableConsoleClient
     public function supportedVersions(): array
     {
         return $this->supportedVersions;
+    }
+
+    public function setDebug(bool $debug): void
+    {
+        $this->debug = $debug;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add global `--debug` option to display detailed API responses
- hide API error bodies by default and optionally show request ID
- wire commands to enable debugging on the console client

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f3abf1548333b42f705c05e7986e