### PR TITLE
fix: build package before publishing release

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Build package
+        run: npm run build
+
       - name: Publish to npm
         env:
           VERSION: ${{ steps.bump.outputs.version }}


### PR DESCRIPTION
## Summary
- add an explicit build step to the cut release workflow so the dist folder exists before publishing to npm

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef02763c84833386ee3c0dbbda87d2