### PR TITLE
Add secret write command for writing secrets to file

### DIFF
--- a/ghostable
+++ b/ghostable
@@ -94,5 +94,6 @@ $app->add(new Commands\EnvDeployCommand);
 $app->add(new Commands\SecretListCommand);
 $app->add(new Commands\SecretCreateCommand);
 $app->add(new Commands\SecretUpdateCommand);
+$app->add(new Commands\SecretWriteCommand);
 
 $app->run();

--- a/src/Commands/SecretWriteCommand.php
+++ b/src/Commands/SecretWriteCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Ghostable\Commands;
+
+use Ghostable\Helpers;
+use Ghostable\Manifest;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+class SecretWriteCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('secret:write')
+            ->addOption('environment', null, InputOption::VALUE_OPTIONAL, 'The environment name')
+            ->addArgument('secret', InputArgument::OPTIONAL, 'The secret identifier')
+            ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'The file path to write the secret to')
+            ->addOption('mode', null, InputOption::VALUE_OPTIONAL, 'The file permissions')
+            ->addOption('mkdir', null, InputOption::VALUE_NONE, 'Create parent directories if missing')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Overwrite the file without confirmation')
+            ->setDescription("Write a secret's value to a file on disk.");
+    }
+
+    public function handle(): ?int
+    {
+        $this->ensureAccessTokenIsAvailable();
+
+        $envNames = Manifest::environmentNames();
+        $env = $this->option('environment');
+
+        if (! $env) {
+            $env = select('Which env would you like to use?', $envNames);
+        } elseif (! in_array($env, $envNames)) {
+            Helpers::warn("Environment <comment>{$env}</comment> not found.");
+
+            return Command::FAILURE;
+        }
+
+        $secrets = $this->ghostable->environmentSecrets(Manifest::id(), $env);
+
+        if (count($secrets) === 0) {
+            Helpers::abort(
+                'No secrets found for this project.'.PHP_EOL.
+                'Then run: ghostable secret:create'
+            );
+        }
+
+        $secret = $this->argument('secret');
+
+        if (! $secret) {
+            $secret = select(
+                label: 'Which secret would you like to write?',
+                options: collect($secrets)->mapWithKeys(
+                    fn ($s) => [$s['id'] => $s['name'] ?? $s['id']]
+                )->all(),
+                scroll: 12
+            );
+        }
+
+        $path = $this->option('path') ?? text('Enter the file path');
+        $mode = $this->option('mode');
+        $mkdir = $this->option('mkdir');
+        $force = $this->option('force');
+
+        $dir = dirname($path);
+        if (! is_dir($dir)) {
+            if ($mkdir) {
+                mkdir($dir, 0777, true);
+            } else {
+                Helpers::warn("Directory <comment>{$dir}</comment> does not exist.");
+
+                return Command::FAILURE;
+            }
+        }
+
+        if (file_exists($path) && ! $force) {
+            if (! confirm('File exists. Overwrite?')) {
+                Helpers::warn('Cancelled. No changes were made.');
+
+                return Command::SUCCESS;
+            }
+        }
+
+        $data = $this->ghostable->environmentSecret(Manifest::id(), $env, $secret);
+        $value = $data['value'] ?? null;
+
+        if ($value === null) {
+            Helpers::warn('Secret value not found.');
+
+            return Command::FAILURE;
+        }
+
+        file_put_contents($path, $value);
+
+        if ($mode) {
+            @chmod($path, octdec($mode));
+        }
+
+        Helpers::info('✅ Secret written successfully.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/GhostableConsoleClient.php
+++ b/src/GhostableConsoleClient.php
@@ -147,6 +147,17 @@ class GhostableConsoleClient
     /**
      * @return array<string,mixed>
      */
+    public function environmentSecret(string $projectId, string $name, string $secret): array
+    {
+        return $this->requestJson(
+            self::GET,
+            "/projects/{$projectId}/environments/{$name}/secrets/{$secret}"
+        )['data'] ?? [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
     public function suggestedEnvironmentNames(string $projectId, string $type): array
     {
         return $this->requestJson(


### PR DESCRIPTION
## Summary
- add `secret:write` command to write a secret value to a file with permissions control
- expose API client method to fetch a single secret
- register new command in CLI entrypoint

## Testing
- `composer test`
- `composer pint`
- `composer phpstan`


------
https://chatgpt.com/codex/tasks/task_e_68b9e2bacf208333b4d7633cb958c768