### PR TITLE
Remove API override options from commands

### DIFF
--- a/src/commands/env-deploy.ts
+++ b/src/commands/env-deploy.ts
@@ -8,7 +8,6 @@ import { log } from '../support/logger.js';
 import { toErrorMessage } from '../support/errors.js';
 import { resolveWorkDir } from '../support/workdir.js';
 import { setMasterSeed } from '../keys.js';
-import { config } from '../config/index.js';
 
 import type { EnvironmentSecretBundle } from '@/domain';
 
@@ -16,7 +15,6 @@ type EnvDeployOptions = {
 	token?: string;
 	file?: string; // default: .env
 	only?: string[]; // limit to specific keys
-	api?: string; // optional override of API base
 };
 
 export function registerEnvDeployCommand(program: Command) {
@@ -26,7 +24,6 @@ export function registerEnvDeployCommand(program: Command) {
 		.option('--token <TOKEN>', 'Ghostable CI token (or env GHOSTABLE_CI_TOKEN)')
 		.option('--file <PATH>', 'Output file (default: .env)')
 		.option('--only <KEY...>', 'Only include these keys')
-		.option('--api <URL>', 'Ghostable API base', config.apiBase)
 		.action(async (opts: EnvDeployOptions) => {
 			const seedFromEnv = process.env.GHOSTABLE_MASTER_SEED?.trim();
 			if (seedFromEnv) {
@@ -45,7 +42,7 @@ export function registerEnvDeployCommand(program: Command) {
 				log.error(toErrorMessage(error));
 				process.exit(1);
 			}
-			const client = createGhostableClient(token, opts.api);
+			const client = createGhostableClient(token);
 
 			// 2) Fetch bundle (environment is implied by the CI token context)
 			const spin = ora('Fetching environment secret bundle…').start();

--- a/src/commands/env-diff.ts
+++ b/src/commands/env-diff.ts
@@ -18,7 +18,6 @@ import { readEnvFileSafe, resolveEnvFile } from '../support/env-files.js';
 import type { EnvironmentSecretBundle } from '@/domain';
 
 type DiffOptions = {
-	api?: string;
 	token?: string;
 	env?: string;
 	file?: string; // optional override; else .env.<env> or .env
@@ -32,7 +31,6 @@ export function registerEnvDiffCommand(program: Command) {
 		.description('Show differences between your local .env and Ghostable (zero-knowledge).')
 		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
 		.option('--file <PATH>', 'Local .env path (default: .env.<env> or .env)')
-		.option('--api <URL>', 'Ghostable API base', config.apiBase)
 		.option('--token <TOKEN>', 'API token (or stored session / GHOSTABLE_TOKEN)')
 		.option('--only <KEY...>', 'Only diff these keys')
 		.option('--include-meta', 'Include meta flags in bundle', false)
@@ -62,7 +60,6 @@ export function registerEnvDiffCommand(program: Command) {
 			}
 
 			// 2) Resolve token
-			const apiBase = opts.api ?? config.apiBase;
 			let token = opts.token || process.env.GHOSTABLE_TOKEN || '';
 			if (!token) {
 				const sessionSvc = new SessionService();
@@ -77,7 +74,7 @@ export function registerEnvDiffCommand(program: Command) {
 			}
 
 			// 3) Pull encrypted bundle from Ghostable
-			const client = GhostableClient.unauthenticated(apiBase).withToken(token);
+			const client = GhostableClient.unauthenticated(config.apiBase).withToken(token);
 			let bundle: EnvironmentSecretBundle;
 			try {
 				bundle = await client.pull(projectId, envName!, {

--- a/src/commands/env-init.ts
+++ b/src/commands/env-init.ts
@@ -18,9 +18,8 @@ export function registerEnvInitCommand(program: Command) {
 		.description(
 			'Initialize a new environment in the current organization and project context.',
 		)
-		.option('--api <URL>', 'Ghostable API base', config.apiBase)
 		.option('--name <NAME>', 'Environment name (slug)')
-		.action(async (opts: { api?: string; name?: string }) => {
+		.action(async (opts: { name?: string }) => {
 			// 1) Ensure session and project context
 			const sessionSvc = new SessionService();
 			const sess = await sessionSvc.load();
@@ -38,7 +37,7 @@ export function registerEnvInitCommand(program: Command) {
 				return;
 			}
 
-			const client = GhostableClient.unauthenticated(opts.api ?? config.apiBase).withToken(
+			const client = GhostableClient.unauthenticated(config.apiBase).withToken(
 				sess.accessToken,
 			);
 

--- a/src/commands/env-pull.ts
+++ b/src/commands/env-pull.ts
@@ -16,7 +16,6 @@ import { resolveWorkDir } from '../support/workdir.js';
 import type { EnvironmentSecret, EnvironmentSecretBundle } from '@/domain';
 
 type PullOptions = {
-	api?: string;
 	token?: string;
 	env?: string;
 	file?: string; // output path; default .env.<env> or .env
@@ -43,7 +42,6 @@ export function registerEnvPullCommand(program: Command) {
 		.description('Pull and decrypt environment variables into a local .env file.')
 		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
 		.option('--file <PATH>', 'Output file (default: .env.<env> or .env)')
-		.option('--api <URL>', 'Ghostable API base', config.apiBase)
 		.option('--token <TOKEN>', 'API token (or stored session / GHOSTABLE_TOKEN)')
 		.option('--only <KEY...>', 'Only include these keys')
 		.option('--include-meta', 'Include meta flags in bundle', false)
@@ -75,7 +73,6 @@ export function registerEnvPullCommand(program: Command) {
 			}
 
 			// 3) Resolve token (org context only affects server-side; decrypt uses AAD)
-			const apiBase = opts.api ?? config.apiBase;
 			let token = opts.token || process.env.GHOSTABLE_TOKEN || '';
 			if (!token) {
 				const sessionSvc = new SessionService();
@@ -90,7 +87,7 @@ export function registerEnvPullCommand(program: Command) {
 			}
 
 			// 4) Fetch secret bundle
-			const client = GhostableClient.unauthenticated(apiBase).withToken(token);
+			const client = GhostableClient.unauthenticated(config.apiBase).withToken(token);
 			let bundle: EnvironmentSecretBundle;
 			try {
 				bundle = await client.pull(projectId, envName!, {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -17,9 +17,8 @@ export function registerOrganizationListCommand(program: Command) {
 		.description(
 			'Initialize a new project in the current directory within the current organization context.',
 		)
-		.option('--api <URL>', 'API base', config.apiBase)
-		.action(async (opts) => {
-			const apiBase = (opts.api as string) ?? config.apiBase;
+		.action(async () => {
+			const apiBase = config.apiBase;
 
 			// Ensure we have a session & org
 			const sessions = new SessionService();

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -11,9 +11,8 @@ export function registerLoginCommand(program: Command) {
 	program
 		.command('login')
 		.description('Authenticate with Ghostable')
-		.option('--api <URL>', 'API base', config.apiBase)
-		.action(async (opts) => {
-			const apiBase = opts.api as string;
+		.action(async () => {
+			const apiBase = config.apiBase;
 			const session = new SessionService();
 			const client = GhostableClient.unauthenticated(apiBase);
 


### PR DESCRIPTION
## Summary
- remove the `--api` override option from interactive commands and rely on the configured API base
- update affected commands to construct clients with the shared configuration value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eed8b4253c8333a702b8b325916eb5