### PR TITLE
Ensure CLI resolves project files from working directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ghostable/cli",
-  "version": "0.1.0-beta",
+  "version": "0.1.1-beta",
   "type": "module",
   "bin": {
     "ghostable": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "bin": {
     "ghostable": "dist/cli.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE.md",
+    "SECURITY.md",
+    "example.env"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",

--- a/src/commands/deploy-cloud.ts
+++ b/src/commands/deploy-cloud.ts
@@ -11,6 +11,7 @@ import {
 import { log } from "../support/logger.js";
 import { toErrorMessage } from "../support/errors.js";
 import type { ProjectionBundle } from "../services/GhostableClient.js";
+import { resolveWorkDir } from "../support/workdir.js";
 
 export function registerDeployCloudCommand(program: Command) {
   program
@@ -74,7 +75,7 @@ export function registerDeployCloudCommand(program: Command) {
         }
 
         // 4) Write .env.<env>
-        const envPath = path.resolve(process.cwd(), `.env`);
+        const envPath = path.resolve(resolveWorkDir(), `.env`);
         const previous = readEnvFileSafe(envPath);
         const combined = { ...previous, ...merged };
         writeEnvFile(envPath, combined);

--- a/src/commands/deploy-forge.ts
+++ b/src/commands/deploy-forge.ts
@@ -14,6 +14,7 @@ import {
 import { log } from "../support/logger.js";
 import { toErrorMessage } from "../support/errors.js";
 import type { ProjectionBundle } from "../services/GhostableClient.js";
+import { resolveWorkDir } from "../support/workdir.js";
 
 export function registerDeployForgeCommand(program: Command) {
   program
@@ -82,7 +83,8 @@ export function registerDeployForgeCommand(program: Command) {
         }
 
         // 4) Write .env.<env>
-        const envPath = path.resolve(process.cwd(), `.env`);
+        const workDir = resolveWorkDir();
+        const envPath = path.resolve(workDir, `.env`);
         const previous = readEnvFileSafe(envPath);
         const combined = { ...previous, ...merged };
         writeEnvFile(envPath, combined);
@@ -112,7 +114,7 @@ export function registerDeployForgeCommand(program: Command) {
           ).start();
 
           // We will temporarily swap `.env` so artisan reads the desired file.
-          const cwd = process.cwd();
+          const cwd = workDir;
           const dotEnv = path.join(cwd, ".env");
           const backup = path.join(cwd, ".env.__ghostable_backup__");
           const targetOut = path.resolve(cwd, opts.out ?? `.env.encrypted`);
@@ -171,5 +173,5 @@ function havePhpAndArtisan(): boolean {
   const php = spawnSync("php", ["-v"], { stdio: "ignore" });
   if (php.status !== 0) return false;
   // artisan file in cwd?
-  return fs.existsSync(path.join(process.cwd(), "artisan"));
+  return fs.existsSync(path.join(resolveWorkDir(), "artisan"));
 }

--- a/src/commands/deploy-vapor.ts
+++ b/src/commands/deploy-vapor.ts
@@ -15,6 +15,7 @@ import {
 import { log } from "../support/logger.js";
 import { toErrorMessage } from "../support/errors.js";
 import type { ProjectionBundle } from "../services/GhostableClient.js";
+import { resolveWorkDir } from "../support/workdir.js";
 
 export function registerDeployVaporCommand(program: Command) {
   program
@@ -129,7 +130,7 @@ async function deployStandardVariables(
   const pull = runVaporCommand(["env:pull", vaporEnv]);
   ensureSuccessfulVaporProcess(pull, `pull environment "${vaporEnv}"`);
 
-  const envPath = path.resolve(process.cwd(), `.env.${vaporEnv}`);
+  const envPath = path.resolve(resolveWorkDir(), `.env.${vaporEnv}`);
   const existing = readEnvFileSafe(envPath);
   const merged = { ...existing, ...variables };
   writeEnvFile(envPath, merged);

--- a/src/commands/env-pull.ts
+++ b/src/commands/env-pull.ts
@@ -15,6 +15,7 @@ import { initSodium, deriveKeys, aeadDecrypt } from "../crypto.js";
 import { loadOrCreateKeys } from "../keys.js";
 import { log } from "../support/logger.js";
 import { toErrorMessage } from "../support/errors.js";
+import { resolveWorkDir } from "../support/workdir.js";
 
 type PullOptions = {
   api?: string;
@@ -30,9 +31,10 @@ function resolveOutputPath(
   envName: string | undefined,
   explicit?: string,
 ): string {
-  if (explicit) return path.resolve(process.cwd(), explicit);
-  if (envName) return path.resolve(process.cwd(), `.env.${envName}`);
-  return path.resolve(process.cwd(), ".env");
+  const workDir = resolveWorkDir();
+  if (explicit) return path.resolve(workDir, explicit);
+  if (envName) return path.resolve(workDir, `.env.${envName}`);
+  return path.resolve(workDir, ".env");
 }
 
 function lineForDotenv(name: string, value: string, commented = false): string {

--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -16,6 +16,7 @@ import { GhostableClient } from "../services/GhostableClient.js";
 import { Manifest } from "../support/Manifest.js";
 import { log } from "../support/logger.js";
 import { toErrorMessage } from "../support/errors.js";
+import { resolveWorkDir } from "../support/workdir.js";
 
 type PushOptions = {
   api?: string;
@@ -34,12 +35,13 @@ function resolveEnvFile(
   envName: string | undefined,
   explicitPath?: string,
 ): string {
-  if (explicitPath) return path.resolve(process.cwd(), explicitPath);
+  const workDir = resolveWorkDir();
+  if (explicitPath) return path.resolve(workDir, explicitPath);
   if (envName) {
-    const candidate = path.resolve(process.cwd(), `.env.${envName}`);
+    const candidate = path.resolve(workDir, `.env.${envName}`);
     if (fs.existsSync(candidate)) return candidate;
   }
-  return path.resolve(process.cwd(), ".env");
+  return path.resolve(workDir, ".env");
 }
 
 export function registerEnvPushCommand(program: Command) {

--- a/src/support/Manifest.ts
+++ b/src/support/Manifest.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import yaml from "js-yaml";
 
+import { resolveWorkDir } from "./workdir.js";
+
 export type EnvEntry = { type?: string } | undefined;
 export type ManifestEnvsLegacy =
   | string[]
@@ -15,7 +17,7 @@ export interface ManifestShape {
 }
 
 function defaultPath(): string {
-  return path.resolve(process.cwd(), "ghostable.yml");
+  return path.resolve(resolveWorkDir(), "ghostable.yml");
 }
 
 /** Resolve manifest path: env var wins, else cwd/ghostable.yml */

--- a/src/support/workdir.ts
+++ b/src/support/workdir.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Determine the on-disk directory the CLI should treat as the current project.
+ *
+ * In many execution environments (npm exec, pnpm dlx, etc.) the Node process
+ * can start with a working directory that differs from the folder where the
+ * user invoked the command. We look at a handful of well-known environment
+ * variables exposed by the package managers and fall back to process.cwd().
+ */
+export function resolveWorkDir(): string {
+  const fallback = process.cwd();
+  const candidates = [
+    process.env.GHOSTABLE_WORKDIR,
+    process.env.INIT_CWD,
+    process.env.PWD,
+    fallback,
+  ];
+
+  const seen = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+
+    const resolved = path.isAbsolute(candidate)
+      ? path.normalize(candidate)
+      : path.resolve(fallback, candidate);
+
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+
+    try {
+      const stat = fs.statSync(resolved);
+      if (stat.isDirectory()) {
+        return resolved;
+      }
+    } catch {
+      // Ignore invalid paths – keep checking other candidates.
+    }
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- add a shared workdir resolver to detect the correct project directory across package managers
- use the resolver when reading or writing manifests and environment files in CLI commands
- restrict the published package to compiled assets to avoid shipping TypeScript sources

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6bc1f72d4833381d346cc1ae944b2