### PR TITLE
Fix release workflow syntax error

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -85,7 +85,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Commit release notes
-        if: ${{ inputs.notes }}
+        if: ${{ inputs.notes != '' }}
         env:
           NOTES: ${{ inputs.notes }}
           TAG: ${{ steps.version.outputs.tag }}
@@ -104,4 +104,5 @@ jobs:
           git push origin --tags
 
       - name: Show created tag
-        run: echo "Created tag: ${{ steps.version.outputs.tag }}"
+        run: |
+          echo "Created tag: ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary
- ensure the release notes step only runs when notes are provided
- format the final step as a multi-line shell command to avoid YAML parsing errors

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68eef6dbfc908333829bdd7e3cae9bb6