### PR TITLE
feat: improve env pull merging and backups

### DIFF
--- a/src/commands/env-pull.ts
+++ b/src/commands/env-pull.ts
@@ -13,17 +13,22 @@ import { log } from '../support/logger.js';
 import { toErrorMessage } from '../support/errors.js';
 import { resolveWorkDir } from '../support/workdir.js';
 import { getIgnoredKeys, filterIgnoredKeys } from '../support/ignore.js';
+import { readEnvFileSafeWithMetadata } from '../support/env-files.js';
 
 import type { EnvironmentSecret, EnvironmentSecretBundle } from '@/domain';
 
 type PullOptions = {
-	token?: string;
-	env?: string;
-	file?: string; // output path; default .env.<env> or .env
-	only?: string[]; // repeatable: --only KEY --only OTHER
-	includeMeta?: boolean;
-	dryRun?: boolean; // don't write file; just show summary
-	showIgnored?: boolean;
+        token?: string;
+        env?: string;
+        file?: string; // output path; default .env.<env> or .env
+        only?: string[]; // repeatable: --only KEY --only OTHER
+        includeMeta?: boolean;
+        dryRun?: boolean; // don't write file; just show summary
+        showIgnored?: boolean;
+        replace?: boolean;
+        pruneLocal?: boolean;
+        noBackup?: boolean;
+        backup?: boolean;
 };
 
 function resolveOutputPath(envName: string | undefined, explicit?: string): string {
@@ -46,10 +51,13 @@ export function registerEnvPullCommand(program: Command) {
 		.option('--file <PATH>', 'Output file (default: .env.<env> or .env)')
 		.option('--token <TOKEN>', 'API token (or stored session / GHOSTABLE_TOKEN)')
 		.option('--only <KEY...>', 'Only include these keys')
-		.option('--include-meta', 'Include meta flags in bundle', false)
-		.option('--dry-run', 'Do not write file; just report', false)
-		.option('--show-ignored', 'Display ignored keys', false)
-		.action(async (opts: PullOptions) => {
+                .option('--include-meta', 'Include meta flags in bundle', false)
+                .option('--dry-run', 'Do not write file; just report', false)
+                .option('--show-ignored', 'Display ignored keys', false)
+                .option('--replace', 'Replace local file instead of merging', false)
+                .option('--prune-local', 'Alias for --replace', false)
+                .option('--no-backup', 'Do not create a backup before writing')
+                .action(async (opts: PullOptions) => {
 			// 1) Load manifest (project + envs)
 			let projectId: string, projectName: string, envNames: string[];
 			try {
@@ -166,24 +174,98 @@ export function registerEnvPullCommand(program: Command) {
 			}
 
 			// 7) Render dotenv
-			const lines = Object.keys(filteredMerged)
-				.sort((a, b) => a.localeCompare(b))
-				.map((k) => lineForDotenv(k, filteredMerged[k], filteredComments[k]));
+                        const outputPath = resolveOutputPath(envName!, opts.file);
+                        const { vars: existingVars, snapshots } = readEnvFileSafeWithMetadata(outputPath);
 
-			const outputPath = resolveOutputPath(envName!, opts.file);
-			const content = lines.join('\n') + '\n';
+                        const replace = Boolean(opts.replace || opts.pruneLocal);
+                        const noBackup = opts.backup === false || opts.noBackup === true;
+                        const serverKeys = Object.keys(filteredMerged);
 
-			if (opts.dryRun) {
-				log.info(
-					`Dry run: would write ${Object.keys(filteredMerged).length} keys to ${outputPath}`,
-				);
-				process.exit(0);
-			}
+                        let createCount = 0;
+                        let updateCount = 0;
+                        for (const key of serverKeys) {
+                                const current = existingVars[key];
+                                if (current === undefined) {
+                                        createCount += 1;
+                                        continue;
+                                }
+                                if (current !== filteredMerged[key]) {
+                                        updateCount += 1;
+                                }
+                        }
 
-			fs.writeFileSync(outputPath, content, 'utf8');
+                        let deleteCount = 0;
+                        if (replace) {
+                                for (const key of Object.keys(existingVars)) {
+                                        if (!(key in filteredMerged)) {
+                                                deleteCount += 1;
+                                        }
+                                }
+                        }
 
-			log.ok(
-				`✅ Wrote ${Object.keys(filteredMerged).length} keys to ${outputPath} (decrypted & merged locally for ${projectName}:${envName}).`,
-			);
-		});
+                        const hasChanges = createCount > 0 || updateCount > 0 || (replace && deleteCount > 0);
+
+                        const summaryParts = [`CREATE ${createCount}`, `UPDATE ${updateCount}`];
+                        if (replace) summaryParts.push(`DELETE ${deleteCount}`);
+                        const summary = summaryParts.join(' | ');
+                        log.info(summary);
+
+                        if (opts.dryRun) {
+                                const dryRunMsg = hasChanges
+                                        ? `Dry run: would update ${outputPath}`
+                                        : `Dry run: no changes for ${outputPath}`;
+                                log.info(dryRunMsg);
+                                process.exit(0);
+                        }
+
+                        if (!hasChanges) {
+                                log.ok(`✅ ${outputPath} is already up to date for ${projectName}:${envName}.`);
+                                return;
+                        }
+
+                        const finalEntries = new Map<string, { value: string; comment?: boolean }>();
+
+                        if (!replace) {
+                                for (const [key, value] of Object.entries(existingVars)) {
+                                        finalEntries.set(key, { value });
+                                }
+                        }
+
+                        for (const key of serverKeys) {
+                                finalEntries.set(key, {
+                                        value: filteredMerged[key],
+                                        comment: Boolean(filteredComments[key]),
+                                });
+                        }
+
+                        const lines = Array.from(finalEntries.keys())
+                                .sort((a, b) => a.localeCompare(b))
+                                .map((key) => {
+                                        const entry = finalEntries.get(key)!;
+                                        if (entry.comment) {
+                                                return lineForDotenv(key, entry.value, true);
+                                        }
+
+                                        const snapshot = snapshots[key];
+                                        if (snapshot && snapshot.value === entry.value) {
+                                                return `${key}=${snapshot.rawValue}`;
+                                        }
+
+                                        return lineForDotenv(key, entry.value);
+                                });
+
+                        const content = lines.join('\n') + '\n';
+
+                        if (!noBackup && fs.existsSync(outputPath)) {
+                                const timestamp = new Date().toISOString().replace(/:/g, '-');
+                                const { dir, base } = path.parse(outputPath);
+                                const backupPath = path.join(dir, `${base}.bak-${timestamp}`);
+                                fs.copyFileSync(outputPath, backupPath);
+                                log.info(`Backup created at ${backupPath}`);
+                        }
+
+                        fs.writeFileSync(outputPath, content, 'utf8');
+
+                        log.ok(`✅ Updated ${outputPath} for ${projectName}:${envName}.`);
+                });
 }

--- a/src/commands/env-pull.ts
+++ b/src/commands/env-pull.ts
@@ -18,17 +18,17 @@ import { readEnvFileSafeWithMetadata } from '../support/env-files.js';
 import type { EnvironmentSecret, EnvironmentSecretBundle } from '@/domain';
 
 type PullOptions = {
-        token?: string;
-        env?: string;
-        file?: string; // output path; default .env.<env> or .env
-        only?: string[]; // repeatable: --only KEY --only OTHER
-        includeMeta?: boolean;
-        dryRun?: boolean; // don't write file; just show summary
-        showIgnored?: boolean;
-        replace?: boolean;
-        pruneLocal?: boolean;
-        noBackup?: boolean;
-        backup?: boolean;
+	token?: string;
+	env?: string;
+	file?: string; // output path; default .env.<env> or .env
+	only?: string[]; // repeatable: --only KEY --only OTHER
+	includeMeta?: boolean;
+	dryRun?: boolean; // don't write file; just show summary
+	showIgnored?: boolean;
+	replace?: boolean;
+	pruneLocal?: boolean;
+	noBackup?: boolean;
+	backup?: boolean;
 };
 
 function resolveOutputPath(envName: string | undefined, explicit?: string): string {
@@ -51,13 +51,13 @@ export function registerEnvPullCommand(program: Command) {
 		.option('--file <PATH>', 'Output file (default: .env.<env> or .env)')
 		.option('--token <TOKEN>', 'API token (or stored session / GHOSTABLE_TOKEN)')
 		.option('--only <KEY...>', 'Only include these keys')
-                .option('--include-meta', 'Include meta flags in bundle', false)
-                .option('--dry-run', 'Do not write file; just report', false)
-                .option('--show-ignored', 'Display ignored keys', false)
-                .option('--replace', 'Replace local file instead of merging', false)
-                .option('--prune-local', 'Alias for --replace', false)
-                .option('--no-backup', 'Do not create a backup before writing')
-                .action(async (opts: PullOptions) => {
+		.option('--include-meta', 'Include meta flags in bundle', false)
+		.option('--dry-run', 'Do not write file; just report', false)
+		.option('--show-ignored', 'Display ignored keys', false)
+		.option('--replace', 'Replace local file instead of merging', false)
+		.option('--prune-local', 'Alias for --replace', false)
+		.option('--no-backup', 'Do not create a backup before writing')
+		.action(async (opts: PullOptions) => {
 			// 1) Load manifest (project + envs)
 			let projectId: string, projectName: string, envNames: string[];
 			try {
@@ -174,98 +174,99 @@ export function registerEnvPullCommand(program: Command) {
 			}
 
 			// 7) Render dotenv
-                        const outputPath = resolveOutputPath(envName!, opts.file);
-                        const { vars: existingVars, snapshots } = readEnvFileSafeWithMetadata(outputPath);
+			const outputPath = resolveOutputPath(envName!, opts.file);
+			const { vars: existingVars, snapshots } = readEnvFileSafeWithMetadata(outputPath);
 
-                        const replace = Boolean(opts.replace || opts.pruneLocal);
-                        const noBackup = opts.backup === false || opts.noBackup === true;
-                        const serverKeys = Object.keys(filteredMerged);
+			const replace = Boolean(opts.replace || opts.pruneLocal);
+			const noBackup = opts.backup === false || opts.noBackup === true;
+			console.log(noBackup);
+			const serverKeys = Object.keys(filteredMerged);
 
-                        let createCount = 0;
-                        let updateCount = 0;
-                        for (const key of serverKeys) {
-                                const current = existingVars[key];
-                                if (current === undefined) {
-                                        createCount += 1;
-                                        continue;
-                                }
-                                if (current !== filteredMerged[key]) {
-                                        updateCount += 1;
-                                }
-                        }
+			let createCount = 0;
+			let updateCount = 0;
+			for (const key of serverKeys) {
+				const current = existingVars[key];
+				if (current === undefined) {
+					createCount += 1;
+					continue;
+				}
+				if (current !== filteredMerged[key]) {
+					updateCount += 1;
+				}
+			}
 
-                        let deleteCount = 0;
-                        if (replace) {
-                                for (const key of Object.keys(existingVars)) {
-                                        if (!(key in filteredMerged)) {
-                                                deleteCount += 1;
-                                        }
-                                }
-                        }
+			let deleteCount = 0;
+			if (replace) {
+				for (const key of Object.keys(existingVars)) {
+					if (!(key in filteredMerged)) {
+						deleteCount += 1;
+					}
+				}
+			}
 
-                        const hasChanges = createCount > 0 || updateCount > 0 || (replace && deleteCount > 0);
+			const hasChanges = createCount > 0 || updateCount > 0 || (replace && deleteCount > 0);
 
-                        const summaryParts = [`CREATE ${createCount}`, `UPDATE ${updateCount}`];
-                        if (replace) summaryParts.push(`DELETE ${deleteCount}`);
-                        const summary = summaryParts.join(' | ');
-                        log.info(summary);
+			const summaryParts = [`CREATE ${createCount}`, `UPDATE ${updateCount}`];
+			if (replace) summaryParts.push(`DELETE ${deleteCount}`);
+			const summary = summaryParts.join(' | ');
+			log.info(summary);
 
-                        if (opts.dryRun) {
-                                const dryRunMsg = hasChanges
-                                        ? `Dry run: would update ${outputPath}`
-                                        : `Dry run: no changes for ${outputPath}`;
-                                log.info(dryRunMsg);
-                                process.exit(0);
-                        }
+			if (opts.dryRun) {
+				const dryRunMsg = hasChanges
+					? `Dry run: would update ${outputPath}`
+					: `Dry run: no changes for ${outputPath}`;
+				log.info(dryRunMsg);
+				process.exit(0);
+			}
 
-                        if (!hasChanges) {
-                                log.ok(`✅ ${outputPath} is already up to date for ${projectName}:${envName}.`);
-                                return;
-                        }
+			if (!hasChanges) {
+				log.ok(`✅ ${outputPath} is already up to date for ${projectName}:${envName}.`);
+				return;
+			}
 
-                        const finalEntries = new Map<string, { value: string; comment?: boolean }>();
+			const finalEntries = new Map<string, { value: string; comment?: boolean }>();
 
-                        if (!replace) {
-                                for (const [key, value] of Object.entries(existingVars)) {
-                                        finalEntries.set(key, { value });
-                                }
-                        }
+			if (!replace) {
+				for (const [key, value] of Object.entries(existingVars)) {
+					finalEntries.set(key, { value });
+				}
+			}
 
-                        for (const key of serverKeys) {
-                                finalEntries.set(key, {
-                                        value: filteredMerged[key],
-                                        comment: Boolean(filteredComments[key]),
-                                });
-                        }
+			for (const key of serverKeys) {
+				finalEntries.set(key, {
+					value: filteredMerged[key],
+					comment: Boolean(filteredComments[key]),
+				});
+			}
 
-                        const lines = Array.from(finalEntries.keys())
-                                .sort((a, b) => a.localeCompare(b))
-                                .map((key) => {
-                                        const entry = finalEntries.get(key)!;
-                                        if (entry.comment) {
-                                                return lineForDotenv(key, entry.value, true);
-                                        }
+			const lines = Array.from(finalEntries.keys())
+				.sort((a, b) => a.localeCompare(b))
+				.map((key) => {
+					const entry = finalEntries.get(key)!;
+					if (entry.comment) {
+						return lineForDotenv(key, entry.value, true);
+					}
 
-                                        const snapshot = snapshots[key];
-                                        if (snapshot && snapshot.value === entry.value) {
-                                                return `${key}=${snapshot.rawValue}`;
-                                        }
+					const snapshot = snapshots[key];
+					if (snapshot && snapshot.value === entry.value) {
+						return `${key}=${snapshot.rawValue}`;
+					}
 
-                                        return lineForDotenv(key, entry.value);
-                                });
+					return lineForDotenv(key, entry.value);
+				});
 
-                        const content = lines.join('\n') + '\n';
+			const content = lines.join('\n') + '\n';
 
-                        if (!noBackup && fs.existsSync(outputPath)) {
-                                const timestamp = new Date().toISOString().replace(/:/g, '-');
-                                const { dir, base } = path.parse(outputPath);
-                                const backupPath = path.join(dir, `${base}.bak-${timestamp}`);
-                                fs.copyFileSync(outputPath, backupPath);
-                                log.info(`Backup created at ${backupPath}`);
-                        }
+			if (!noBackup && fs.existsSync(outputPath)) {
+				const timestamp = new Date().toISOString().replace(/:/g, '-');
+				const { dir, base } = path.parse(outputPath);
+				const backupPath = path.join(dir, `${base}.bak-${timestamp}`);
+				fs.copyFileSync(outputPath, backupPath);
+				log.info(`Backup created at ${backupPath}`);
+			}
 
-                        fs.writeFileSync(outputPath, content, 'utf8');
+			fs.writeFileSync(outputPath, content, 'utf8');
 
-                        log.ok(`✅ Updated ${outputPath} for ${projectName}:${envName}.`);
-                });
+			log.ok(`✅ Updated ${outputPath} for ${projectName}:${envName}.`);
+		});
 }

--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -21,6 +21,7 @@ let decryptedSecrets: Array<{
 }> = [];
 const uploadPayloads: any[] = [];
 const writeFileCalls: Array<{ path: string; content: string }> = [];
+const copyFileCalls: Array<{ src: string; dest: string }> = [];
 
 vi.mock('../src/support/logger.js', () => ({
 	log: {
@@ -137,17 +138,22 @@ vi.mock('listr2', () => ({
 
 const existsSyncMock = vi.fn(() => true);
 const writeFileSyncMock = vi.fn((path: string, content: string) => {
-	writeFileCalls.push({ path, content });
+        writeFileCalls.push({ path, content });
+});
+const copyFileSyncMock = vi.fn((src: string, dest: string) => {
+        copyFileCalls.push({ src, dest });
 });
 
 vi.mock('node:fs', () => ({
-	__esModule: true,
-	default: {
-		existsSync: existsSyncMock,
-		writeFileSync: writeFileSyncMock,
-	},
-	existsSync: existsSyncMock,
-	writeFileSync: writeFileSyncMock,
+        __esModule: true,
+        default: {
+                existsSync: existsSyncMock,
+                writeFileSync: writeFileSyncMock,
+                copyFileSync: copyFileSyncMock,
+        },
+        existsSync: existsSyncMock,
+        writeFileSync: writeFileSyncMock,
+        copyFileSync: copyFileSyncMock,
 }));
 
 vi.mock('../src/support/errors.js', () => ({
@@ -177,19 +183,21 @@ beforeEach(() => {
 	envFilePath = '/workdir/.env.prod';
 	localEnvVars = {};
 	snapshots = {};
-	remoteBundle = { chain: ['prod'], secrets: [] };
-	decryptedSecrets = [];
-	uploadPayloads.splice(0, uploadPayloads.length);
-	writeFileCalls.splice(0, writeFileCalls.length);
-	logOutputs.info.length = 0;
-	logOutputs.warn.length = 0;
-	logOutputs.error.length = 0;
-	logOutputs.ok.length = 0;
-	client.pull.mockClear();
-	client.uploadSecret.mockClear();
-	existsSyncMock.mockClear();
-	existsSyncMock.mockReturnValue(true);
-	writeFileSyncMock.mockClear();
+        remoteBundle = { chain: ['prod'], secrets: [] };
+        decryptedSecrets = [];
+        uploadPayloads.splice(0, uploadPayloads.length);
+        writeFileCalls.splice(0, writeFileCalls.length);
+        copyFileCalls.splice(0, copyFileCalls.length);
+        logOutputs.info.length = 0;
+        logOutputs.warn.length = 0;
+        logOutputs.error.length = 0;
+        logOutputs.ok.length = 0;
+        client.pull.mockClear();
+        client.uploadSecret.mockClear();
+        existsSyncMock.mockClear();
+        existsSyncMock.mockReturnValue(true);
+        writeFileSyncMock.mockClear();
+        copyFileSyncMock.mockClear();
 });
 
 describe('env:diff ignore behaviour', () => {
@@ -320,10 +328,10 @@ describe('env:push ignore behaviour', () => {
 });
 
 describe('env:pull ignore behaviour', () => {
-	it('omits ignored keys from written file and reports them', async () => {
-		remoteBundle = {
-			chain: ['prod'],
-			secrets: [
+        it('omits ignored keys from written file and reports them', async () => {
+                remoteBundle = {
+                        chain: ['prod'],
+                        secrets: [
 				{
 					env: 'prod',
 					name: 'FOO',
@@ -382,8 +390,158 @@ describe('env:pull ignore behaviour', () => {
 		expect(content).not.toContain('GHOSTABLE_CI_TOKEN');
 		expect(content).not.toContain('GHOSTABLE_MASTER_SEED');
 		expect(content).not.toContain('CUSTOM_TOKEN');
-		expect(logOutputs.info).toContain(
-			'Ignored keys (3): GHOSTABLE_CI_TOKEN, GHOSTABLE_MASTER_SEED, CUSTOM_TOKEN',
-		);
-	});
+                expect(logOutputs.info).toContain(
+                        'Ignored keys (3): GHOSTABLE_CI_TOKEN, GHOSTABLE_MASTER_SEED, CUSTOM_TOKEN',
+                );
+        });
+});
+
+describe('env:pull file management', () => {
+        it('merges remote keys into existing file and creates a backup', async () => {
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-01-02T03:04:05.678Z'));
+
+                try {
+                        localEnvVars = {
+                                KEEP: 'keep-value',
+                                UPDATE_ME: 'old',
+                        };
+                        snapshots = {
+                                KEEP: { rawValue: 'keep-value' },
+                                UPDATE_ME: { rawValue: 'old' },
+                        };
+                        remoteBundle = {
+                                chain: ['prod'],
+                                secrets: [
+                                        {
+                                                env: 'prod',
+                                                name: 'UPDATE_ME',
+                                                ciphertext: 'new',
+                                                nonce: 'nonce',
+                                                alg: 'xchacha20',
+                                                aad: {},
+                                                meta: {},
+                                        },
+                                        {
+                                                env: 'prod',
+                                                name: 'NEW_KEY',
+                                                ciphertext: 'added',
+                                                nonce: 'nonce',
+                                                alg: 'xchacha20',
+                                                aad: {},
+                                                meta: {},
+                                        },
+                                ],
+                        };
+
+                        const program = new Command();
+                        registerEnvPullCommand(program);
+                        await program.parseAsync([
+                                'node',
+                                'test',
+                                'env:pull',
+                                '--env',
+                                'prod',
+                                '--token',
+                                'api-token',
+                        ]);
+
+                        expect(copyFileCalls).toHaveLength(1);
+                        expect(copyFileCalls[0]).toEqual({
+                                src: envFilePath,
+                                dest: '/workdir/.env.prod.bak-2024-01-02T03-04-05.678Z',
+                        });
+                        expect(existsSyncMock).toHaveBeenCalledWith(envFilePath);
+
+                        expect(writeFileCalls).toHaveLength(1);
+                        const [{ content }] = writeFileCalls;
+                        expect(content).toContain('KEEP=keep-value');
+                        expect(content).toContain('NEW_KEY=added');
+                        expect(content).toContain('UPDATE_ME=new');
+
+                        expect(logOutputs.info).toContain('CREATE 1 | UPDATE 1');
+                        expect(logOutputs.ok[0]).toContain('Updated /workdir/.env.prod');
+                } finally {
+                        vi.useRealTimers();
+                }
+        });
+
+        it('honours --replace and reports deletions', async () => {
+                localEnvVars = {
+                        KEEP: 'keep-value',
+                        REMOVE_ME: 'bye',
+                };
+                snapshots = {
+                        KEEP: { rawValue: 'keep-value' },
+                        REMOVE_ME: { rawValue: 'bye' },
+                };
+                remoteBundle = {
+                        chain: ['prod'],
+                        secrets: [
+                                {
+                                        env: 'prod',
+                                        name: 'KEEP',
+                                        ciphertext: 'keep-value',
+                                        nonce: 'nonce',
+                                        alg: 'xchacha20',
+                                        aad: {},
+                                        meta: {},
+                                },
+                        ],
+                };
+
+                const program = new Command();
+                registerEnvPullCommand(program);
+                await program.parseAsync([
+                        'node',
+                        'test',
+                        'env:pull',
+                        '--env',
+                        'prod',
+                        '--token',
+                        'api-token',
+                        '--replace',
+                ]);
+
+                expect(writeFileCalls).toHaveLength(1);
+                const [{ content }] = writeFileCalls;
+                expect(content).toContain('KEEP=keep-value');
+                expect(content).not.toContain('REMOVE_ME');
+                expect(logOutputs.info).toContain('CREATE 0 | UPDATE 0 | DELETE 1');
+        });
+
+        it('skips backups when --no-backup is provided', async () => {
+                localEnvVars = { EXISTING: 'one' };
+                snapshots = { EXISTING: { rawValue: 'one' } };
+                remoteBundle = {
+                        chain: ['prod'],
+                        secrets: [
+                                {
+                                        env: 'prod',
+                                        name: 'EXISTING',
+                                        ciphertext: 'two',
+                                        nonce: 'nonce',
+                                        alg: 'xchacha20',
+                                        aad: {},
+                                        meta: {},
+                                },
+                        ],
+                };
+
+                const program = new Command();
+                registerEnvPullCommand(program);
+                await program.parseAsync([
+                        'node',
+                        'test',
+                        'env:pull',
+                        '--env',
+                        'prod',
+                        '--token',
+                        'api-token',
+                        '--no-backup',
+                ]);
+
+                expect(copyFileCalls).toHaveLength(0);
+                expect(writeFileCalls).toHaveLength(1);
+        });
 });

--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -138,22 +138,22 @@ vi.mock('listr2', () => ({
 
 const existsSyncMock = vi.fn(() => true);
 const writeFileSyncMock = vi.fn((path: string, content: string) => {
-        writeFileCalls.push({ path, content });
+	writeFileCalls.push({ path, content });
 });
 const copyFileSyncMock = vi.fn((src: string, dest: string) => {
-        copyFileCalls.push({ src, dest });
+	copyFileCalls.push({ src, dest });
 });
 
 vi.mock('node:fs', () => ({
-        __esModule: true,
-        default: {
-                existsSync: existsSyncMock,
-                writeFileSync: writeFileSyncMock,
-                copyFileSync: copyFileSyncMock,
-        },
-        existsSync: existsSyncMock,
-        writeFileSync: writeFileSyncMock,
-        copyFileSync: copyFileSyncMock,
+	__esModule: true,
+	default: {
+		existsSync: existsSyncMock,
+		writeFileSync: writeFileSyncMock,
+		copyFileSync: copyFileSyncMock,
+	},
+	existsSync: existsSyncMock,
+	writeFileSync: writeFileSyncMock,
+	copyFileSync: copyFileSyncMock,
 }));
 
 vi.mock('../src/support/errors.js', () => ({
@@ -183,21 +183,21 @@ beforeEach(() => {
 	envFilePath = '/workdir/.env.prod';
 	localEnvVars = {};
 	snapshots = {};
-        remoteBundle = { chain: ['prod'], secrets: [] };
-        decryptedSecrets = [];
-        uploadPayloads.splice(0, uploadPayloads.length);
-        writeFileCalls.splice(0, writeFileCalls.length);
-        copyFileCalls.splice(0, copyFileCalls.length);
-        logOutputs.info.length = 0;
-        logOutputs.warn.length = 0;
-        logOutputs.error.length = 0;
-        logOutputs.ok.length = 0;
-        client.pull.mockClear();
-        client.uploadSecret.mockClear();
-        existsSyncMock.mockClear();
-        existsSyncMock.mockReturnValue(true);
-        writeFileSyncMock.mockClear();
-        copyFileSyncMock.mockClear();
+	remoteBundle = { chain: ['prod'], secrets: [] };
+	decryptedSecrets = [];
+	uploadPayloads.splice(0, uploadPayloads.length);
+	writeFileCalls.splice(0, writeFileCalls.length);
+	copyFileCalls.splice(0, copyFileCalls.length);
+	logOutputs.info.length = 0;
+	logOutputs.warn.length = 0;
+	logOutputs.error.length = 0;
+	logOutputs.ok.length = 0;
+	client.pull.mockClear();
+	client.uploadSecret.mockClear();
+	existsSyncMock.mockClear();
+	existsSyncMock.mockReturnValue(true);
+	writeFileSyncMock.mockClear();
+	copyFileSyncMock.mockClear();
 });
 
 describe('env:diff ignore behaviour', () => {
@@ -328,10 +328,10 @@ describe('env:push ignore behaviour', () => {
 });
 
 describe('env:pull ignore behaviour', () => {
-        it('omits ignored keys from written file and reports them', async () => {
-                remoteBundle = {
-                        chain: ['prod'],
-                        secrets: [
+	it('omits ignored keys from written file and reports them', async () => {
+		remoteBundle = {
+			chain: ['prod'],
+			secrets: [
 				{
 					env: 'prod',
 					name: 'FOO',
@@ -390,158 +390,158 @@ describe('env:pull ignore behaviour', () => {
 		expect(content).not.toContain('GHOSTABLE_CI_TOKEN');
 		expect(content).not.toContain('GHOSTABLE_MASTER_SEED');
 		expect(content).not.toContain('CUSTOM_TOKEN');
-                expect(logOutputs.info).toContain(
-                        'Ignored keys (3): GHOSTABLE_CI_TOKEN, GHOSTABLE_MASTER_SEED, CUSTOM_TOKEN',
-                );
-        });
+		expect(logOutputs.info).toContain(
+			'Ignored keys (3): GHOSTABLE_CI_TOKEN, GHOSTABLE_MASTER_SEED, CUSTOM_TOKEN',
+		);
+	});
 });
 
 describe('env:pull file management', () => {
-        it('merges remote keys into existing file and creates a backup', async () => {
-                vi.useFakeTimers();
-                vi.setSystemTime(new Date('2024-01-02T03:04:05.678Z'));
+	it('merges remote keys into existing file and creates a backup', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2024-01-02T03:04:05.678Z'));
 
-                try {
-                        localEnvVars = {
-                                KEEP: 'keep-value',
-                                UPDATE_ME: 'old',
-                        };
-                        snapshots = {
-                                KEEP: { rawValue: 'keep-value' },
-                                UPDATE_ME: { rawValue: 'old' },
-                        };
-                        remoteBundle = {
-                                chain: ['prod'],
-                                secrets: [
-                                        {
-                                                env: 'prod',
-                                                name: 'UPDATE_ME',
-                                                ciphertext: 'new',
-                                                nonce: 'nonce',
-                                                alg: 'xchacha20',
-                                                aad: {},
-                                                meta: {},
-                                        },
-                                        {
-                                                env: 'prod',
-                                                name: 'NEW_KEY',
-                                                ciphertext: 'added',
-                                                nonce: 'nonce',
-                                                alg: 'xchacha20',
-                                                aad: {},
-                                                meta: {},
-                                        },
-                                ],
-                        };
+		try {
+			localEnvVars = {
+				KEEP: 'keep-value',
+				UPDATE_ME: 'old',
+			};
+			snapshots = {
+				KEEP: { rawValue: 'keep-value' },
+				UPDATE_ME: { rawValue: 'old' },
+			};
+			remoteBundle = {
+				chain: ['prod'],
+				secrets: [
+					{
+						env: 'prod',
+						name: 'UPDATE_ME',
+						ciphertext: 'new',
+						nonce: 'nonce',
+						alg: 'xchacha20',
+						aad: {},
+						meta: {},
+					},
+					{
+						env: 'prod',
+						name: 'NEW_KEY',
+						ciphertext: 'added',
+						nonce: 'nonce',
+						alg: 'xchacha20',
+						aad: {},
+						meta: {},
+					},
+				],
+			};
 
-                        const program = new Command();
-                        registerEnvPullCommand(program);
-                        await program.parseAsync([
-                                'node',
-                                'test',
-                                'env:pull',
-                                '--env',
-                                'prod',
-                                '--token',
-                                'api-token',
-                        ]);
+			const program = new Command();
+			registerEnvPullCommand(program);
+			await program.parseAsync([
+				'node',
+				'test',
+				'env:pull',
+				'--env',
+				'prod',
+				'--token',
+				'api-token',
+			]);
 
-                        expect(copyFileCalls).toHaveLength(1);
-                        expect(copyFileCalls[0]).toEqual({
-                                src: envFilePath,
-                                dest: '/workdir/.env.prod.bak-2024-01-02T03-04-05.678Z',
-                        });
-                        expect(existsSyncMock).toHaveBeenCalledWith(envFilePath);
+			expect(copyFileCalls).toHaveLength(1);
+			expect(copyFileCalls[0]).toEqual({
+				src: envFilePath,
+				dest: '/workdir/.env.prod.bak-2024-01-02T03-04-05.678Z',
+			});
+			expect(existsSyncMock).toHaveBeenCalledWith(envFilePath);
 
-                        expect(writeFileCalls).toHaveLength(1);
-                        const [{ content }] = writeFileCalls;
-                        expect(content).toContain('KEEP=keep-value');
-                        expect(content).toContain('NEW_KEY=added');
-                        expect(content).toContain('UPDATE_ME=new');
+			expect(writeFileCalls).toHaveLength(1);
+			const [{ content }] = writeFileCalls;
+			expect(content).toContain('KEEP=keep-value');
+			expect(content).toContain('NEW_KEY=added');
+			expect(content).toContain('UPDATE_ME=new');
 
-                        expect(logOutputs.info).toContain('CREATE 1 | UPDATE 1');
-                        expect(logOutputs.ok[0]).toContain('Updated /workdir/.env.prod');
-                } finally {
-                        vi.useRealTimers();
-                }
-        });
+			expect(logOutputs.info).toContain('CREATE 1 | UPDATE 1');
+			expect(logOutputs.ok[0]).toContain('Updated /workdir/.env.prod');
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 
-        it('honours --replace and reports deletions', async () => {
-                localEnvVars = {
-                        KEEP: 'keep-value',
-                        REMOVE_ME: 'bye',
-                };
-                snapshots = {
-                        KEEP: { rawValue: 'keep-value' },
-                        REMOVE_ME: { rawValue: 'bye' },
-                };
-                remoteBundle = {
-                        chain: ['prod'],
-                        secrets: [
-                                {
-                                        env: 'prod',
-                                        name: 'KEEP',
-                                        ciphertext: 'keep-value',
-                                        nonce: 'nonce',
-                                        alg: 'xchacha20',
-                                        aad: {},
-                                        meta: {},
-                                },
-                        ],
-                };
+	it('honours --replace and reports deletions', async () => {
+		localEnvVars = {
+			KEEP: 'keep-value',
+			REMOVE_ME: 'bye',
+		};
+		snapshots = {
+			KEEP: { rawValue: 'keep-value' },
+			REMOVE_ME: { rawValue: 'bye' },
+		};
+		remoteBundle = {
+			chain: ['prod'],
+			secrets: [
+				{
+					env: 'prod',
+					name: 'KEEP',
+					ciphertext: 'keep-value',
+					nonce: 'nonce',
+					alg: 'xchacha20',
+					aad: {},
+					meta: {},
+				},
+			],
+		};
 
-                const program = new Command();
-                registerEnvPullCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:pull',
-                        '--env',
-                        'prod',
-                        '--token',
-                        'api-token',
-                        '--replace',
-                ]);
+		const program = new Command();
+		registerEnvPullCommand(program);
+		await program.parseAsync([
+			'node',
+			'test',
+			'env:pull',
+			'--env',
+			'prod',
+			'--token',
+			'api-token',
+			'--replace',
+		]);
 
-                expect(writeFileCalls).toHaveLength(1);
-                const [{ content }] = writeFileCalls;
-                expect(content).toContain('KEEP=keep-value');
-                expect(content).not.toContain('REMOVE_ME');
-                expect(logOutputs.info).toContain('CREATE 0 | UPDATE 0 | DELETE 1');
-        });
+		expect(writeFileCalls).toHaveLength(1);
+		const [{ content }] = writeFileCalls;
+		expect(content).toContain('KEEP=keep-value');
+		expect(content).not.toContain('REMOVE_ME');
+		expect(logOutputs.info).toContain('CREATE 0 | UPDATE 0 | DELETE 1');
+	});
 
-        it('skips backups when --no-backup is provided', async () => {
-                localEnvVars = { EXISTING: 'one' };
-                snapshots = { EXISTING: { rawValue: 'one' } };
-                remoteBundle = {
-                        chain: ['prod'],
-                        secrets: [
-                                {
-                                        env: 'prod',
-                                        name: 'EXISTING',
-                                        ciphertext: 'two',
-                                        nonce: 'nonce',
-                                        alg: 'xchacha20',
-                                        aad: {},
-                                        meta: {},
-                                },
-                        ],
-                };
+	it('skips backups when --no-backup is provided', async () => {
+		localEnvVars = { EXISTING: 'one' };
+		snapshots = { EXISTING: { rawValue: 'one' } };
+		remoteBundle = {
+			chain: ['prod'],
+			secrets: [
+				{
+					env: 'prod',
+					name: 'EXISTING',
+					ciphertext: 'two',
+					nonce: 'nonce',
+					alg: 'xchacha20',
+					aad: {},
+					meta: {},
+				},
+			],
+		};
 
-                const program = new Command();
-                registerEnvPullCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:pull',
-                        '--env',
-                        'prod',
-                        '--token',
-                        'api-token',
-                        '--no-backup',
-                ]);
+		const program = new Command();
+		registerEnvPullCommand(program);
+		await program.parseAsync([
+			'node',
+			'test',
+			'env:pull',
+			'--env',
+			'prod',
+			'--token',
+			'api-token',
+			'--no-backup',
+		]);
 
-                expect(copyFileCalls).toHaveLength(0);
-                expect(writeFileCalls).toHaveLength(1);
-        });
+		expect(copyFileCalls).toHaveLength(0);
+		expect(writeFileCalls).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## Summary
- merge env:pull output with existing .env content by default and add replace/no-backup options
- create timestamped backups before writing and log per-operation summaries
- extend env:pull tests to cover merging, replacements, and backup behaviour

## Testing
- npx vitest run env-ignore

------
https://chatgpt.com/codex/tasks/task_e_68f12619c6648333b76e4bf66a823b65