### PR TITLE
Add CLI support for environment secrets

### DIFF
--- a/ghostable
+++ b/ghostable
@@ -90,4 +90,10 @@ $app->add(new Commands\EnvDiffCommand);
 $app->add(new Commands\EnvPullCommand);
 $app->add(new Commands\EnvDeployCommand);
 
+// Secrets...
+$app->add(new Commands\SecretTypesCommand);
+$app->add(new Commands\SecretListCommand);
+$app->add(new Commands\SecretCreateCommand);
+$app->add(new Commands\SecretUpdateCommand);
+
 $app->run();

--- a/src/Commands/SecretCreateCommand.php
+++ b/src/Commands/SecretCreateCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Ghostable\Commands;
+
+use Ghostable\Helpers;
+use Ghostable\Manifest;
+use Symfony\Component\Console\Input\InputOption;
+
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\select;
+
+class SecretCreateCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('secret:create')
+            ->addOption('environment', null, InputOption::VALUE_OPTIONAL, 'The environment name')
+            ->addOption('type', null, InputOption::VALUE_OPTIONAL, 'The secret type')
+            ->addOption('value', null, InputOption::VALUE_OPTIONAL, 'The secret value')
+            ->setDescription('Create a new secret for the given environment.');
+    }
+
+    public function handle(): ?int
+    {
+        $this->ensureAccessTokenIsAvailable();
+
+        $envNames = Manifest::environmentNames();
+        $env = $this->option('environment');
+
+        if (! $env) {
+            $env = select('Which env would you like to use?', $envNames);
+        } elseif (! in_array($env, $envNames)) {
+            Helpers::warn("Environment <comment>{$env}</comment> not found.");
+
+            return Command::FAILURE;
+        }
+
+        $types = $this->ghostable->secretTypes();
+        $type = $this->option('type');
+
+        if (! $type) {
+            $type = select(
+                label: 'Which secret type?',
+                options: collect($types)->mapWithKeys(
+                    fn ($t) => [($t['value'] ?? ($t['id'] ?? '')) => $t['label'] ?? ($t['name'] ?? '')]
+                )->all(),
+                scroll: 12
+            );
+        }
+
+        $value = $this->option('value') ?? password('Enter the secret value');
+
+        $this->ghostable->createEnvironmentSecret(Manifest::id(), $env, $type, $value);
+
+        Helpers::info('✅ Secret created successfully.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Commands/SecretListCommand.php
+++ b/src/Commands/SecretListCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Ghostable\Commands;
+
+use Ghostable\Helpers;
+use Ghostable\Manifest;
+use Symfony\Component\Console\Input\InputOption;
+
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\table;
+
+class SecretListCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('secret:list')
+            ->addOption('environment', null, InputOption::VALUE_OPTIONAL, 'The environment name')
+            ->setDescription('List the secrets for the given environment within the current project context.');
+    }
+
+    public function handle(): ?int
+    {
+        $this->ensureAccessTokenIsAvailable();
+
+        $envNames = Manifest::environmentNames();
+        $env = $this->option('environment');
+
+        if (! $env) {
+            $env = select('Which env would you like to use?', $envNames);
+        } elseif (! in_array($env, $envNames)) {
+            Helpers::warn("Environment <comment>{$env}</comment> not found.");
+
+            return Command::FAILURE;
+        }
+
+        $secrets = $this->ghostable->environmentSecrets(Manifest::id(), $env);
+
+        table(
+            headers: ['ID', 'Type'],
+            rows: collect($secrets)->map(function ($secret) {
+                return [
+                    $secret['id'] ?? '',
+                    $secret['type'] ?? ($secret['secret_type'] ?? ''),
+                ];
+            })->values()->all()
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Commands/SecretTypesCommand.php
+++ b/src/Commands/SecretTypesCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ghostable\Commands;
+
+use function Laravel\Prompts\table;
+
+class SecretTypesCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('secret:types')
+            ->setDescription('List the available secret types.');
+    }
+
+    public function handle(): ?int
+    {
+        $this->ensureAccessTokenIsAvailable();
+
+        $types = $this->ghostable->secretTypes();
+
+        table(
+            headers: ['Value', 'Label'],
+            rows: collect($types)->map(function ($type) {
+                return [
+                    $type['value'] ?? ($type['id'] ?? ''),
+                    $type['label'] ?? ($type['name'] ?? ''),
+                ];
+            })->values()->all()
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Commands/SecretUpdateCommand.php
+++ b/src/Commands/SecretUpdateCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Ghostable\Commands;
+
+use Ghostable\Helpers;
+use Ghostable\Manifest;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\select;
+
+class SecretUpdateCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('secret:update')
+            ->addOption('environment', null, InputOption::VALUE_OPTIONAL, 'The environment name')
+            ->addArgument('secret', InputArgument::OPTIONAL, 'The secret identifier')
+            ->addOption('value', null, InputOption::VALUE_OPTIONAL, 'The new secret value')
+            ->setDescription('Update an existing secret for the given environment.');
+    }
+
+    public function handle(): ?int
+    {
+        $this->ensureAccessTokenIsAvailable();
+
+        $envNames = Manifest::environmentNames();
+        $env = $this->option('environment');
+
+        if (! $env) {
+            $env = select('Which env would you like to use?', $envNames);
+        } elseif (! in_array($env, $envNames)) {
+            Helpers::warn("Environment <comment>{$env}</comment> not found.");
+
+            return Command::FAILURE;
+        }
+
+        $secrets = $this->ghostable->environmentSecrets(Manifest::id(), $env);
+        $secret = $this->argument('secret');
+
+        if (! $secret) {
+            $secret = select(
+                label: 'Which secret would you like to update?',
+                options: collect($secrets)->mapWithKeys(
+                    fn ($s) => [$s['id'] => $s['type'] ?? ($s['secret_type'] ?? $s['id'])]
+                )->all(),
+                scroll: 12
+            );
+        }
+
+        $value = $this->option('value') ?? password('Enter the new secret value');
+
+        $this->ghostable->updateEnvironmentSecret(Manifest::id(), $env, $secret, $value);
+
+        Helpers::info('✅ Secret updated successfully.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/GhostableConsoleClient.php
+++ b/src/GhostableConsoleClient.php
@@ -18,6 +18,8 @@ class GhostableConsoleClient
 
     private const GET = 'GET';
 
+    private const PUT = 'PUT';
+
     protected array $supportedVersions = [];
 
     protected bool $debug = false;
@@ -115,11 +117,30 @@ class GhostableConsoleClient
     /**
      * @return array<string,mixed>
      */
+    public function secretTypes(): array
+    {
+        return $this->requestJson(self::GET, '/secret-types')['data'] ?? [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
     public function environments(string $projectId): array
     {
         return $this->requestJson(
             self::GET,
             "/projects/{$projectId}/environments"
+        )['data'] ?? [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function environmentSecrets(string $projectId, string $name): array
+    {
+        return $this->requestJson(
+            self::GET,
+            "/projects/{$projectId}/environments/{$name}/secrets"
         )['data'] ?? [];
     }
 
@@ -165,6 +186,43 @@ class GhostableConsoleClient
             "/projects/{$projectId}/environments/{$name}/push",
             ['vars' => $vars]
         );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function createEnvironmentSecret(
+        string $projectId,
+        string $name,
+        string $type,
+        string $value,
+    ): array {
+        return $this->requestJson(
+            self::POST,
+            "/projects/{$projectId}/environments/{$name}/secrets",
+            [
+                'type' => $type,
+                'value' => $value,
+            ]
+        )['data'] ?? [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function updateEnvironmentSecret(
+        string $projectId,
+        string $name,
+        string $secret,
+        string $value,
+    ): array {
+        return $this->requestJson(
+            self::PUT,
+            "/projects/{$projectId}/environments/{$name}/secrets/{$secret}",
+            [
+                'value' => $value,
+            ]
+        )['data'] ?? [];
     }
 
     public function pull(string $projectId, string $name, ?string $format = null): string


### PR DESCRIPTION
## Summary
- implement environment secret management commands
- expose secret API endpoints

## Testing
- `composer pint`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a62f06ede083339c0117748c5f1771