### PR TITLE
Add global ignore support for env commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ environments:
   production:
     type: production
     ignore:
-      - GHOSTABLE_TOKEN
       - LOCAL_DB_URL
       - APP_DEBUG
 ```
 
-Default ignored keys (`GHOSTABLE_TOKEN`, `APP_DEBUG`, `LOCAL_DB_URL`, `NODE_ENV`) still apply across environments, and any per-environment list extends that default set.
+The defaults `GHOSTABLE_CI_TOKEN` and `GHOSTABLE_MASTER_SEED` are always ignored across every environment, and any per-environment list extends that fixed set.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You can specify keys per environment in `ghostable.yml → environments.<env>.ig
 
 ```yaml
 environments:
-  production:
-    type: production
-    ignore:
-      - LOCAL_DB_URL
-      - APP_DEBUG
+    production:
+        type: production
+        ignore:
+            - LOCAL_DB_URL
+            - APP_DEBUG
 ```
 
 The defaults `GHOSTABLE_CI_TOKEN` and `GHOSTABLE_MASTER_SEED` are always ignored across every environment, and any per-environment list extends that fixed set.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ See [SECURITY.md](./SECURITY.md) for our security policy.
 
 ### Ignored Keys
 
-You can specify keys in `ghostable.yml → ghostable.ignore` that Ghostable will skip during push, pull, and diff. These keys are never synced or overwritten.
+You can specify keys per environment in `ghostable.yml → environments.<env>.ignore` that Ghostable will skip during push, pull, and diff. These keys are never synced or overwritten.
 
 ```yaml
-ghostable:
-  ignore:
-    - GHOSTABLE_TOKEN
-    - LOCAL_DB_URL
-    - APP_DEBUG
+environments:
+  production:
+    type: production
+    ignore:
+      - GHOSTABLE_TOKEN
+      - LOCAL_DB_URL
+      - APP_DEBUG
 ```
+
+Default ignored keys (`GHOSTABLE_TOKEN`, `APP_DEBUG`, `LOCAL_DB_URL`, `NODE_ENV`) still apply across environments, and any per-environment list extends that default set.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ Ghostable stores and organizes your `.env` variables, validates them, and integr
 Read the [official documentation](https://docs.ghostable.dev) or try it out at [Ghostable.dev](https://ghostable.dev).
 
 See [SECURITY.md](./SECURITY.md) for our security policy.
+
+### Ignored Keys
+
+You can specify keys in `ghostable.yml → ghostable.ignore` that Ghostable will skip during push, pull, and diff. These keys are never synced or overwritten.
+
+```yaml
+ghostable:
+  ignore:
+    - GHOSTABLE_TOKEN
+    - LOCAL_DB_URL
+    - APP_DEBUG
+```

--- a/src/commands/env-diff.ts
+++ b/src/commands/env-diff.ts
@@ -116,7 +116,7 @@ export function registerEnvDiffCommand(program: Command) {
                         }
 
                         // 6) Apply ignore list (unless overridden by --only)
-                        const ignored = getIgnoredKeys();
+                        const ignored = getIgnoredKeys(envName);
                         const localFiltered = filterIgnoredKeys(localMap, ignored, opts.only);
                         const remoteFiltered = filterIgnoredKeys(remoteMap, ignored, opts.only);
                         const ignoredKeysUsed =

--- a/src/commands/env-diff.ts
+++ b/src/commands/env-diff.ts
@@ -10,6 +10,7 @@ import { GhostableClient } from '../services/GhostableClient.js';
 import { log } from '../support/logger.js';
 import { toErrorMessage } from '../support/errors.js';
 import { resolveWorkDir } from '../support/workdir.js';
+import { getIgnoredKeys, filterIgnoredKeys } from '../support/ignore.js';
 
 import { initSodium } from '../crypto.js';
 import { decryptBundle } from '../support/deploy-helpers.js';
@@ -18,11 +19,12 @@ import { readEnvFileSafe, resolveEnvFile } from '../support/env-files.js';
 import type { EnvironmentSecretBundle } from '@/domain';
 
 type DiffOptions = {
-	token?: string;
-	env?: string;
-	file?: string; // optional override; else .env.<env> or .env
-	only?: string[]; // optional; diff just these keys
-	includeMeta?: boolean;
+        token?: string;
+        env?: string;
+        file?: string; // optional override; else .env.<env> or .env
+        only?: string[]; // optional; diff just these keys
+        includeMeta?: boolean;
+        showIgnored?: boolean;
 };
 
 export function registerEnvDiffCommand(program: Command) {
@@ -31,10 +33,11 @@ export function registerEnvDiffCommand(program: Command) {
 		.description('Show differences between your local .env and Ghostable (zero-knowledge).')
 		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
 		.option('--file <PATH>', 'Local .env path (default: .env.<env> or .env)')
-		.option('--token <TOKEN>', 'API token (or stored session / GHOSTABLE_TOKEN)')
-		.option('--only <KEY...>', 'Only diff these keys')
-		.option('--include-meta', 'Include meta flags in bundle', false)
-		.action(async (opts: DiffOptions) => {
+                .option('--token <TOKEN>', 'API token (or stored session / GHOSTABLE_TOKEN)')
+                .option('--only <KEY...>', 'Only diff these keys')
+                .option('--include-meta', 'Include meta flags in bundle', false)
+                .option('--show-ignored', 'Display ignored keys', false)
+                .action(async (opts: DiffOptions) => {
 			// 1) Resolve project + environment from manifest
 			let projectId: string, projectName: string, envNames: string[];
 			try {
@@ -105,76 +108,93 @@ export function registerEnvDiffCommand(program: Command) {
 			// 5) Load local .env for this env (or explicit path)
 			const workDir = resolveWorkDir();
 			const envPath = resolveEnvFile(envName!, opts.file, /* mustExist */ false);
-			const localVars = readEnvFileSafe(envPath);
-			// Local map assumes “not commented” for keys present in file; commented state is unknown locally.
-			const localMap: Record<string, { value: string; commented: boolean }> = {};
-			for (const [k, v] of Object.entries(localVars)) {
-				localMap[k] = { value: v, commented: false };
-			}
+                        const localVars = readEnvFileSafe(envPath);
+                        // Local map assumes “not commented” for keys present in file; commented state is unknown locally.
+                        const localMap: Record<string, { value: string; commented: boolean }> = {};
+                        for (const [k, v] of Object.entries(localVars)) {
+                                localMap[k] = { value: v, commented: false };
+                        }
 
-			// 6) Optionally restrict to `only`
-			const restrict = (keys: string[]) =>
-				opts.only && opts.only.length ? keys.filter((k) => opts.only!.includes(k)) : keys;
+                        // 6) Apply ignore list (unless overridden by --only)
+                        const ignored = getIgnoredKeys();
+                        const localFiltered = filterIgnoredKeys(localMap, ignored, opts.only);
+                        const remoteFiltered = filterIgnoredKeys(remoteMap, ignored, opts.only);
+                        const ignoredKeysUsed =
+                                opts.only && opts.only.length
+                                        ? []
+                                        : ignored.filter((key) => key in localMap || key in remoteMap);
 
-			// 7) Compute diff
-			const added: string[] = [];
-			const updated: string[] = [];
-			const removed: string[] = [];
+                        if (opts.showIgnored) {
+                                const message = ignoredKeysUsed.length
+                                        ? `Ignored keys (${ignoredKeysUsed.length}): ${ignoredKeysUsed.join(', ')}`
+                                        : 'Ignored keys (0): none';
+                                log.info(message);
+                        }
 
-			// added/updated (present locally)
-			for (const key of restrict(Object.keys(localMap))) {
-				if (!(key in remoteMap)) {
-					added.push(key);
-				} else {
-					const lv = localMap[key].value;
-					const rv = remoteMap[key].value;
-					const localCommented = localMap[key].commented;
-					const remoteCommented = remoteMap[key].commented;
-					if (lv !== rv || localCommented !== remoteCommented) {
-						updated.push(key);
-					}
-				}
-			}
+                        // 7) Optionally restrict to `only`
+                        const restrict = (keys: string[]) =>
+                                opts.only && opts.only.length ? keys.filter((k) => opts.only!.includes(k)) : keys;
 
-			// removed (present remotely, not locally)
-			for (const key of restrict(Object.keys(remoteMap))) {
-				if (!(key in localMap)) {
-					removed.push(key);
-				}
-			}
+                        // 8) Compute diff
+                        const added: string[] = [];
+                        const updated: string[] = [];
+                        const removed: string[] = [];
 
-			// 8) Render
-			if (!added.length && !updated.length && !removed.length) {
-				log.info('No differences detected.');
-				return;
+                        // added/updated (present locally)
+                        for (const key of restrict(Object.keys(localFiltered))) {
+                                if (!(key in remoteFiltered)) {
+                                        added.push(key);
+                                } else {
+                                        const lv = localFiltered[key].value;
+                                        const rv = remoteFiltered[key].value;
+                                        const localCommented = localFiltered[key].commented;
+                                        const remoteCommented = remoteFiltered[key].commented;
+                                        if (lv !== rv || localCommented !== remoteCommented) {
+                                                updated.push(key);
+                                        }
+                                }
+                        }
+
+                        // removed (present remotely, not locally)
+                        for (const key of restrict(Object.keys(remoteFiltered))) {
+                                if (!(key in localFiltered)) {
+                                        removed.push(key);
+                                }
+                        }
+
+                        // 9) Render
+                        if (!added.length && !updated.length && !removed.length) {
+                                log.info('No differences detected.');
+                                return;
 			}
 
 			log.info(chalk.bold(`Diff for ${projectName}:${envName}`));
-			if (added.length) {
-				console.log(chalk.green('\nAdded variables:'));
-				for (const k of added) {
-					const v = localMap[k]?.value ?? '';
-					console.log(`  ${chalk.green('+')} ${k}=${v}`);
-				}
-			}
-			if (updated.length) {
-				console.log(chalk.yellow('\nUpdated variables:'));
-				for (const k of updated) {
-					const cur = remoteMap[k]?.value ?? '';
-					const inc = localMap[k]?.value ?? '';
-					const commentChanged =
-						(remoteMap[k]?.commented ?? false) !== (localMap[k]?.commented ?? false);
-					const note = commentChanged ? ' (commented state changed)' : '';
-					console.log(`  ${chalk.yellow('~')} ${k}: ${cur} -> ${inc}${note}`);
-				}
-			}
-			if (removed.length) {
-				console.log(chalk.red('\nRemoved variables:'));
-				for (const k of removed) {
-					const v = remoteMap[k]?.value ?? '';
-					const comment = (remoteMap[k]?.commented ?? false) ? ' (commented)' : '';
-					console.log(`  ${chalk.red('-')} ${k}=${v}${comment}`);
-				}
+                        if (added.length) {
+                                console.log(chalk.green('\nAdded variables:'));
+                                for (const k of added) {
+                                        const v = localFiltered[k]?.value ?? '';
+                                        console.log(`  ${chalk.green('+')} ${k}=${v}`);
+                                }
+                        }
+                        if (updated.length) {
+                                console.log(chalk.yellow('\nUpdated variables:'));
+                                for (const k of updated) {
+                                        const cur = remoteFiltered[k]?.value ?? '';
+                                        const inc = localFiltered[k]?.value ?? '';
+                                        const commentChanged =
+                                                (remoteFiltered[k]?.commented ?? false) !==
+                                                (localFiltered[k]?.commented ?? false);
+                                        const note = commentChanged ? ' (commented state changed)' : '';
+                                        console.log(`  ${chalk.yellow('~')} ${k}: ${cur} -> ${inc}${note}`);
+                                }
+                        }
+                        if (removed.length) {
+                                console.log(chalk.red('\nRemoved variables:'));
+                                for (const k of removed) {
+                                        const v = remoteFiltered[k]?.value ?? '';
+                                        const comment = (remoteFiltered[k]?.commented ?? false) ? ' (commented)' : '';
+                                        console.log(`  ${chalk.red('-')} ${k}=${v}${comment}`);
+                                }
 			}
 
 			console.log(''); // trailing newline

--- a/src/commands/env-pull.ts
+++ b/src/commands/env-pull.ts
@@ -19,11 +19,11 @@ import type { EnvironmentSecret, EnvironmentSecretBundle } from '@/domain';
 type PullOptions = {
 	token?: string;
 	env?: string;
-        file?: string; // output path; default .env.<env> or .env
-        only?: string[]; // repeatable: --only KEY --only OTHER
-        includeMeta?: boolean;
-        dryRun?: boolean; // don't write file; just show summary
-        showIgnored?: boolean;
+	file?: string; // output path; default .env.<env> or .env
+	only?: string[]; // repeatable: --only KEY --only OTHER
+	includeMeta?: boolean;
+	dryRun?: boolean; // don't write file; just show summary
+	showIgnored?: boolean;
 };
 
 function resolveOutputPath(envName: string | undefined, explicit?: string): string {
@@ -45,11 +45,11 @@ export function registerEnvPullCommand(program: Command) {
 		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
 		.option('--file <PATH>', 'Output file (default: .env.<env> or .env)')
 		.option('--token <TOKEN>', 'API token (or stored session / GHOSTABLE_TOKEN)')
-                .option('--only <KEY...>', 'Only include these keys')
-                .option('--include-meta', 'Include meta flags in bundle', false)
-                .option('--dry-run', 'Do not write file; just report', false)
-                .option('--show-ignored', 'Display ignored keys', false)
-                .action(async (opts: PullOptions) => {
+		.option('--only <KEY...>', 'Only include these keys')
+		.option('--include-meta', 'Include meta flags in bundle', false)
+		.option('--dry-run', 'Do not write file; just report', false)
+		.option('--show-ignored', 'Display ignored keys', false)
+		.action(async (opts: PullOptions) => {
 			// 1) Load manifest (project + envs)
 			let projectId: string, projectName: string, envNames: string[];
 			try {
@@ -122,8 +122,8 @@ export function registerEnvPullCommand(program: Command) {
 				byEnv.get(entry.env)!.push(entry);
 			}
 
-                        const merged: Record<string, string> = {};
-                        const commentFlags: Record<string, boolean> = {};
+			const merged: Record<string, string> = {};
+			const commentFlags: Record<string, boolean> = {};
 
 			for (const layer of chainOrder) {
 				const entries: EnvironmentSecret[] = byEnv.get(layer) || [];
@@ -148,44 +148,42 @@ export function registerEnvPullCommand(program: Command) {
 						commentFlags[entry.name] = Boolean(entry.meta?.is_commented);
 					} catch {
 						log.warn(`⚠️ Could not decrypt ${entry.name}; skipping`);
-                                        }
-                                }
-                        }
+					}
+				}
+			}
 
-                        const ignored = getIgnoredKeys(envName);
-                        const filteredMerged = filterIgnoredKeys(merged, ignored, opts.only);
-                        const filteredComments = filterIgnoredKeys(commentFlags, ignored, opts.only);
-                        const ignoredKeysUsed =
-                                opts.only && opts.only.length
-                                        ? []
-                                        : ignored.filter((key) => key in merged);
+			const ignored = getIgnoredKeys(envName);
+			const filteredMerged = filterIgnoredKeys(merged, ignored, opts.only);
+			const filteredComments = filterIgnoredKeys(commentFlags, ignored, opts.only);
+			const ignoredKeysUsed =
+				opts.only && opts.only.length ? [] : ignored.filter((key) => key in merged);
 
-                        if (opts.showIgnored) {
-                                const message = ignoredKeysUsed.length
-                                        ? `Ignored keys (${ignoredKeysUsed.length}): ${ignoredKeysUsed.join(', ')}`
-                                        : 'Ignored keys (0): none';
-                                log.info(message);
-                        }
+			if (opts.showIgnored) {
+				const message = ignoredKeysUsed.length
+					? `Ignored keys (${ignoredKeysUsed.length}): ${ignoredKeysUsed.join(', ')}`
+					: 'Ignored keys (0): none';
+				log.info(message);
+			}
 
-                        // 7) Render dotenv
-                        const lines = Object.keys(filteredMerged)
-                                .sort((a, b) => a.localeCompare(b))
-                                .map((k) => lineForDotenv(k, filteredMerged[k], filteredComments[k]));
+			// 7) Render dotenv
+			const lines = Object.keys(filteredMerged)
+				.sort((a, b) => a.localeCompare(b))
+				.map((k) => lineForDotenv(k, filteredMerged[k], filteredComments[k]));
 
-                        const outputPath = resolveOutputPath(envName!, opts.file);
-                        const content = lines.join('\n') + '\n';
+			const outputPath = resolveOutputPath(envName!, opts.file);
+			const content = lines.join('\n') + '\n';
 
-                        if (opts.dryRun) {
-                                log.info(
-                                        `Dry run: would write ${Object.keys(filteredMerged).length} keys to ${outputPath}`,
-                                );
-                                process.exit(0);
-                        }
+			if (opts.dryRun) {
+				log.info(
+					`Dry run: would write ${Object.keys(filteredMerged).length} keys to ${outputPath}`,
+				);
+				process.exit(0);
+			}
 
-                        fs.writeFileSync(outputPath, content, 'utf8');
+			fs.writeFileSync(outputPath, content, 'utf8');
 
-                        log.ok(
-                                `✅ Wrote ${Object.keys(filteredMerged).length} keys to ${outputPath} (decrypted & merged locally for ${projectName}:${envName}).`,
-                        );
-                });
+			log.ok(
+				`✅ Wrote ${Object.keys(filteredMerged).length} keys to ${outputPath} (decrypted & merged locally for ${projectName}:${envName}).`,
+			);
+		});
 }

--- a/src/commands/env-pull.ts
+++ b/src/commands/env-pull.ts
@@ -152,7 +152,7 @@ export function registerEnvPullCommand(program: Command) {
                                 }
                         }
 
-                        const ignored = getIgnoredKeys();
+                        const ignored = getIgnoredKeys(envName);
                         const filteredMerged = filterIgnoredKeys(merged, ignored, opts.only);
                         const filteredComments = filterIgnoredKeys(commentFlags, ignored, opts.only);
                         const ignoredKeysUsed =

--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -96,14 +96,14 @@ export function registerEnvPushCommand(program: Command) {
 			}
 
 			// 5) Read variables
-                        const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
-                        const ignored = getIgnoredKeys(envName);
-                        const filteredVars = filterIgnoredKeys(envMap, ignored);
-                        const entries = Object.entries(filteredVars).map(([name, parsedValue]) => ({
-                                name,
-                                parsedValue,
-                                plaintext: resolvePlaintext(parsedValue, snapshots[name]),
-                        }));
+			const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
+			const ignored = getIgnoredKeys(envName);
+			const filteredVars = filterIgnoredKeys(envMap, ignored);
+			const entries = Object.entries(filteredVars).map(([name, parsedValue]) => ({
+				name,
+				parsedValue,
+				plaintext: resolvePlaintext(parsedValue, snapshots[name]),
+			}));
 			if (!entries.length) {
 				log.warn('⚠️  No variables found in the .env file.');
 				return;

--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -13,6 +13,7 @@ import { GhostableClient } from '../services/GhostableClient.js';
 import { Manifest } from '../support/Manifest.js';
 import { log } from '../support/logger.js';
 import { toErrorMessage } from '../support/errors.js';
+import { getIgnoredKeys, filterIgnoredKeys } from '../support/ignore.js';
 
 import {
 	EnvVarSnapshot,
@@ -95,12 +96,14 @@ export function registerEnvPushCommand(program: Command) {
 			}
 
 			// 5) Read variables
-			const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
-			const entries = Object.entries(envMap).map(([name, parsedValue]) => ({
-				name,
-				parsedValue,
-				plaintext: resolvePlaintext(parsedValue, snapshots[name]),
-			}));
+                        const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
+                        const ignored = getIgnoredKeys();
+                        const filteredVars = filterIgnoredKeys(envMap, ignored);
+                        const entries = Object.entries(filteredVars).map(([name, parsedValue]) => ({
+                                name,
+                                parsedValue,
+                                plaintext: resolvePlaintext(parsedValue, snapshots[name]),
+                        }));
 			if (!entries.length) {
 				log.warn('⚠️  No variables found in the .env file.');
 				return;

--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -97,7 +97,7 @@ export function registerEnvPushCommand(program: Command) {
 
 			// 5) Read variables
                         const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
-                        const ignored = getIgnoredKeys();
+                        const ignored = getIgnoredKeys(envName);
                         const filteredVars = filterIgnoredKeys(envMap, ignored);
                         const entries = Object.entries(filteredVars).map(([name, parsedValue]) => ({
                                 name,

--- a/src/support/Manifest.ts
+++ b/src/support/Manifest.ts
@@ -18,10 +18,6 @@ export interface ManifestShape {
         id?: string;
         name?: string;
         environments?: ManifestEnvs;
-        ghostable?: {
-                ignore?: string[];
-                [key: string]: unknown;
-        };
         [key: string]: unknown;
 }
 

--- a/src/support/Manifest.ts
+++ b/src/support/Manifest.ts
@@ -9,9 +9,14 @@ export type ManifestEnvsLegacy = string[] | Array<string | { name: string; type?
 export type ManifestEnvs = Record<string, EnvEntry> | ManifestEnvsLegacy;
 
 export interface ManifestShape {
-	id?: string;
-	name?: string;
-	environments?: ManifestEnvs;
+        id?: string;
+        name?: string;
+        environments?: ManifestEnvs;
+        ghostable?: {
+                ignore?: string[];
+                [key: string]: unknown;
+        };
+        [key: string]: unknown;
 }
 
 function defaultPath(): string {
@@ -96,13 +101,22 @@ export class Manifest {
 	}
 
 	/** Project name (required) */
-	static name(file = resolveManifestPath()): string {
-		const m = this.current(file);
-		if (!m.name) {
-			fail(`Invalid project name. Please verify your Ghostable manifest at [${file}].`);
-		}
-		return m.name!;
-	}
+        static name(file = resolveManifestPath()): string {
+                const m = this.current(file);
+                if (!m.name) {
+                        fail(`Invalid project name. Please verify your Ghostable manifest at [${file}].`);
+                }
+                return m.name!;
+        }
+
+        /** Return manifest data if available, or undefined when missing */
+        static data(file = resolveManifestPath()): ManifestShape | undefined {
+                try {
+                        return this.current(file);
+                } catch {
+                        return undefined;
+                }
+        }
 
 	/** Write a fresh manifest from an API project payload */
 	static fresh(

--- a/src/support/Manifest.ts
+++ b/src/support/Manifest.ts
@@ -5,20 +5,22 @@ import yaml from 'js-yaml';
 import { resolveWorkDir } from './workdir.js';
 
 export interface EnvConfig {
-        type?: string;
-        ignore?: string[];
-        [key: string]: unknown;
+	type?: string;
+	ignore?: string[];
+	[key: string]: unknown;
 }
 
 export type EnvEntry = EnvConfig | undefined;
-export type ManifestEnvsLegacy = string[] | Array<string | { name: string; type?: string; ignore?: string[] }>;
+export type ManifestEnvsLegacy =
+	| string[]
+	| Array<string | { name: string; type?: string; ignore?: string[] }>;
 export type ManifestEnvs = Record<string, EnvEntry> | ManifestEnvsLegacy;
 
 export interface ManifestShape {
-        id?: string;
-        name?: string;
-        environments?: ManifestEnvs;
-        [key: string]: unknown;
+	id?: string;
+	name?: string;
+	environments?: ManifestEnvs;
+	[key: string]: unknown;
 }
 
 function defaultPath(): string {
@@ -58,34 +60,36 @@ function writeYaml(file: string, manifest: ManifestShape) {
 
 /** Convert legacy list formats to the normalized map format */
 function normalizeEnvs(envs: ManifestEnvs | undefined): Record<string, EnvEntry> {
-        if (!envs) return {};
+	if (!envs) return {};
 
-        if (!Array.isArray(envs)) {
-                return { ...envs };
-        }
+	if (!Array.isArray(envs)) {
+		return { ...envs };
+	}
 
-        const out: Record<string, EnvEntry> = {};
-        for (const item of envs) {
-                if (typeof item === 'string') {
-                        out[item] = {};
-                } else if (item && typeof item === 'object') {
-                        const name = 'name' in item && typeof item.name === 'string' ? item.name : undefined;
-                        if (!name) continue;
+	const out: Record<string, EnvEntry> = {};
+	for (const item of envs) {
+		if (typeof item === 'string') {
+			out[item] = {};
+		} else if (item && typeof item === 'object') {
+			const name = 'name' in item && typeof item.name === 'string' ? item.name : undefined;
+			if (!name) continue;
 
-                        const type = 'type' in item && typeof item.type === 'string' ? item.type : undefined;
-                        const ignore =
-                                'ignore' in item && Array.isArray(item.ignore)
-                                        ? (item.ignore as string[]).filter((value): value is string => typeof value === 'string')
-                                        : undefined;
+			const type = 'type' in item && typeof item.type === 'string' ? item.type : undefined;
+			const ignore =
+				'ignore' in item && Array.isArray(item.ignore)
+					? (item.ignore as string[]).filter(
+							(value): value is string => typeof value === 'string',
+						)
+					: undefined;
 
-                        const entry: EnvConfig = {};
-                        if (type) entry.type = type;
-                        if (ignore) entry.ignore = [...ignore];
+			const entry: EnvConfig = {};
+			if (type) entry.type = type;
+			if (ignore) entry.ignore = [...ignore];
 
-                        out[name] = entry;
-                }
-        }
-        return out;
+			out[name] = entry;
+		}
+	}
+	return out;
 }
 
 export class Manifest {
@@ -112,22 +116,22 @@ export class Manifest {
 	}
 
 	/** Project name (required) */
-        static name(file = resolveManifestPath()): string {
-                const m = this.current(file);
-                if (!m.name) {
-                        fail(`Invalid project name. Please verify your Ghostable manifest at [${file}].`);
-                }
-                return m.name!;
-        }
+	static name(file = resolveManifestPath()): string {
+		const m = this.current(file);
+		if (!m.name) {
+			fail(`Invalid project name. Please verify your Ghostable manifest at [${file}].`);
+		}
+		return m.name!;
+	}
 
-        /** Return manifest data if available, or undefined when missing */
-        static data(file = resolveManifestPath()): ManifestShape | undefined {
-                try {
-                        return this.current(file);
-                } catch {
-                        return undefined;
-                }
-        }
+	/** Return manifest data if available, or undefined when missing */
+	static data(file = resolveManifestPath()): ManifestShape | undefined {
+		try {
+			return this.current(file);
+		} catch {
+			return undefined;
+		}
+	}
 
 	/** Write a fresh manifest from an API project payload */
 	static fresh(

--- a/src/support/ignore.ts
+++ b/src/support/ignore.ts
@@ -1,33 +1,39 @@
 import { Manifest } from './Manifest.js';
 import type { EnvEntry } from './Manifest.js';
 
-export const DEFAULT_IGNORES = [
-        'GHOSTABLE_CI_TOKEN',
-        'GHOSTABLE_MASTER_SEED',
-];
+export const DEFAULT_IGNORES = ['GHOSTABLE_CI_TOKEN', 'GHOSTABLE_MASTER_SEED'];
 
 export function getIgnoredKeys(env?: string): string[] {
-        const manifest = Manifest.data();
+	const manifest = Manifest.data();
 
-        let environmentSpecific: string[] = [];
-        if (env && manifest?.environments && !Array.isArray(manifest.environments)) {
-                const entry = manifest.environments[env] as EnvEntry;
-                if (entry && typeof entry === 'object' && 'ignore' in entry && Array.isArray(entry.ignore)) {
-                        environmentSpecific = entry.ignore.filter((value): value is string => typeof value === 'string');
-                }
-        }
+	let environmentSpecific: string[] = [];
+	if (env && manifest?.environments && !Array.isArray(manifest.environments)) {
+		const entry = manifest.environments[env] as EnvEntry;
+		if (
+			entry &&
+			typeof entry === 'object' &&
+			'ignore' in entry &&
+			Array.isArray(entry.ignore)
+		) {
+			environmentSpecific = entry.ignore.filter(
+				(value): value is string => typeof value === 'string',
+			);
+		}
+	}
 
-        return Array.from(new Set([...DEFAULT_IGNORES, ...environmentSpecific]));
+	return Array.from(new Set([...DEFAULT_IGNORES, ...environmentSpecific]));
 }
 
-export function filterIgnoredKeys<T extends Record<string, any>>(
-        obj: T,
-        ignored: string[],
-        only?: string[],
+export function filterIgnoredKeys<T extends Record<string, unknown>>(
+	obj: T,
+	ignored: string[],
+	only?: string[],
 ): T {
-        const ignoreSet = new Set(ignored);
-        const onlySet = new Set(only ?? []);
-        return Object.fromEntries(
-                Object.entries(obj).filter(([k]) => (onlySet.size > 0 ? onlySet.has(k) : !ignoreSet.has(k))),
-        ) as T;
+	const ignoreSet = new Set(ignored);
+	const onlySet = new Set(only ?? []);
+	return Object.fromEntries(
+		Object.entries(obj).filter(([k]) =>
+			onlySet.size > 0 ? onlySet.has(k) : !ignoreSet.has(k),
+		),
+	) as T;
 }

--- a/src/support/ignore.ts
+++ b/src/support/ignore.ts
@@ -2,19 +2,12 @@ import { Manifest } from './Manifest.js';
 import type { EnvEntry } from './Manifest.js';
 
 export const DEFAULT_IGNORES = [
-        'GHOSTABLE_TOKEN',
-        'APP_DEBUG',
-        'LOCAL_DB_URL',
-        'NODE_ENV',
+        'GHOSTABLE_CI_TOKEN',
+        'GHOSTABLE_MASTER_SEED',
 ];
 
 export function getIgnoredKeys(env?: string): string[] {
         const manifest = Manifest.data();
-
-        const legacy =
-                manifest?.ghostable?.ignore && Array.isArray(manifest.ghostable.ignore)
-                        ? (manifest.ghostable.ignore as string[])
-                        : [];
 
         let environmentSpecific: string[] = [];
         if (env && manifest?.environments && !Array.isArray(manifest.environments)) {
@@ -24,7 +17,7 @@ export function getIgnoredKeys(env?: string): string[] {
                 }
         }
 
-        return Array.from(new Set([...DEFAULT_IGNORES, ...legacy, ...environmentSpecific]));
+        return Array.from(new Set([...DEFAULT_IGNORES, ...environmentSpecific]));
 }
 
 export function filterIgnoredKeys<T extends Record<string, any>>(

--- a/src/support/ignore.ts
+++ b/src/support/ignore.ts
@@ -1,0 +1,29 @@
+import { Manifest } from './Manifest.js';
+
+export const DEFAULT_IGNORES = [
+        'GHOSTABLE_TOKEN',
+        'APP_DEBUG',
+        'LOCAL_DB_URL',
+        'NODE_ENV',
+];
+
+export function getIgnoredKeys(): string[] {
+        const manifest = Manifest.data();
+        const fromManifest =
+                manifest?.ghostable?.ignore && Array.isArray(manifest.ghostable.ignore)
+                        ? (manifest.ghostable.ignore as string[])
+                        : [];
+        return Array.from(new Set([...DEFAULT_IGNORES, ...fromManifest]));
+}
+
+export function filterIgnoredKeys<T extends Record<string, any>>(
+        obj: T,
+        ignored: string[],
+        only?: string[],
+): T {
+        const ignoreSet = new Set(ignored);
+        const onlySet = new Set(only ?? []);
+        return Object.fromEntries(
+                Object.entries(obj).filter(([k]) => (onlySet.size > 0 ? onlySet.has(k) : !ignoreSet.has(k))),
+        ) as T;
+}

--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -1,0 +1,359 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+
+const logOutputs = {
+        info: [] as string[],
+        warn: [] as string[],
+        error: [] as string[],
+        ok: [] as string[],
+};
+
+let manifestData: any = {};
+let manifestEnvs: string[] = ['prod'];
+let sessionData: any = { accessToken: 'session-token', organizationId: 'org-1' };
+let envFilePath = '/workdir/.env.prod';
+let localEnvVars: Record<string, string> = {};
+let snapshots: Record<string, { rawValue: string }> = {};
+let remoteBundle: any = { chain: ['prod'], secrets: [] };
+let decryptedSecrets: Array<{ entry: { name: string; meta?: { is_commented?: boolean } }; value: string }> = [];
+const uploadPayloads: any[] = [];
+const writeFileCalls: Array<{ path: string; content: string }> = [];
+
+vi.mock('../src/support/logger.js', () => ({
+        log: {
+                info: vi.fn((msg: string) => logOutputs.info.push(msg)),
+                warn: vi.fn((msg: string) => logOutputs.warn.push(msg)),
+                error: vi.fn((msg: string) => logOutputs.error.push(msg)),
+                ok: vi.fn((msg: string) => logOutputs.ok.push(msg)),
+        },
+}));
+
+vi.mock('../src/support/Manifest.js', () => ({
+        Manifest: {
+                id: vi.fn(() => manifestData.id ?? 'project-id'),
+                name: vi.fn(() => manifestData.name ?? 'Project'),
+                environmentNames: vi.fn(() => manifestEnvs),
+                data: vi.fn(() => manifestData),
+        },
+}));
+
+vi.mock('../src/config/index.js', () => ({
+        config: { apiBase: 'https://api.example.com' },
+}));
+
+vi.mock('../src/services/SessionService.js', () => ({
+        SessionService: class {
+                async load() {
+                        return sessionData;
+                }
+        },
+}));
+
+const client = {
+        pull: vi.fn(async () => remoteBundle),
+        uploadSecret: vi.fn(async (_projectId: string, _env: string, payload: any) => {
+                uploadPayloads.push(payload);
+        }),
+};
+
+vi.mock('../src/services/GhostableClient.js', () => ({
+        GhostableClient: {
+                unauthenticated: vi.fn(() => ({
+                        withToken: vi.fn(() => client),
+                })),
+        },
+}));
+
+vi.mock('../src/support/deploy-helpers.js', () => ({
+        decryptBundle: vi.fn(async () => ({ secrets: decryptedSecrets, warnings: [] })),
+}));
+
+vi.mock('../src/support/env-files.js', () => ({
+        readEnvFileSafe: vi.fn(() => localEnvVars),
+        resolveEnvFile: vi.fn(() => envFilePath),
+        readEnvFileSafeWithMetadata: vi.fn(() => ({ vars: localEnvVars, snapshots })),
+}));
+
+vi.mock('../src/support/workdir.js', () => ({
+        resolveWorkDir: vi.fn(() => '/workdir'),
+}));
+
+vi.mock('../src/support/secret-payload.js', () => ({
+        buildSecretPayload: vi.fn(async ({ name, plaintext }: { name: string; plaintext: string }) => ({
+                name,
+                plaintext,
+        })),
+}));
+
+vi.mock('../src/crypto.js', () => ({
+        initSodium: vi.fn(async () => {}),
+        deriveKeys: vi.fn(() => ({ encKey: new Uint8Array(), hmacKey: new Uint8Array() })),
+        aeadDecrypt: vi.fn((_encKey: Uint8Array, params: { ciphertext: string }) =>
+                new TextEncoder().encode(params.ciphertext),
+        ),
+        scopeFromAAD: vi.fn(() => 'scope'),
+}));
+
+vi.mock('../src/keys.js', () => ({
+        loadOrCreateKeys: vi.fn(async () => ({
+                masterSeedB64: 'b64:master',
+                ed25519PrivB64: 'b64:priv',
+        })),
+}));
+
+vi.mock('@inquirer/prompts', () => ({
+        select: vi.fn(),
+}));
+
+class MockListr<TContext> {
+        private readonly tasks: Array<{ title: string; task: (ctx: TContext, task: { title: string }) => Promise<void> | void }>;
+
+        constructor(tasks: Array<{ title: string; task: (ctx: TContext, task: { title: string }) => Promise<void> | void }>) {
+                this.tasks = tasks;
+        }
+
+        async run(): Promise<void> {
+                for (const item of this.tasks) {
+                        const task = { title: item.title };
+                        await item.task({} as TContext, task);
+                }
+        }
+}
+
+vi.mock('listr2', () => ({
+        Listr: MockListr,
+}));
+
+const existsSyncMock = vi.fn(() => true);
+const writeFileSyncMock = vi.fn((path: string, content: string) => {
+        writeFileCalls.push({ path, content });
+});
+
+vi.mock('node:fs', () => ({
+        __esModule: true,
+        default: {
+                existsSync: existsSyncMock,
+                writeFileSync: writeFileSyncMock,
+        },
+        existsSync: existsSyncMock,
+        writeFileSync: writeFileSyncMock,
+}));
+
+vi.mock('../src/support/errors.js', () => ({
+        toErrorMessage: (err: unknown) => String(err),
+}));
+
+let registerEnvDiffCommand: typeof import('../src/commands/env-diff.js').registerEnvDiffCommand;
+let registerEnvPushCommand: typeof import('../src/commands/env-push.js').registerEnvPushCommand;
+let registerEnvPullCommand: typeof import('../src/commands/env-pull.js').registerEnvPullCommand;
+
+beforeAll(async () => {
+        ({ registerEnvDiffCommand } = await import('../src/commands/env-diff.js'));
+        ({ registerEnvPushCommand } = await import('../src/commands/env-push.js'));
+        ({ registerEnvPullCommand } = await import('../src/commands/env-pull.js'));
+});
+
+beforeEach(() => {
+        manifestData = { id: 'project-id', name: 'Project', ghostable: { ignore: ['LOCAL_DB_URL'] } };
+        manifestEnvs = ['prod'];
+        sessionData = { accessToken: 'session-token', organizationId: 'org-1' };
+        envFilePath = '/workdir/.env.prod';
+        localEnvVars = {};
+        snapshots = {};
+        remoteBundle = { chain: ['prod'], secrets: [] };
+        decryptedSecrets = [];
+        uploadPayloads.splice(0, uploadPayloads.length);
+        writeFileCalls.splice(0, writeFileCalls.length);
+        logOutputs.info.length = 0;
+        logOutputs.warn.length = 0;
+        logOutputs.error.length = 0;
+        logOutputs.ok.length = 0;
+        client.pull.mockClear();
+        client.uploadSecret.mockClear();
+        existsSyncMock.mockClear();
+        existsSyncMock.mockReturnValue(true);
+        writeFileSyncMock.mockClear();
+});
+
+describe('env:diff ignore behaviour', () => {
+        it('hides ignored keys and prints them with --show-ignored', async () => {
+                localEnvVars = {
+                        FOO: 'local-value',
+                        GHOSTABLE_TOKEN: 'local-token',
+                        LOCAL_DB_URL: 'postgres://local',
+                };
+                snapshots = Object.fromEntries(
+                        Object.entries(localEnvVars).map(([name, value]) => [name, { rawValue: value }]),
+                );
+                decryptedSecrets = [
+                        { entry: { name: 'FOO', meta: {} }, value: 'remote-value' },
+                        { entry: { name: 'BAR', meta: {} }, value: 'remote-bar' },
+                        { entry: { name: 'LOCAL_DB_URL', meta: {} }, value: 'remote-db' },
+                        { entry: { name: 'GHOSTABLE_TOKEN', meta: {} }, value: 'remote-token' },
+                ];
+
+                const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+                const program = new Command();
+                registerEnvDiffCommand(program);
+                await program.parseAsync([
+                        'node',
+                        'test',
+                        'env:diff',
+                        '--env',
+                        'prod',
+                        '--token',
+                        'api-token',
+                        '--show-ignored',
+                ]);
+
+                const combinedOutput = consoleLog.mock.calls.flat().join(' ');
+                expect(combinedOutput).toContain('FOO');
+                expect(combinedOutput).not.toContain('GHOSTABLE_TOKEN');
+                expect(combinedOutput).not.toContain('LOCAL_DB_URL');
+                expect(logOutputs.info).toContain('Ignored keys (2): GHOSTABLE_TOKEN, LOCAL_DB_URL');
+
+                consoleLog.mockRestore();
+        });
+
+        it('--only overrides ignore list', async () => {
+                localEnvVars = { GHOSTABLE_TOKEN: 'only-token' };
+                snapshots = { GHOSTABLE_TOKEN: { rawValue: 'only-token' } };
+                decryptedSecrets = [];
+
+                const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+                const program = new Command();
+                registerEnvDiffCommand(program);
+                await program.parseAsync([
+                        'node',
+                        'test',
+                        'env:diff',
+                        '--env',
+                        'prod',
+                        '--token',
+                        'api-token',
+                        '--only',
+                        'GHOSTABLE_TOKEN',
+                        '--show-ignored',
+                ]);
+
+                const combinedOutput = consoleLog.mock.calls.flat().join(' ');
+                expect(combinedOutput).toContain('GHOSTABLE_TOKEN');
+                expect(logOutputs.info).toContain('Ignored keys (0): none');
+
+                consoleLog.mockRestore();
+        });
+
+        it('uses default ignores when manifest omit ghostable section', async () => {
+                manifestData = { id: 'project-id', name: 'Project' };
+                localEnvVars = { NODE_ENV: 'development' };
+                snapshots = { NODE_ENV: { rawValue: 'development' } };
+                decryptedSecrets = [];
+
+                const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+                const program = new Command();
+                registerEnvDiffCommand(program);
+                await program.parseAsync([
+                        'node',
+                        'test',
+                        'env:diff',
+                        '--env',
+                        'prod',
+                        '--token',
+                        'api-token',
+                        '--show-ignored',
+                ]);
+
+                expect(logOutputs.info).toContain('Ignored keys (1): NODE_ENV');
+                const combinedOutput = consoleLog.mock.calls.flat().join(' ');
+                expect(combinedOutput).not.toContain('NODE_ENV');
+
+                consoleLog.mockRestore();
+        });
+});
+
+describe('env:push ignore behaviour', () => {
+        it('skips ignored keys when uploading', async () => {
+                localEnvVars = {
+                        FOO: 'value',
+                        APP_DEBUG: 'true',
+                };
+                snapshots = {
+                        FOO: { rawValue: 'value' },
+                        APP_DEBUG: { rawValue: 'true' },
+                };
+
+                const program = new Command();
+                registerEnvPushCommand(program);
+                await program.parseAsync([
+                        'node',
+                        'test',
+                        'env:push',
+                        '--env',
+                        'prod',
+                        '--assume-yes',
+                ]);
+
+                const uploadedNames = uploadPayloads.map((payload) => payload.name);
+                expect(uploadedNames).toEqual(['FOO']);
+        });
+});
+
+describe('env:pull ignore behaviour', () => {
+        it('omits ignored keys from written file and reports them', async () => {
+                remoteBundle = {
+                        chain: ['prod'],
+                        secrets: [
+                                {
+                                        env: 'prod',
+                                        name: 'FOO',
+                                        ciphertext: 'foo-value',
+                                        nonce: 'nonce',
+                                        alg: 'xchacha20',
+                                        aad: {},
+                                        meta: {},
+                                },
+                                {
+                                        env: 'prod',
+                                        name: 'GHOSTABLE_TOKEN',
+                                        ciphertext: 'token-value',
+                                        nonce: 'nonce',
+                                        alg: 'xchacha20',
+                                        aad: {},
+                                        meta: {},
+                                },
+                                {
+                                        env: 'prod',
+                                        name: 'NODE_ENV',
+                                        ciphertext: 'production',
+                                        nonce: 'nonce',
+                                        alg: 'xchacha20',
+                                        aad: {},
+                                        meta: {},
+                                },
+                        ],
+                };
+
+                const program = new Command();
+                registerEnvPullCommand(program);
+                await program.parseAsync([
+                        'node',
+                        'test',
+                        'env:pull',
+                        '--env',
+                        'prod',
+                        '--token',
+                        'api-token',
+                        '--show-ignored',
+                ]);
+
+                expect(writeFileCalls).toHaveLength(1);
+                const [{ content }] = writeFileCalls;
+                expect(content).toContain('FOO=foo-value');
+                expect(content).not.toContain('GHOSTABLE_TOKEN');
+                expect(content).not.toContain('NODE_ENV');
+                expect(logOutputs.info).toContain('Ignored keys (2): GHOSTABLE_TOKEN, NODE_ENV');
+        });
+});

--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -2,10 +2,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Command } from 'commander';
 
 const logOutputs = {
-        info: [] as string[],
-        warn: [] as string[],
-        error: [] as string[],
-        ok: [] as string[],
+	info: [] as string[],
+	warn: [] as string[],
+	error: [] as string[],
+	ok: [] as string[],
 };
 
 let manifestData: any = {};
@@ -15,132 +15,143 @@ let envFilePath = '/workdir/.env.prod';
 let localEnvVars: Record<string, string> = {};
 let snapshots: Record<string, { rawValue: string }> = {};
 let remoteBundle: any = { chain: ['prod'], secrets: [] };
-let decryptedSecrets: Array<{ entry: { name: string; meta?: { is_commented?: boolean } }; value: string }> = [];
+let decryptedSecrets: Array<{
+	entry: { name: string; meta?: { is_commented?: boolean } };
+	value: string;
+}> = [];
 const uploadPayloads: any[] = [];
 const writeFileCalls: Array<{ path: string; content: string }> = [];
 
 vi.mock('../src/support/logger.js', () => ({
-        log: {
-                info: vi.fn((msg: string) => logOutputs.info.push(msg)),
-                warn: vi.fn((msg: string) => logOutputs.warn.push(msg)),
-                error: vi.fn((msg: string) => logOutputs.error.push(msg)),
-                ok: vi.fn((msg: string) => logOutputs.ok.push(msg)),
-        },
+	log: {
+		info: vi.fn((msg: string) => logOutputs.info.push(msg)),
+		warn: vi.fn((msg: string) => logOutputs.warn.push(msg)),
+		error: vi.fn((msg: string) => logOutputs.error.push(msg)),
+		ok: vi.fn((msg: string) => logOutputs.ok.push(msg)),
+	},
 }));
 
 vi.mock('../src/support/Manifest.js', () => ({
-        Manifest: {
-                id: vi.fn(() => manifestData.id ?? 'project-id'),
-                name: vi.fn(() => manifestData.name ?? 'Project'),
-                environmentNames: vi.fn(() => manifestEnvs),
-                data: vi.fn(() => manifestData),
-        },
+	Manifest: {
+		id: vi.fn(() => manifestData.id ?? 'project-id'),
+		name: vi.fn(() => manifestData.name ?? 'Project'),
+		environmentNames: vi.fn(() => manifestEnvs),
+		data: vi.fn(() => manifestData),
+	},
 }));
 
 vi.mock('../src/config/index.js', () => ({
-        config: { apiBase: 'https://api.example.com' },
+	config: { apiBase: 'https://api.example.com' },
 }));
 
 vi.mock('../src/services/SessionService.js', () => ({
-        SessionService: class {
-                async load() {
-                        return sessionData;
-                }
-        },
+	SessionService: class {
+		async load() {
+			return sessionData;
+		}
+	},
 }));
 
 const client = {
-        pull: vi.fn(async () => remoteBundle),
-        uploadSecret: vi.fn(async (_projectId: string, _env: string, payload: any) => {
-                uploadPayloads.push(payload);
-        }),
+	pull: vi.fn(async () => remoteBundle),
+	uploadSecret: vi.fn(async (_projectId: string, _env: string, payload: any) => {
+		uploadPayloads.push(payload);
+	}),
 };
 
 vi.mock('../src/services/GhostableClient.js', () => ({
-        GhostableClient: {
-                unauthenticated: vi.fn(() => ({
-                        withToken: vi.fn(() => client),
-                })),
-        },
+	GhostableClient: {
+		unauthenticated: vi.fn(() => ({
+			withToken: vi.fn(() => client),
+		})),
+	},
 }));
 
 vi.mock('../src/support/deploy-helpers.js', () => ({
-        decryptBundle: vi.fn(async () => ({ secrets: decryptedSecrets, warnings: [] })),
+	decryptBundle: vi.fn(async () => ({ secrets: decryptedSecrets, warnings: [] })),
 }));
 
 vi.mock('../src/support/env-files.js', () => ({
-        readEnvFileSafe: vi.fn(() => localEnvVars),
-        resolveEnvFile: vi.fn(() => envFilePath),
-        readEnvFileSafeWithMetadata: vi.fn(() => ({ vars: localEnvVars, snapshots })),
+	readEnvFileSafe: vi.fn(() => localEnvVars),
+	resolveEnvFile: vi.fn(() => envFilePath),
+	readEnvFileSafeWithMetadata: vi.fn(() => ({ vars: localEnvVars, snapshots })),
 }));
 
 vi.mock('../src/support/workdir.js', () => ({
-        resolveWorkDir: vi.fn(() => '/workdir'),
+	resolveWorkDir: vi.fn(() => '/workdir'),
 }));
 
 vi.mock('../src/support/secret-payload.js', () => ({
-        buildSecretPayload: vi.fn(async ({ name, plaintext }: { name: string; plaintext: string }) => ({
-                name,
-                plaintext,
-        })),
+	buildSecretPayload: vi.fn(async ({ name, plaintext }: { name: string; plaintext: string }) => ({
+		name,
+		plaintext,
+	})),
 }));
 
 vi.mock('../src/crypto.js', () => ({
-        initSodium: vi.fn(async () => {}),
-        deriveKeys: vi.fn(() => ({ encKey: new Uint8Array(), hmacKey: new Uint8Array() })),
-        aeadDecrypt: vi.fn((_encKey: Uint8Array, params: { ciphertext: string }) =>
-                new TextEncoder().encode(params.ciphertext),
-        ),
-        scopeFromAAD: vi.fn(() => 'scope'),
+	initSodium: vi.fn(async () => {}),
+	deriveKeys: vi.fn(() => ({ encKey: new Uint8Array(), hmacKey: new Uint8Array() })),
+	aeadDecrypt: vi.fn((_encKey: Uint8Array, params: { ciphertext: string }) =>
+		new TextEncoder().encode(params.ciphertext),
+	),
+	scopeFromAAD: vi.fn(() => 'scope'),
 }));
 
 vi.mock('../src/keys.js', () => ({
-        loadOrCreateKeys: vi.fn(async () => ({
-                masterSeedB64: 'b64:master',
-                ed25519PrivB64: 'b64:priv',
-        })),
+	loadOrCreateKeys: vi.fn(async () => ({
+		masterSeedB64: 'b64:master',
+		ed25519PrivB64: 'b64:priv',
+	})),
 }));
 
 vi.mock('@inquirer/prompts', () => ({
-        select: vi.fn(),
+	select: vi.fn(),
 }));
 
 class MockListr<TContext> {
-        private readonly tasks: Array<{ title: string; task: (ctx: TContext, task: { title: string }) => Promise<void> | void }>;
+	private readonly tasks: Array<{
+		title: string;
+		task: (ctx: TContext, task: { title: string }) => Promise<void> | void;
+	}>;
 
-        constructor(tasks: Array<{ title: string; task: (ctx: TContext, task: { title: string }) => Promise<void> | void }>) {
-                this.tasks = tasks;
-        }
+	constructor(
+		tasks: Array<{
+			title: string;
+			task: (ctx: TContext, task: { title: string }) => Promise<void> | void;
+		}>,
+	) {
+		this.tasks = tasks;
+	}
 
-        async run(): Promise<void> {
-                for (const item of this.tasks) {
-                        const task = { title: item.title };
-                        await item.task({} as TContext, task);
-                }
-        }
+	async run(): Promise<void> {
+		for (const item of this.tasks) {
+			const task = { title: item.title };
+			await item.task({} as TContext, task);
+		}
+	}
 }
 
 vi.mock('listr2', () => ({
-        Listr: MockListr,
+	Listr: MockListr,
 }));
 
 const existsSyncMock = vi.fn(() => true);
 const writeFileSyncMock = vi.fn((path: string, content: string) => {
-        writeFileCalls.push({ path, content });
+	writeFileCalls.push({ path, content });
 });
 
 vi.mock('node:fs', () => ({
-        __esModule: true,
-        default: {
-                existsSync: existsSyncMock,
-                writeFileSync: writeFileSyncMock,
-        },
-        existsSync: existsSyncMock,
-        writeFileSync: writeFileSyncMock,
+	__esModule: true,
+	default: {
+		existsSync: existsSyncMock,
+		writeFileSync: writeFileSyncMock,
+	},
+	existsSync: existsSyncMock,
+	writeFileSync: writeFileSyncMock,
 }));
 
 vi.mock('../src/support/errors.js', () => ({
-        toErrorMessage: (err: unknown) => String(err),
+	toErrorMessage: (err: unknown) => String(err),
 }));
 
 let registerEnvDiffCommand: typeof import('../src/commands/env-diff.js').registerEnvDiffCommand;
@@ -148,236 +159,231 @@ let registerEnvPushCommand: typeof import('../src/commands/env-push.js').registe
 let registerEnvPullCommand: typeof import('../src/commands/env-pull.js').registerEnvPullCommand;
 
 beforeAll(async () => {
-        ({ registerEnvDiffCommand } = await import('../src/commands/env-diff.js'));
-        ({ registerEnvPushCommand } = await import('../src/commands/env-push.js'));
-        ({ registerEnvPullCommand } = await import('../src/commands/env-pull.js'));
+	({ registerEnvDiffCommand } = await import('../src/commands/env-diff.js'));
+	({ registerEnvPushCommand } = await import('../src/commands/env-push.js'));
+	({ registerEnvPullCommand } = await import('../src/commands/env-pull.js'));
 });
 
 beforeEach(() => {
-        manifestData = {
-                id: 'project-id',
-                name: 'Project',
-                environments: {
-                        prod: { ignore: ['CUSTOM_TOKEN'] },
-                },
-        };
-        manifestEnvs = ['prod'];
-        sessionData = { accessToken: 'session-token', organizationId: 'org-1' };
-        envFilePath = '/workdir/.env.prod';
-        localEnvVars = {};
-        snapshots = {};
-        remoteBundle = { chain: ['prod'], secrets: [] };
-        decryptedSecrets = [];
-        uploadPayloads.splice(0, uploadPayloads.length);
-        writeFileCalls.splice(0, writeFileCalls.length);
-        logOutputs.info.length = 0;
-        logOutputs.warn.length = 0;
-        logOutputs.error.length = 0;
-        logOutputs.ok.length = 0;
-        client.pull.mockClear();
-        client.uploadSecret.mockClear();
-        existsSyncMock.mockClear();
-        existsSyncMock.mockReturnValue(true);
-        writeFileSyncMock.mockClear();
+	manifestData = {
+		id: 'project-id',
+		name: 'Project',
+		environments: {
+			prod: { ignore: ['CUSTOM_TOKEN'] },
+		},
+	};
+	manifestEnvs = ['prod'];
+	sessionData = { accessToken: 'session-token', organizationId: 'org-1' };
+	envFilePath = '/workdir/.env.prod';
+	localEnvVars = {};
+	snapshots = {};
+	remoteBundle = { chain: ['prod'], secrets: [] };
+	decryptedSecrets = [];
+	uploadPayloads.splice(0, uploadPayloads.length);
+	writeFileCalls.splice(0, writeFileCalls.length);
+	logOutputs.info.length = 0;
+	logOutputs.warn.length = 0;
+	logOutputs.error.length = 0;
+	logOutputs.ok.length = 0;
+	client.pull.mockClear();
+	client.uploadSecret.mockClear();
+	existsSyncMock.mockClear();
+	existsSyncMock.mockReturnValue(true);
+	writeFileSyncMock.mockClear();
 });
 
 describe('env:diff ignore behaviour', () => {
-        it('hides ignored keys and prints them with --show-ignored', async () => {
-                localEnvVars = {
-                        FOO: 'local-value',
-                        GHOSTABLE_CI_TOKEN: 'local-token',
-                        CUSTOM_TOKEN: 'custom-local',
-                };
-                snapshots = Object.fromEntries(
-                        Object.entries(localEnvVars).map(([name, value]) => [name, { rawValue: value }]),
-                );
-                decryptedSecrets = [
-                        { entry: { name: 'FOO', meta: {} }, value: 'remote-value' },
-                        { entry: { name: 'BAR', meta: {} }, value: 'remote-bar' },
-                        { entry: { name: 'CUSTOM_TOKEN', meta: {} }, value: 'remote-custom' },
-                        { entry: { name: 'GHOSTABLE_CI_TOKEN', meta: {} }, value: 'remote-token' },
-                ];
+	it('hides ignored keys and prints them with --show-ignored', async () => {
+		localEnvVars = {
+			FOO: 'local-value',
+			GHOSTABLE_CI_TOKEN: 'local-token',
+			CUSTOM_TOKEN: 'custom-local',
+		};
+		snapshots = Object.fromEntries(
+			Object.entries(localEnvVars).map(([name, value]) => [name, { rawValue: value }]),
+		);
+		decryptedSecrets = [
+			{ entry: { name: 'FOO', meta: {} }, value: 'remote-value' },
+			{ entry: { name: 'BAR', meta: {} }, value: 'remote-bar' },
+			{ entry: { name: 'CUSTOM_TOKEN', meta: {} }, value: 'remote-custom' },
+			{ entry: { name: 'GHOSTABLE_CI_TOKEN', meta: {} }, value: 'remote-token' },
+		];
 
-                const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-                const program = new Command();
-                registerEnvDiffCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:diff',
-                        '--env',
-                        'prod',
-                        '--token',
-                        'api-token',
-                        '--show-ignored',
-                ]);
+		const program = new Command();
+		registerEnvDiffCommand(program);
+		await program.parseAsync([
+			'node',
+			'test',
+			'env:diff',
+			'--env',
+			'prod',
+			'--token',
+			'api-token',
+			'--show-ignored',
+		]);
 
-                const combinedOutput = consoleLog.mock.calls.flat().join(' ');
-                expect(combinedOutput).toContain('FOO');
-                expect(combinedOutput).not.toContain('GHOSTABLE_CI_TOKEN');
-                expect(combinedOutput).not.toContain('CUSTOM_TOKEN');
-                expect(logOutputs.info).toContain('Ignored keys (2): GHOSTABLE_CI_TOKEN, CUSTOM_TOKEN');
+		const combinedOutput = consoleLog.mock.calls.flat().join(' ');
+		expect(combinedOutput).toContain('FOO');
+		expect(combinedOutput).not.toContain('GHOSTABLE_CI_TOKEN');
+		expect(combinedOutput).not.toContain('CUSTOM_TOKEN');
+		expect(logOutputs.info).toContain('Ignored keys (2): GHOSTABLE_CI_TOKEN, CUSTOM_TOKEN');
 
-                consoleLog.mockRestore();
-        });
+		consoleLog.mockRestore();
+	});
 
-        it('--only overrides ignore list', async () => {
-                localEnvVars = { GHOSTABLE_CI_TOKEN: 'only-token' };
-                snapshots = { GHOSTABLE_CI_TOKEN: { rawValue: 'only-token' } };
-                decryptedSecrets = [];
+	it('--only overrides ignore list', async () => {
+		localEnvVars = { GHOSTABLE_CI_TOKEN: 'only-token' };
+		snapshots = { GHOSTABLE_CI_TOKEN: { rawValue: 'only-token' } };
+		decryptedSecrets = [];
 
-                const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-                const program = new Command();
-                registerEnvDiffCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:diff',
-                        '--env',
-                        'prod',
-                        '--token',
-                        'api-token',
-                        '--only',
-                        'GHOSTABLE_CI_TOKEN',
-                        '--show-ignored',
-                ]);
+		const program = new Command();
+		registerEnvDiffCommand(program);
+		await program.parseAsync([
+			'node',
+			'test',
+			'env:diff',
+			'--env',
+			'prod',
+			'--token',
+			'api-token',
+			'--only',
+			'GHOSTABLE_CI_TOKEN',
+			'--show-ignored',
+		]);
 
-                const combinedOutput = consoleLog.mock.calls.flat().join(' ');
-                expect(combinedOutput).toContain('GHOSTABLE_CI_TOKEN');
-                expect(logOutputs.info).toContain('Ignored keys (0): none');
+		const combinedOutput = consoleLog.mock.calls.flat().join(' ');
+		expect(combinedOutput).toContain('GHOSTABLE_CI_TOKEN');
+		expect(logOutputs.info).toContain('Ignored keys (0): none');
 
-                consoleLog.mockRestore();
-        });
+		consoleLog.mockRestore();
+	});
 
-        it('uses default ignores when manifest omits environment ignore list', async () => {
-                manifestData = {
-                        id: 'project-id',
-                        name: 'Project',
-                        environments: {
-                                prod: {},
-                        },
-                };
-                localEnvVars = { GHOSTABLE_MASTER_SEED: 'seed' };
-                snapshots = { GHOSTABLE_MASTER_SEED: { rawValue: 'seed' } };
-                decryptedSecrets = [];
+	it('uses default ignores when manifest omits environment ignore list', async () => {
+		manifestData = {
+			id: 'project-id',
+			name: 'Project',
+			environments: {
+				prod: {},
+			},
+		};
+		localEnvVars = { GHOSTABLE_MASTER_SEED: 'seed' };
+		snapshots = { GHOSTABLE_MASTER_SEED: { rawValue: 'seed' } };
+		decryptedSecrets = [];
 
-                const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-                const program = new Command();
-                registerEnvDiffCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:diff',
-                        '--env',
-                        'prod',
-                        '--token',
-                        'api-token',
-                        '--show-ignored',
-                ]);
+		const program = new Command();
+		registerEnvDiffCommand(program);
+		await program.parseAsync([
+			'node',
+			'test',
+			'env:diff',
+			'--env',
+			'prod',
+			'--token',
+			'api-token',
+			'--show-ignored',
+		]);
 
-                expect(logOutputs.info).toContain('Ignored keys (1): GHOSTABLE_MASTER_SEED');
-                const combinedOutput = consoleLog.mock.calls.flat().join(' ');
-                expect(combinedOutput).not.toContain('GHOSTABLE_MASTER_SEED');
+		expect(logOutputs.info).toContain('Ignored keys (1): GHOSTABLE_MASTER_SEED');
+		const combinedOutput = consoleLog.mock.calls.flat().join(' ');
+		expect(combinedOutput).not.toContain('GHOSTABLE_MASTER_SEED');
 
-                consoleLog.mockRestore();
-        });
+		consoleLog.mockRestore();
+	});
 });
 
 describe('env:push ignore behaviour', () => {
-        it('skips ignored keys when uploading', async () => {
-                localEnvVars = {
-                        FOO: 'value',
-                        GHOSTABLE_MASTER_SEED: 'true',
-                        CUSTOM_TOKEN: 'custom',
-                };
-                snapshots = {
-                        FOO: { rawValue: 'value' },
-                        GHOSTABLE_MASTER_SEED: { rawValue: 'true' },
-                        CUSTOM_TOKEN: { rawValue: 'custom' },
-                };
+	it('skips ignored keys when uploading', async () => {
+		localEnvVars = {
+			FOO: 'value',
+			GHOSTABLE_MASTER_SEED: 'true',
+			CUSTOM_TOKEN: 'custom',
+		};
+		snapshots = {
+			FOO: { rawValue: 'value' },
+			GHOSTABLE_MASTER_SEED: { rawValue: 'true' },
+			CUSTOM_TOKEN: { rawValue: 'custom' },
+		};
 
-                const program = new Command();
-                registerEnvPushCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:push',
-                        '--env',
-                        'prod',
-                        '--assume-yes',
-                ]);
+		const program = new Command();
+		registerEnvPushCommand(program);
+		await program.parseAsync(['node', 'test', 'env:push', '--env', 'prod', '--assume-yes']);
 
-                const uploadedNames = uploadPayloads.map((payload) => payload.name);
-                expect(uploadedNames).toEqual(['FOO']);
-        });
+		const uploadedNames = uploadPayloads.map((payload) => payload.name);
+		expect(uploadedNames).toEqual(['FOO']);
+	});
 });
 
 describe('env:pull ignore behaviour', () => {
-        it('omits ignored keys from written file and reports them', async () => {
-                remoteBundle = {
-                        chain: ['prod'],
-                        secrets: [
-                                {
-                                        env: 'prod',
-                                        name: 'FOO',
-                                        ciphertext: 'foo-value',
-                                        nonce: 'nonce',
-                                        alg: 'xchacha20',
-                                        aad: {},
-                                        meta: {},
-                                },
-                                {
-                                        env: 'prod',
-                                        name: 'GHOSTABLE_CI_TOKEN',
-                                        ciphertext: 'token-value',
-                                        nonce: 'nonce',
-                                        alg: 'xchacha20',
-                                        aad: {},
-                                        meta: {},
-                                },
-                                {
-                                        env: 'prod',
-                                        name: 'CUSTOM_TOKEN',
-                                        ciphertext: 'custom-value',
-                                        nonce: 'nonce',
-                                        alg: 'xchacha20',
-                                        aad: {},
-                                        meta: {},
-                                },
-                                {
-                                        env: 'prod',
-                                        name: 'GHOSTABLE_MASTER_SEED',
-                                        ciphertext: 'seed',
-                                        nonce: 'nonce',
-                                        alg: 'xchacha20',
-                                        aad: {},
-                                        meta: {},
-                                },
-                        ],
-                };
+	it('omits ignored keys from written file and reports them', async () => {
+		remoteBundle = {
+			chain: ['prod'],
+			secrets: [
+				{
+					env: 'prod',
+					name: 'FOO',
+					ciphertext: 'foo-value',
+					nonce: 'nonce',
+					alg: 'xchacha20',
+					aad: {},
+					meta: {},
+				},
+				{
+					env: 'prod',
+					name: 'GHOSTABLE_CI_TOKEN',
+					ciphertext: 'token-value',
+					nonce: 'nonce',
+					alg: 'xchacha20',
+					aad: {},
+					meta: {},
+				},
+				{
+					env: 'prod',
+					name: 'CUSTOM_TOKEN',
+					ciphertext: 'custom-value',
+					nonce: 'nonce',
+					alg: 'xchacha20',
+					aad: {},
+					meta: {},
+				},
+				{
+					env: 'prod',
+					name: 'GHOSTABLE_MASTER_SEED',
+					ciphertext: 'seed',
+					nonce: 'nonce',
+					alg: 'xchacha20',
+					aad: {},
+					meta: {},
+				},
+			],
+		};
 
-                const program = new Command();
-                registerEnvPullCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:pull',
-                        '--env',
-                        'prod',
-                        '--token',
-                        'api-token',
-                        '--show-ignored',
-                ]);
+		const program = new Command();
+		registerEnvPullCommand(program);
+		await program.parseAsync([
+			'node',
+			'test',
+			'env:pull',
+			'--env',
+			'prod',
+			'--token',
+			'api-token',
+			'--show-ignored',
+		]);
 
-                expect(writeFileCalls).toHaveLength(1);
-                const [{ content }] = writeFileCalls;
-                expect(content).toContain('FOO=foo-value');
-                expect(content).not.toContain('GHOSTABLE_CI_TOKEN');
-                expect(content).not.toContain('GHOSTABLE_MASTER_SEED');
-                expect(content).not.toContain('CUSTOM_TOKEN');
-                expect(logOutputs.info).toContain('Ignored keys (3): GHOSTABLE_CI_TOKEN, GHOSTABLE_MASTER_SEED, CUSTOM_TOKEN');
-        });
+		expect(writeFileCalls).toHaveLength(1);
+		const [{ content }] = writeFileCalls;
+		expect(content).toContain('FOO=foo-value');
+		expect(content).not.toContain('GHOSTABLE_CI_TOKEN');
+		expect(content).not.toContain('GHOSTABLE_MASTER_SEED');
+		expect(content).not.toContain('CUSTOM_TOKEN');
+		expect(logOutputs.info).toContain(
+			'Ignored keys (3): GHOSTABLE_CI_TOKEN, GHOSTABLE_MASTER_SEED, CUSTOM_TOKEN',
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- add shared helpers to load global ignore entries from the manifest
- filter env diff, push, and pull operations using the combined ignore list with an optional --show-ignored flag
- document ignore configuration and cover the new behaviour with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0feb39bac8333816a894b15008cf7