### PR TITLE
refactor env:deploy to run commands under resolved env

### DIFF
--- a/src/Commands/EnvDeployCommand.php
+++ b/src/Commands/EnvDeployCommand.php
@@ -2,77 +2,153 @@
 
 namespace Ghostable\Commands;
 
-use Ghostable\Helpers;
-use Ghostable\Manifest;
-use GuzzleHttp\Exception\ClientException;
+use Ghostable\Env\Resolver;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Process\Process;
 
 class EnvDeployCommand extends Command
 {
     protected function configure(): void
     {
         $this->setName('env:deploy')
-            ->addOption('validate', null, InputOption::VALUE_NONE, 'Validate the environment after pulling')
-            ->setDescription('Fetch environment variables for deployment.');
+            ->setDescription('Resolve env vars from the API and apply them without writing files.')
+            ->addOption('environment', 'e', InputOption::VALUE_REQUIRED, 'The environment name (e.g. production, staging)')
+            ->addOption('target', null, InputOption::VALUE_REQUIRED, 'Deployment target', 'process')
+            ->addOption('exec', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Commands to run under injected env')
+            ->addOption('laravel', null, InputOption::VALUE_NONE, 'Run Laravel cache rebuild')
+            ->addOption('plan', null, InputOption::VALUE_NONE, 'Show key names to be applied (no values) and exit')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do everything except actually run child processes')
+            ->addOption('redact', null, InputOption::VALUE_NEGATABLE, 'Redact secret values in logs', true)
+            ->addOption('no-restart-horizon', null, InputOption::VALUE_NONE, 'If --laravel, skip horizon:terminate');
     }
 
     public function handle(): ?int
     {
-        $token = $this->config->getCiToken();
+        $this->ensureAccessTokenIsAvailable();
 
-        if (! $token) {
-            Helpers::danger('GHOSTABLE_CI_TOKEN environment variable is not set.');
+        $env = $this->option('environment');
+        if (! $env) {
+            $this->writeError('ERR[5] Environment not specified.');
 
-            return Command::FAILURE;
+            return 5;
         }
 
-        $ghostable = $this->makeGhostableClient(token: $token);
+        $redact = (bool) $this->option('redact');
+        if (! $redact && ! $this->isInteractive()) {
+            $this->writeError('ERR[3] --no-redact is only allowed on an interactive TTY.');
+
+            return 3;
+        }
 
         try {
-            $contents = $ghostable->deploy();
-        } catch (ClientException $e) {
-            return Command::FAILURE;
+            $envMap = Resolver::resolve($this->ghostable, (string) $env);
+        } catch (\Throwable $e) {
+            $this->writeError('ERR[5] Environment not found.');
+
+            return 5;
         }
 
-        if ($this->option('validate')) {
-            try {
-                ob_start();
-                $response = $ghostable->validateEnvironment(
-                    Manifest::id(),
-                    'deploy',
-                    preg_split("/\r?\n/", trim($contents)) ?: []
-                );
-                ob_end_clean();
-            } catch (ClientException $e) {
-                ob_end_clean();
-                $response = $e->getResponse();
+        $keys = array_keys($envMap);
+        sort($keys, SORT_NATURAL | SORT_FLAG_CASE);
 
-                if ($response->getStatusCode() === 422) {
-                    Helpers::danger('Validation failed due to errors:');
-                    $data = json_decode((string) $response->getBody(), true);
-                    foreach (($data['errors'] ?? []) as $field => $messages) {
-                        foreach ((array) $messages as $message) {
-                            Helpers::line('  - '.$message);
-                        }
-                    }
-                } else {
-                    Helpers::danger('Validation failed.');
-                }
-
-                return Command::FAILURE;
+        if ($this->option('plan') || $this->option('dry-run')) {
+            $this->output->writeln(count($keys).' environment variables:');
+            foreach ($keys as $k) {
+                $this->output->writeln(' - '.$k);
             }
 
-            Helpers::info('✅ Environment is valid.');
-            if (isset($response['message'])) {
-                Helpers::info($response['message']);
+            return Command::SUCCESS;
+        }
+
+        $target = strtolower((string) ($this->option('target') ?: 'process'));
+        if ($target !== 'process') {
+            $this->writeError('ERR[5] Unsupported target.');
+
+            return 5;
+        }
+
+        // Merge existing env with fetched values
+        $childEnv = array_merge($_ENV, $_SERVER);
+        foreach ($envMap as $k => $v) {
+            $childEnv[$k] = $v;
+        }
+
+        $commands = [];
+
+        if ($this->option('laravel')) {
+            $commands[] = 'php artisan config:clear';
+            $commands[] = 'php artisan config:cache';
+            if (! $this->option('no-restart-horizon')) {
+                $commands[] = ['cmd' => 'php artisan horizon:terminate', 'ignore' => true];
             }
         }
 
-        file_put_contents('.env', $contents, LOCK_EX);
-        chmod('.env', 0600);
+        foreach ((array) $this->option('exec') as $cmd) {
+            $commands[] = $cmd;
+        }
 
-        Helpers::info('✅ Environment variables successfully written to .env');
+        foreach ($commands as $entry) {
+            $cmd = is_array($entry) ? $entry['cmd'] : $entry;
+            $ignore = is_array($entry) && ($entry['ignore'] ?? false);
+            $exit = $this->runCmd($cmd, $childEnv, $envMap, $redact, $ignore);
+            if ($exit !== 0) {
+                return $exit;
+            }
+        }
 
         return Command::SUCCESS;
+    }
+
+    protected function runCmd(string $cmd, array $env, array $envMap, bool $redact, bool $ignoreFailure = false): int
+    {
+        $this->logEnv($cmd, $envMap, $redact);
+
+        $shell = getenv('SHELL') ?: '/bin/bash';
+        $process = new Process([$shell, '-lc', $cmd], null, $env);
+        $process->setTty($this->isInteractive());
+        $process->run(function ($type, $buffer) {
+            $this->output->write($buffer);
+        });
+
+        $code = $process->getExitCode() ?? 0;
+        if ($code !== 0 && ! $ignoreFailure) {
+            return $code;
+        }
+
+        return 0;
+    }
+
+    protected function logEnv(string $cmd, array $envMap, bool $redact): void
+    {
+        $this->output->writeln('> '.$cmd);
+        if ($redact) {
+            $this->output->writeln('Env: '.implode(', ', array_keys($envMap)));
+        } else {
+            foreach ($envMap as $k => $v) {
+                $this->output->writeln($k.'='.$v);
+            }
+        }
+    }
+
+    protected function isInteractive(): bool
+    {
+        if (function_exists('stream_isatty')) {
+            return @stream_isatty(STDOUT);
+        }
+        if (function_exists('posix_isatty')) {
+            return @posix_isatty(STDOUT);
+        }
+
+        return false;
+    }
+
+    protected function writeError(string $message): void
+    {
+        if ($this->output instanceof ConsoleOutputInterface) {
+            $this->output->getErrorOutput()->writeln($message);
+        } else {
+            $this->output->writeln($message);
+        }
     }
 }

--- a/src/Env/Resolver.php
+++ b/src/Env/Resolver.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Ghostable\Env;
+
+use Ghostable\GhostableConsoleClient;
+use Ghostable\Manifest;
+
+class Resolver
+{
+    /**
+     * Fetch environment variables from the Ghostable API and return a map of key => value.
+     *
+     * @return array<string,string>
+     */
+    public static function resolve(GhostableConsoleClient $client, string $env): array
+    {
+        $payload = $client->fetch(Manifest::id(), $env);
+
+        if (is_string($payload)) {
+            $decoded = json_decode($payload, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $payload = $decoded;
+            }
+        }
+
+        if (! is_array($payload) || ! isset($payload['data']) || ! is_array($payload['data'])) {
+            throw new \RuntimeException('Unexpected response shape.');
+        }
+
+        $vars = [];
+        foreach ($payload['data'] as $row) {
+            if (! isset($row['key'])) {
+                continue;
+            }
+            if (isset($row['is_commented']) && (int) $row['is_commented'] === 1) {
+                continue;
+            }
+            $k = (string) $row['key'];
+            $v = isset($row['value']) ? (string) $row['value'] : '';
+            $vars[$k] = $v;
+        }
+
+        return $vars;
+    }
+}

--- a/tests/EnvDeployCommandTest.php
+++ b/tests/EnvDeployCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Commands\EnvDeployCommand;
+use Ghostable\Config;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Yaml\Yaml;
+
+class EnvDeployCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_SERVER['HOME'] = sys_get_temp_dir();
+        Config::setAccessToken('token');
+    }
+
+    private function makeManifest(): string
+    {
+        $data = [
+            'id' => '1',
+            'name' => 'Test',
+            'environments' => [
+                'production' => ['type' => 'production'],
+            ],
+        ];
+        $path = tempnam(sys_get_temp_dir(), 'manifest');
+        file_put_contents($path, Yaml::dump($data));
+
+        return $path;
+    }
+
+    private function makeCommand(array $map, bool $interactive = false): EnvDeployCommand
+    {
+        $client = new class($map) extends \Ghostable\GhostableConsoleClient
+        {
+            public function __construct(private array $map) {}
+
+            public function fetch(string $projectId, string $env): string
+            {
+                $data = [];
+                foreach ($this->map as $k => $v) {
+                    $row = ['key' => $k, 'value' => $v];
+                    $data[] = $row;
+                }
+
+                return json_encode(['data' => $data]);
+            }
+        };
+
+        return new class($client, $interactive) extends EnvDeployCommand
+        {
+            public function __construct(private $fakeClient, private bool $interactive)
+            {
+                parent::__construct();
+                $this->ghostable = $fakeClient;
+                $this->getDefinition()->addOption(new InputOption('manifest'));
+                $this->getDefinition()->addOption(new InputOption('api-version'));
+                $this->getDefinition()->addOption(new InputOption('debug'));
+            }
+
+            protected function isInteractive(): bool
+            {
+                return $this->interactive;
+            }
+        };
+    }
+
+    public function test_plan_outputs_sorted_keys(): void
+    {
+        $manifest = $this->makeManifest();
+        $command = $this->makeCommand(['B' => '2', 'A' => '1']);
+        $tester = new CommandTester($command);
+        $exit = $tester->execute([
+            '--environment' => 'production',
+            '--manifest' => $manifest,
+            '--plan' => true,
+        ]);
+        $this->assertSame(0, $exit);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('2 environment variables:', $display);
+        $this->assertTrue(strpos($display, ' - A') < strpos($display, ' - B'));
+    }
+
+    public function test_exec_receives_env(): void
+    {
+        $manifest = $this->makeManifest();
+        $command = $this->makeCommand(['FOO' => 'bar']);
+        $tester = new CommandTester($command);
+        $exit = $tester->execute([
+            '--environment' => 'production',
+            '--manifest' => $manifest,
+            '--exec' => ['php -r "echo getenv(\'FOO\');"'],
+        ]);
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('bar', $tester->getDisplay());
+    }
+
+    public function test_no_redact_without_tty_fails(): void
+    {
+        $manifest = $this->makeManifest();
+        $command = $this->makeCommand(['A' => '1']);
+        $tester = new CommandTester($command);
+        $exit = $tester->execute([
+            '--environment' => 'production',
+            '--manifest' => $manifest,
+            '--no-redact' => true,
+        ]);
+        $this->assertSame(3, $exit);
+        $this->assertStringContainsString('--no-redact is only allowed', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
- add Env\Resolver for fetching and parsing environment variables
- refactor `env:deploy` to overlay resolved variables on child processes and support execution hooks
- add tests covering planning, execution, and security restrictions

## Testing
- `composer pint`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c19dfdf2c883338b3ed5d29fbf8d47