### PR TITLE
Add release automation workflows

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -3,6 +3,10 @@ name: Cut Release
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: "Branch to release from (defaults to repository default branch)"
+        required: false
+        type: string
       bump:
         description: "Version bump to apply"
         required: false
@@ -12,8 +16,17 @@ on:
           - patch
           - minor
           - major
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
+      preid:
+        description: "Pre-release identifier (used with pre* bumps)"
+        required: false
+        default: beta
+        type: string
       version:
-        description: "Explicit version (overrides bump)"
+        description: "Explicit version (overrides bump/preid)"
         required: false
         type: string
       notes:
@@ -27,11 +40,14 @@ permissions:
 jobs:
   cut-release:
     runs-on: ubuntu-latest
+    env:
+      TARGET_BRANCH: ${{ inputs.branch != '' && inputs.branch || github.event.repository.default_branch }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ env.TARGET_BRANCH }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -45,18 +61,26 @@ jobs:
 
       - name: Bump version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUMP: ${{ inputs.bump }}
+          INPUT_PREID: ${{ inputs.preid }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            npm version "${{ inputs.version }}" -m "chore(release): v%s"
+          set -euo pipefail
+          if [ -n "$INPUT_VERSION" ]; then
+            npm version "$INPUT_VERSION" -m "chore(release): v%s"
           else
-            npm version "${{ inputs.bump }}" -m "chore(release): v%s"
+            case "$INPUT_BUMP" in
+              prepatch|preminor|premajor|prerelease)
+                npm version "$INPUT_BUMP" --preid "$INPUT_PREID" -m "chore(release): v%s"
+                ;;
+              *)
+                npm version "$INPUT_BUMP" -m "chore(release): v%s"
+                ;;
+            esac
           fi
-          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
-
-      - name: Push changes and tags
-        run: |
-          git push origin HEAD
-          git push origin --tags
+          TAG=$(git describe --tags --abbrev=0)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Commit release notes
         if: ${{ inputs.notes != '' }}
@@ -64,7 +88,18 @@ jobs:
           NOTES: ${{ inputs.notes }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
+          set -euo pipefail
           printf '%s\n' "$NOTES" > RELEASE_NOTES.txt
           git add RELEASE_NOTES.txt
           git commit -m "chore: add release notes for ${TAG}"
-          git push origin HEAD
+
+      - name: Push changes and tags
+        env:
+          TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
+        run: |
+          set -euo pipefail
+          git push origin "HEAD:${TARGET_BRANCH}"
+          git push origin --tags
+
+      - name: Show created tag
+        run: echo "Created tag: ${{ steps.version.outputs.tag }}"

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -25,8 +25,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Enable npm provenance
-        run: |
-          echo 'provenance=true' >> ~/.npmrc
+        run: echo 'provenance=true' >> ~/.npmrc
 
       - name: Install dependencies
         run: npm ci
@@ -37,21 +36,45 @@ jobs:
       - name: Build
         run: npm run build --if-present
 
+      - name: Determine release metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then
+            PRE_PART=${VERSION#*-}
+            PREID=${PRE_PART%%.*}
+            echo "dist_tag=$PREID" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish
+          DIST_TAG: ${{ steps.meta.outputs.dist_tag }}
+        run: npm publish --tag "$DIST_TAG"
 
       - name: Load release notes
         id: notes
         env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           TAG: ${{ github.ref_name }}
         run: |
-          git fetch origin "$DEFAULT_BRANCH" --depth=50
-          COMMIT=$(git log "origin/$DEFAULT_BRANCH" --grep="chore: add release notes for ${TAG}" --format=%H -n 1)
-          if [ -n "$COMMIT" ]; then
-            git show "$COMMIT:RELEASE_NOTES.txt" > RELEASE_NOTES.txt
+          set -euo pipefail
+          git fetch --all --tags --prune
+          NOTES_COMMIT=$(git log --all --grep="chore: add release notes for ${TAG}" --format=%H -n 1)
+          FOUND=false
+          if [ -n "$NOTES_COMMIT" ]; then
+            git show "${NOTES_COMMIT}:RELEASE_NOTES.txt" > RELEASE_NOTES.txt
+            FOUND=true
+          elif [ -f RELEASE_NOTES.txt ]; then
+            FOUND=true
+          fi
+
+          if [ "$FOUND" = true ] && [ -s RELEASE_NOTES.txt ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
             {
               echo "body<<'EOF'"
@@ -68,3 +91,4 @@ jobs:
           tag: ${{ github.ref_name }}
           body: ${{ steps.notes.outputs.body }}
           generateReleaseNotes: ${{ steps.notes.outputs.found != 'true' }}
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}


### PR DESCRIPTION
## Summary
- expand the Cut Release workflow to support branch selection, prerelease bumps, manual version overrides, and optional release notes commits
- enhance the Publish on Tag workflow to derive npm dist-tags, publish with provenance, and create GitHub releases with prerelease support

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68eeeda7e4fc83339b766683bb6cc2ba