### PR TITLE
Preserve raw env variable formatting when deploying

### DIFF
--- a/src/commands/deploy-cloud.ts
+++ b/src/commands/deploy-cloud.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import ora from 'ora';
 import path from 'node:path';
 
-import { writeEnvFile, readEnvFileSafe } from '../support/env-files.js';
+import { writeEnvFile, readEnvFileSafeWithMetadata, buildPreservedSnapshot } from '../support/env-files.js';
 import {
 	createGhostableClient,
 	decryptBundle,
@@ -71,9 +71,11 @@ export function registerDeployCloudCommand(program: Command) {
 
 			// 4) Write .env in working directory (Cloud flow expects plain .env here)
 			const envPath = path.resolve(resolveWorkDir(), '.env');
-			const previous = readEnvFileSafe(envPath);
-			const combined = { ...previous, ...merged };
-			writeEnvFile(envPath, combined);
+                        const previousMeta = readEnvFileSafeWithMetadata(envPath);
+                        const previous = previousMeta.vars;
+                        const combined = { ...previous, ...merged };
+                        const preserved = buildPreservedSnapshot(previousMeta, merged);
+                        writeEnvFile(envPath, combined, { preserve: preserved });
 			log.ok(`✅ Wrote ${Object.keys(merged).length} keys → ${envPath}`);
 
 			log.ok('Ghostable 👻 deployed (local).');

--- a/src/commands/deploy-forge.ts
+++ b/src/commands/deploy-forge.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 
 import { b64, randomBytes } from '../crypto.js';
-import { writeEnvFile, readEnvFileSafe } from '../support/env-files.js';
+import { writeEnvFile, readEnvFileSafeWithMetadata, buildPreservedSnapshot } from '../support/env-files.js';
 import { artisan } from '../support/artisan.js';
 import {
 	createGhostableClient,
@@ -83,9 +83,12 @@ export function registerDeployForgeCommand(program: Command) {
 				// 4) Write .env in working directory (Forge flow expects plain .env here)
 				const workDir = resolveWorkDir();
 				const envPath = path.resolve(workDir, '.env');
-				const previous = readEnvFileSafe(envPath);
-				const combined = { ...previous, ...merged };
-				writeEnvFile(envPath, combined);
+                                const previousMeta = readEnvFileSafeWithMetadata(envPath);
+                                const previous = previousMeta.vars;
+                                const combined = { ...previous, ...merged };
+                                const preserved = buildPreservedSnapshot(previousMeta, merged);
+
+                                writeEnvFile(envPath, combined, { preserve: preserved });
 				log.ok(`✅ Wrote ${Object.keys(merged).length} keys → ${envPath}`);
 
 				// 5) If --encrypted, generate base64 key, run php artisan env:encrypt, and persist key in .env
@@ -102,7 +105,7 @@ export function registerDeployForgeCommand(program: Command) {
 
 					// ensure key is present in the plain .env file
 					combined['LARAVEL_ENV_ENCRYPTION_KEY'] = envKeyB64;
-					writeEnvFile(envPath, combined);
+                                        writeEnvFile(envPath, combined, { preserve: preserved });
 					log.ok(`🔑 Set LARAVEL_ENV_ENCRYPTION_KEY in ${path.basename(envPath)}`);
 
 					// Create encrypted blob using Laravel's own command

--- a/src/commands/env-deploy.ts
+++ b/src/commands/env-deploy.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import ora from 'ora';
 import path from 'node:path';
 
-import { writeEnvFile, readEnvFileSafe } from '../support/env-files.js';
+import { writeEnvFile, readEnvFileSafeWithMetadata, buildPreservedSnapshot } from '../support/env-files.js';
 import {
 	createGhostableClient,
 	decryptBundle,
@@ -78,10 +78,12 @@ export function registerEnvDeployCommand(program: Command) {
 			// 4) Write .env (default) or a custom path
 			const workDir = resolveWorkDir();
 			const outPath = path.resolve(workDir, opts.file ?? '.env');
-			const previous = readEnvFileSafe(outPath);
-			const combined = { ...previous, ...merged };
+                        const previousMeta = readEnvFileSafeWithMetadata(outPath);
+                        const previous = previousMeta.vars;
+                        const combined = { ...previous, ...merged };
+                        const preserved = buildPreservedSnapshot(previousMeta, merged);
 
-			writeEnvFile(outPath, combined);
+                        writeEnvFile(outPath, combined, { preserve: preserved });
 			log.ok(`✅ Wrote ${Object.keys(merged).length} keys → ${outPath}`);
 			log.ok('Ghostable 👻 deployed (local).');
 		});

--- a/src/support/env-files.ts
+++ b/src/support/env-files.ts
@@ -3,36 +3,108 @@ import path from 'node:path';
 import dotenv from 'dotenv';
 import { resolveWorkDir } from './workdir.js';
 
+export type EnvVarSnapshot = {
+        value: string;
+        rawValue: string;
+};
+
+export type EnvFileMetadata = {
+        vars: Record<string, string>;
+        snapshots: Record<string, EnvVarSnapshot>;
+};
+
 /**
  * Write a .env-style file from a vars map.
  */
-export function writeEnvFile(filePath: string, vars: Record<string, string>): void {
-	const content =
-		Object.keys(vars)
-			.sort((a, b) => a.localeCompare(b))
-			.map((key) => `${key}=${vars[key]}`)
-			.join('\n') + '\n';
+export function writeEnvFile(
+        filePath: string,
+        vars: Record<string, string>,
+        opts?: { preserve?: Record<string, EnvVarSnapshot> },
+): void {
+        const preserve = opts?.preserve ?? {};
 
-	fs.writeFileSync(filePath, content, 'utf8');
+        const content =
+                Object.keys(vars)
+                        .sort((a, b) => a.localeCompare(b))
+                        .map((key) => {
+                                const snapshot = preserve[key];
+                                if (snapshot && snapshot.value === vars[key]) {
+                                        return `${key}=${snapshot.rawValue}`;
+                                }
+
+                                return `${key}=${vars[key]}`;
+                        })
+                        .join('\n') + '\n';
+
+        fs.writeFileSync(filePath, content, 'utf8');
 }
 
 /**
  * Read a .env-style file into a vars map.
  */
 export function readEnvFile(filePath: string): Record<string, string> {
-	if (!fs.existsSync(filePath)) return {};
-	// strip BOM if present
-	let raw = fs.readFileSync(filePath, 'utf8');
-	if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
-	return dotenv.parse(raw);
+        return readEnvFileWithMetadata(filePath).vars;
 }
 
 export function readEnvFileSafe(filePath: string): Record<string, string> {
-	try {
-		return readEnvFile(filePath);
-	} catch {
-		return {};
-	}
+        try {
+                return readEnvFile(filePath);
+        } catch {
+                return {};
+        }
+}
+
+export function readEnvFileWithMetadata(filePath: string): EnvFileMetadata {
+        if (!fs.existsSync(filePath)) {
+                return { vars: {}, snapshots: {} };
+        }
+
+        let raw = fs.readFileSync(filePath, 'utf8');
+        if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+
+        const vars = dotenv.parse(raw);
+        const snapshots: Record<string, EnvVarSnapshot> = {};
+
+        const lines = raw.split(/\r?\n/);
+        for (const line of lines) {
+                const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*)$/);
+                if (!match) continue;
+
+                const [, key, rawValue] = match;
+
+                if (key in vars) {
+                        snapshots[key] = {
+                                value: vars[key],
+                                rawValue,
+                        };
+                }
+        }
+
+        return { vars, snapshots };
+}
+
+export function readEnvFileSafeWithMetadata(filePath: string): EnvFileMetadata {
+        try {
+                return readEnvFileWithMetadata(filePath);
+        } catch {
+                return { vars: {}, snapshots: {} };
+        }
+}
+
+export function buildPreservedSnapshot(
+        metadata: EnvFileMetadata,
+        overrides: Record<string, string>,
+): Record<string, EnvVarSnapshot> {
+        const preserved: Record<string, EnvVarSnapshot> = {};
+
+        for (const [key, snapshot] of Object.entries(metadata.snapshots)) {
+                const overrideValue = overrides[key];
+                if (overrideValue === undefined || overrideValue === snapshot.value) {
+                        preserved[key] = snapshot;
+                }
+        }
+
+        return preserved;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add metadata-aware env file reader and helper to retain previously formatted values
- update deploy commands to reuse preserved formatting when rewriting .env files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f007d5fed88333a474266eb010fd73