### PR TITLE
chore: align messaging tone

### DIFF
--- a/src/Commands/EnvInitCommand.php
+++ b/src/Commands/EnvInitCommand.php
@@ -25,7 +25,7 @@ class EnvInitCommand extends Command
         $projectId = Manifest::id();
 
         if (! $projectId) {
-            Helpers::abort('No project is currently selected. Run `ghostable init` first.');
+            Helpers::abort('No project selected. Run `ghostable init` first.');
         }
 
         // Fetch environment types

--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -45,7 +45,7 @@ class EnvPullCommand extends Command
 
         $format = $format === 'default' ? null : $format;
 
-        Helpers::info("You're about to pull the <comment>{$env}</comment> environment from Ghostable.");
+        Helpers::info("Preparing to pull the <comment>{$env}</comment> environment from Ghostable.");
         Helpers::warn('This will overwrite the existing environment file (if present).'.PHP_EOL);
         if (! confirm('Are you sure you want to continue?')) {
             Helpers::warn('Cancelled. No changes were made.');

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -41,7 +41,7 @@ class EnvPushCommand extends Command
             Helpers::abort('The environment could not be loaded.');
         }
 
-        Helpers::info("You're about to push the <comment>{$env}</comment> environment to Ghostable.");
+        Helpers::info("Preparing to push the <comment>{$env}</comment> environment to Ghostable.");
         Helpers::warn('This will overwrite the existing environment configuration.'.PHP_EOL);
         if (! confirm('Are you sure you want to continue?')) {
             Helpers::warn('Cancelled. No changes were made.');

--- a/src/Commands/LoginCommand.php
+++ b/src/Commands/LoginCommand.php
@@ -70,7 +70,7 @@ class LoginCommand extends Command
     {
         $this->config->setAccessToken($token);
 
-        Helpers::info('Authenticated successfully.'.PHP_EOL);
+        Helpers::info('✅ Authenticated successfully.'.PHP_EOL);
     }
 
     protected function ensureCurrentTeamIsSet(): void
@@ -85,7 +85,7 @@ class LoginCommand extends Command
 
             $teamName = $team['name'] ?? $team['id'];
 
-            Helpers::info("Using team: <comment>{$teamName}</comment>");
+            Helpers::info("✅ Using team: <comment>{$teamName}</comment>");
 
             return;
         }
@@ -102,6 +102,6 @@ class LoginCommand extends Command
 
         $teamName = collect($teams)->firstWhere('id', $teamId)['name'] ?? $teamId;
 
-        Helpers::info("Using team: <comment>{$teamName}</comment>");
+        Helpers::info("✅ Using team: <comment>{$teamName}</comment>");
     }
 }

--- a/src/Commands/TeamSwitchCommand.php
+++ b/src/Commands/TeamSwitchCommand.php
@@ -36,7 +36,7 @@ class TeamSwitchCommand extends Command
         $this->config->setTeam($teamId);
 
         $teamName = collect($teams)->firstWhere('id', $teamId)['name'] ?? $teamId;
-        Helpers::info("Switched to team: <comment>{$teamName}</comment>");
+        Helpers::info("✅ Using team: <comment>{$teamName}</comment>");
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
## Summary
- rephrase environment push/pull confirmations to a consistent "preparing" tone
- unify team selection messaging with check-marked success notices
- streamline project selection error wording

## Testing
- `composer pint`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a65f0ac7d88333ab3f70baa2909f81