### PR TITLE
Remove user-directed comments and clean lint warnings

### DIFF
--- a/src/commands/deploy-cloud.ts
+++ b/src/commands/deploy-cloud.ts
@@ -23,7 +23,7 @@ export function registerDeployCloudCommand(program: Command) {
 			if (seedFromEnv) {
 				try {
 					await setMasterSeed(seedFromEnv);
-				} catch (e) {
+				} catch {
 					log.warn('⚠️ Failed to import master seed from GHOSTABLE_MASTER_SEED.');
 				}
 			}

--- a/src/commands/env-diff.ts
+++ b/src/commands/env-diff.ts
@@ -12,7 +12,6 @@ import { toErrorMessage } from '../support/errors.js';
 import { resolveWorkDir } from '../support/workdir.js';
 
 import { initSodium } from '../crypto.js';
-import { loadOrCreateKeys } from '../keys.js';
 import { decryptBundle } from '../support/deploy-helpers.js';
 import { readEnvFileSafe, resolveEnvFile } from '../support/env-files.js';
 

--- a/src/commands/env-init.ts
+++ b/src/commands/env-init.ts
@@ -143,7 +143,7 @@ export function registerEnvInitCommand(program: Command) {
 					env && existingEnvs
 						? [...existingEnvs, env].map((e: Environment) => ({
 								name: e.name,
-								type: e.type, // your manifest accepts optional type; no transform needed
+								type: e.type,
 							}))
 						: [{ name: env.name, type: env.type }];
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -98,7 +98,6 @@ export function registerOrganizationListCommand(program: Command) {
 				const manifestEnvs =
 					project.environments?.map((env: { name: string; type: string }) => ({
 						name: env.name,
-						// your manifest accepts optional type; keep same shape
 						type: env.type ?? undefined,
 					})) ?? [];
 


### PR DESCRIPTION
## Summary
- remove user-directed manifest comments from environment initialization commands
- drop an unused keys import and simplify error handling
- ensure formatting matches project linting expectations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eec39c10f8833389044c81e5523c33