### PR TITLE
Add Laravel Forge deployment command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,12 @@ Ghostable stores and organizes your `.env` variables, validates them, and integr
 
 Read the [official documentation](https://docs.ghostable.dev) or try it out at [Ghostable.dev](https://ghostable.dev).
 
+## Forge Deployments
+
+Use the `env:forge` command to push environment variables directly to a Laravel Forge site and optionally trigger a deployment:
+
+```bash
+ghostable env:forge --environment=production --server=123 --site=456 --token=FORGE_API_TOKEN --deploy
+```
+
 See [SECURITY.md](./SECURITY.md) for our security policy.

--- a/ghostable
+++ b/ghostable
@@ -89,6 +89,7 @@ $app->add(new Commands\EnvValidateCommand);
 $app->add(new Commands\EnvDiffCommand);
 $app->add(new Commands\EnvPullCommand);
 $app->add(new Commands\EnvDeployCommand);
+$app->add(new Commands\EnvForgeCommand);
 $app->add(new Commands\EnvExportCommand);
 
 // Secrets...

--- a/src/Commands/EnvForgeCommand.php
+++ b/src/Commands/EnvForgeCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Ghostable\Commands;
+
+use Ghostable\Env\Resolver;
+use Ghostable\Helpers;
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Input\InputOption;
+
+class EnvForgeCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setName('env:forge')
+            ->setDescription('Deploy environment variables to a Laravel Forge site.')
+            ->addOption('environment', 'e', InputOption::VALUE_REQUIRED, 'The environment name (e.g. production, staging)')
+            ->addOption('server', null, InputOption::VALUE_REQUIRED, 'Forge server ID')
+            ->addOption('site', null, InputOption::VALUE_REQUIRED, 'Forge site ID')
+            ->addOption('token', null, InputOption::VALUE_REQUIRED, 'Forge API token')
+            ->addOption('deploy', null, InputOption::VALUE_NONE, 'Trigger a deployment after updating env');
+    }
+
+    public function handle(): ?int
+    {
+        $this->ensureAccessTokenIsAvailable();
+
+        $env = $this->option('environment');
+        $server = $this->option('server');
+        $site = $this->option('site');
+        $token = $this->option('token') ?: getenv('FORGE_API_TOKEN');
+
+        if (! $env || ! $server || ! $site || ! $token) {
+            Helpers::danger('ERR[5] Missing required options.');
+
+            return 5;
+        }
+
+        try {
+            $envMap = Resolver::resolve($this->ghostable, (string) $env);
+        } catch (\Throwable $e) {
+            Helpers::danger('ERR[5] Environment not found.');
+
+            return 5;
+        }
+
+        ksort($envMap, SORT_NATURAL | SORT_FLAG_CASE);
+
+        $lines = [];
+        foreach ($envMap as $k => $v) {
+            $lines[] = $k.'='.$v;
+        }
+        $content = implode(PHP_EOL, $lines).PHP_EOL;
+
+        $client = $this->makeForgeClient($token);
+
+        $response = $client->put("servers/{$server}/sites/{$site}/env", [
+            'form_params' => ['content' => $content],
+        ]);
+
+        if ($response->getStatusCode() >= 300) {
+            Helpers::danger('ERR[5] Forge API error.');
+
+            return 5;
+        }
+
+        Helpers::info('Forge environment updated.');
+
+        if ($this->option('deploy')) {
+            $response = $client->post("servers/{$server}/sites/{$site}/deploy");
+
+            if ($response->getStatusCode() >= 300) {
+                Helpers::danger('ERR[5] Forge deploy failed.');
+
+                return 5;
+            }
+
+            Helpers::info('Forge deployment triggered.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    protected function makeForgeClient(string $token): Client
+    {
+        return new Client([
+            'base_uri' => 'https://forge.laravel.com/api/v1/',
+            'http_errors' => false,
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+                'Accept' => 'application/json',
+            ],
+        ]);
+    }
+}

--- a/tests/EnvDeployCommandTest.php
+++ b/tests/EnvDeployCommandTest.php
@@ -41,13 +41,13 @@ class EnvDeployCommandTest extends TestCase
             public function fetch(string $projectId, string $env): array
             {
                 $data = [];
-                
+
                 foreach ($this->map as $k => $v) {
                     $row = ['key' => $k, 'value' => $v];
                     $data[] = $row;
                 }
 
-                return $data;
+                return ['data' => $data];
             }
         };
 
@@ -79,7 +79,7 @@ class EnvDeployCommandTest extends TestCase
             '--manifest' => $manifest,
             '--plan' => true,
         ]);
-    
+
         $this->assertSame(0, $exit);
         $display = $tester->getDisplay();
         $this->assertStringContainsString('2 environment variables:', $display);

--- a/tests/EnvForgeCommandTest.php
+++ b/tests/EnvForgeCommandTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Ghostable\Tests;
+
+use Ghostable\Commands\EnvForgeCommand;
+use Ghostable\Config;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Yaml\Yaml;
+
+class EnvForgeCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_SERVER['HOME'] = sys_get_temp_dir();
+        Config::setAccessToken('token');
+    }
+
+    private function makeManifest(): string
+    {
+        $data = [
+            'id' => '1',
+            'name' => 'Test',
+            'environments' => [
+                'production' => ['type' => 'production'],
+            ],
+        ];
+        $path = tempnam(sys_get_temp_dir(), 'manifest');
+        file_put_contents($path, Yaml::dump($data));
+
+        return $path;
+    }
+
+    private function makeCommand(array $map, Client $client): EnvForgeCommand
+    {
+        $gc = new class($map) extends \Ghostable\GhostableConsoleClient
+        {
+            public function __construct(private array $map) {}
+
+            public function fetch(string $projectId, string $env): array
+            {
+                $data = [];
+                foreach ($this->map as $k => $v) {
+                    $data[] = ['key' => $k, 'value' => $v];
+                }
+
+                return ['data' => $data];
+            }
+        };
+
+        return new class($gc, $client) extends EnvForgeCommand
+        {
+            public function __construct(private $fakeClient, private $httpClient)
+            {
+                parent::__construct();
+                $this->ghostable = $fakeClient;
+                $this->getDefinition()->addOption(new InputOption('manifest'));
+                $this->getDefinition()->addOption(new InputOption('api-version'));
+                $this->getDefinition()->addOption(new InputOption('debug'));
+            }
+
+            protected function makeForgeClient(string $token): Client
+            {
+                return $this->httpClient;
+            }
+        };
+    }
+
+    public function test_updates_env_and_triggers_deploy(): void
+    {
+        $manifest = $this->makeManifest();
+
+        $mock = new MockHandler([
+            new Response(200, [], '{}'),
+            new Response(200, [], '{}'),
+        ]);
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $client = new Client(['handler' => $stack]);
+
+        $command = $this->makeCommand(['FOO' => 'bar'], $client);
+        $tester = new CommandTester($command);
+        $exit = $tester->execute([
+            '--environment' => 'production',
+            '--server' => '123',
+            '--site' => '456',
+            '--token' => 'forge-token',
+            '--deploy' => true,
+            '--manifest' => $manifest,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertCount(2, $container);
+        $this->assertSame('PUT', $container[0]['request']->getMethod());
+        $this->assertSame('servers/123/sites/456/env', $container[0]['request']->getUri()->getPath());
+        $this->assertSame('content=FOO%3Dbar%0A', (string) $container[0]['request']->getBody());
+        $this->assertSame('POST', $container[1]['request']->getMethod());
+        $this->assertSame('servers/123/sites/456/deploy', $container[1]['request']->getUri()->getPath());
+    }
+}


### PR DESCRIPTION
## Summary
- add `env:forge` command to push Ghostable variables to Laravel Forge and optionally trigger deployment
- document Forge deployment workflow
- update tests to cover Forge command and adjust env resolver mock

## Testing
- `composer pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ed75d438833391c5348f5cf81074