### PR TITLE
Add sync mode to env:push command

### DIFF
--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -25,14 +25,14 @@ import { buildSecretPayload } from '../support/secret-payload.js';
 import type { ValidatorRecord } from '@/types';
 
 type PushOptions = {
-        api?: string;
-        token?: string;
-        file?: string; // optional override; else .env.<env> or .env
-        env?: string; // optional; prompt if missing
-        assumeYes?: boolean;
-        sync?: boolean;
-        replace?: boolean;
-        pruneServer?: boolean;
+	api?: string;
+	token?: string;
+	file?: string; // optional override; else .env.<env> or .env
+	env?: string; // optional; prompt if missing
+	assumeYes?: boolean;
+	sync?: boolean;
+	replace?: boolean;
+	pruneServer?: boolean;
 };
 
 function resolvePlaintext(parsed: string, snapshot?: EnvVarSnapshot): string {
@@ -52,13 +52,13 @@ export function registerEnvPushCommand(program: Command) {
 	program
 		.command('env:push')
 		.description('Encrypt and push a local .env file to Ghostable (uses ghostable.yml)')
-                .option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
-                .option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
-                .option('-y, --assume-yes', 'Skip confirmation prompts', false)
-                .option('--sync', 'Prune server variables not present locally', false)
-                .option('--replace', 'Alias for --sync', false)
-                .option('--prune-server', 'Alias for --sync', false)
-                .action(async (opts: PushOptions) => {
+		.option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
+		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
+		.option('-y, --assume-yes', 'Skip confirmation prompts', false)
+		.option('--sync', 'Prune server variables not present locally', false)
+		.option('--replace', 'Alias for --sync', false)
+		.option('--prune-server', 'Alias for --sync', false)
+		.action(async (opts: PushOptions) => {
 			// 1) Load manifest
 			let projectId: string, projectName: string, manifestEnvs: string[];
 			try {
@@ -105,13 +105,13 @@ export function registerEnvPushCommand(program: Command) {
 			const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
 			const ignored = getIgnoredKeys(envName);
 			const filteredVars = filterIgnoredKeys(envMap, ignored);
-                        const sync = Boolean(opts.sync || opts.replace || opts.pruneServer);
+			const sync = Boolean(opts.sync || opts.replace || opts.pruneServer);
 
-                        const entries = Object.entries(filteredVars).map(([name, parsedValue]) => ({
-                                name,
-                                parsedValue,
-                                plaintext: resolvePlaintext(parsedValue, snapshots[name]),
-                        }));
+			const entries = Object.entries(filteredVars).map(([name, parsedValue]) => ({
+				name,
+				parsedValue,
+				plaintext: resolvePlaintext(parsedValue, snapshots[name]),
+			}));
 			if (!entries.length) {
 				log.warn('⚠️  No variables found in the .env file.');
 				return;
@@ -161,12 +161,12 @@ export function registerEnvPushCommand(program: Command) {
 							// ifVersion?: number  // add later for optimistic concurrency
 						});
 
-                                                await client.uploadSecret(
-                                                        projectId,
-                                                        envName,
-                                                        payload,
-                                                        sync ? { sync: true } : undefined,
-                                                );
+						await client.uploadSecret(
+							projectId,
+							envName,
+							payload,
+							sync ? { sync: true } : undefined,
+						);
 						task.title = `${name}  ${chalk.green('✓')}`;
 					},
 				})),

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -103,15 +103,17 @@ export class GhostableClient {
 		return Environment.fromJSON(res);
 	}
 
-	async uploadSecret(
-		projectId: string,
-		envName: string,
-		payload: SignedEnvironmentSecretUploadRequest,
-	): Promise<{ id?: string; version?: number }> {
-		const p = encodeURIComponent(projectId);
-		const e = encodeURIComponent(envName);
-		return this.http.post(`/projects/${p}/environments/${e}/secrets`, payload);
-	}
+        async uploadSecret(
+                projectId: string,
+                envName: string,
+                payload: SignedEnvironmentSecretUploadRequest,
+                opts?: { sync?: boolean },
+        ): Promise<{ id?: string; version?: number }> {
+                const p = encodeURIComponent(projectId);
+                const e = encodeURIComponent(envName);
+                const suffix = opts?.sync ? '?sync=1' : '';
+                return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
+        }
 
 	async pull(
 		projectId: string,

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -103,17 +103,17 @@ export class GhostableClient {
 		return Environment.fromJSON(res);
 	}
 
-        async uploadSecret(
-                projectId: string,
-                envName: string,
-                payload: SignedEnvironmentSecretUploadRequest,
-                opts?: { sync?: boolean },
-        ): Promise<{ id?: string; version?: number }> {
-                const p = encodeURIComponent(projectId);
-                const e = encodeURIComponent(envName);
-                const suffix = opts?.sync ? '?sync=1' : '';
-                return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
-        }
+	async uploadSecret(
+		projectId: string,
+		envName: string,
+		payload: SignedEnvironmentSecretUploadRequest,
+		opts?: { sync?: boolean },
+	): Promise<{ id?: string; version?: number }> {
+		const p = encodeURIComponent(projectId);
+		const e = encodeURIComponent(envName);
+		const suffix = opts?.sync ? '?sync=1' : '';
+		return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
+	}
 
 	async pull(
 		projectId: string,

--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -16,8 +16,8 @@ let localEnvVars: Record<string, string> = {};
 let snapshots: Record<string, { rawValue: string }> = {};
 let remoteBundle: any = { chain: ['prod'], secrets: [] };
 let decryptedSecrets: Array<{
-        entry: { name: string; meta?: { is_commented?: boolean } };
-        value: string;
+	entry: { name: string; meta?: { is_commented?: boolean } };
+	value: string;
 }> = [];
 const uploadPayloads: any[] = [];
 const uploadOptions: Array<{ sync?: boolean }> = [];
@@ -55,18 +55,13 @@ vi.mock('../src/services/SessionService.js', () => ({
 }));
 
 const client = {
-        pull: vi.fn(async () => remoteBundle),
-        uploadSecret: vi.fn(
-                async (
-                        _projectId: string,
-                        _env: string,
-                        payload: any,
-                        options?: { sync?: boolean },
-                ) => {
-                        uploadPayloads.push(payload);
-                        uploadOptions.push(options ?? {});
-                },
-        ),
+	pull: vi.fn(async () => remoteBundle),
+	uploadSecret: vi.fn(
+		async (_projectId: string, _env: string, payload: any, options?: { sync?: boolean }) => {
+			uploadPayloads.push(payload);
+			uploadOptions.push(options ?? {});
+		},
+	),
 };
 
 vi.mock('../src/services/GhostableClient.js', () => ({
@@ -194,8 +189,8 @@ beforeEach(() => {
 	snapshots = {};
 	remoteBundle = { chain: ['prod'], secrets: [] };
 	decryptedSecrets = [];
-        uploadPayloads.splice(0, uploadPayloads.length);
-        uploadOptions.splice(0, uploadOptions.length);
+	uploadPayloads.splice(0, uploadPayloads.length);
+	uploadOptions.splice(0, uploadOptions.length);
 	writeFileCalls.splice(0, writeFileCalls.length);
 	copyFileCalls.splice(0, copyFileCalls.length);
 	logOutputs.info.length = 0;
@@ -316,11 +311,11 @@ describe('env:diff ignore behaviour', () => {
 });
 
 describe('env:push ignore behaviour', () => {
-        it('skips ignored keys when uploading', async () => {
-                localEnvVars = {
-                        FOO: 'value',
-                        GHOSTABLE_MASTER_SEED: 'true',
-                        CUSTOM_TOKEN: 'custom',
+	it('skips ignored keys when uploading', async () => {
+		localEnvVars = {
+			FOO: 'value',
+			GHOSTABLE_MASTER_SEED: 'true',
+			CUSTOM_TOKEN: 'custom',
 		};
 		snapshots = {
 			FOO: { rawValue: 'value' },
@@ -332,34 +327,34 @@ describe('env:push ignore behaviour', () => {
 		registerEnvPushCommand(program);
 		await program.parseAsync(['node', 'test', 'env:push', '--env', 'prod', '--assume-yes']);
 
-                const uploadedNames = uploadPayloads.map((payload) => payload.name);
-                expect(uploadedNames).toEqual(['FOO']);
-                expect(uploadOptions).toEqual([{}]);
-        });
+		const uploadedNames = uploadPayloads.map((payload) => payload.name);
+		expect(uploadedNames).toEqual(['FOO']);
+		expect(uploadOptions).toEqual([{}]);
+	});
 
-        it('passes sync flag to upload when requested', async () => {
-                localEnvVars = {
-                        FOO: 'value',
-                };
-                snapshots = {
-                        FOO: { rawValue: 'value' },
-                };
+	it('passes sync flag to upload when requested', async () => {
+		localEnvVars = {
+			FOO: 'value',
+		};
+		snapshots = {
+			FOO: { rawValue: 'value' },
+		};
 
-                const program = new Command();
-                registerEnvPushCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:push',
-                        '--env',
-                        'prod',
-                        '--assume-yes',
-                        '--sync',
-                ]);
+		const program = new Command();
+		registerEnvPushCommand(program);
+		await program.parseAsync([
+			'node',
+			'test',
+			'env:push',
+			'--env',
+			'prod',
+			'--assume-yes',
+			'--sync',
+		]);
 
-                expect(uploadPayloads).toHaveLength(1);
-                expect(uploadOptions).toEqual([{ sync: true }]);
-        });
+		expect(uploadPayloads).toHaveLength(1);
+		expect(uploadOptions).toEqual([{ sync: true }]);
+	});
 });
 
 describe('env:pull ignore behaviour', () => {


### PR DESCRIPTION
## Summary
- add `--sync`/`--replace`/`--prune-server` flags to `env:push` to request pruning server-only variables
- send the sync hint to the Ghostable API when uploading secrets
- extend env push tests to cover the new flag behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f12f260e188333996a09cccee488fc