### PR TITLE
Fix cut-release workflow inputs handling

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -6,6 +6,7 @@ on:
       branch:
         description: "Branch to release from (defaults to repository default branch)"
         required: false
+        default: ""
         type: string
       bump:
         description: "Version bump to apply"
@@ -32,6 +33,7 @@ on:
       notes:
         description: "Release notes (optional)"
         required: false
+        default: ""
         type: string
 
 permissions:
@@ -41,7 +43,7 @@ jobs:
   cut-release:
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: ${{ inputs.branch != '' && inputs.branch || github.event.repository.default_branch }}
+      TARGET_BRANCH: ${{ inputs.branch || github.event.repository.default_branch }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -83,7 +85,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Commit release notes
-        if: ${{ inputs.notes != '' }}
+        if: ${{ inputs.notes }}
         env:
           NOTES: ${{ inputs.notes }}
           TAG: ${{ steps.version.outputs.tag }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.github/workflows/


### PR DESCRIPTION
## Summary
- add explicit defaults for optional branch and notes inputs in the cut-release workflow
- simplify the target branch expression and guard the release notes commit step
- extend the prettier ignore list so workflows are excluded while preserving the newline at EOF

## Testing
- npm run lint
- npm run pretty

------
https://chatgpt.com/codex/tasks/task_e_68eef35091b083338edc755386c98bdf