### PR TITLE
Fix npm publish authentication in workflow

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -24,8 +24,13 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      - name: Enable npm provenance
-        run: echo 'provenance=true' >> ~/.npmrc
+      - name: Configure npm authentication
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
+          npm config set //registry.npmjs.org/:always-auth true
+          npm config set provenance true
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- configure npm to use the injected auth token before running publish
- set npm provenance via npm config rather than directly editing .npmrc

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef03fedd7883338289e83bccc1b13c