### PR TITLE
Add env:sync command for replace pushes

### DIFF
--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -57,133 +57,133 @@ export function registerEnvPushCommand(program: Command) {
 		.option('-y, --assume-yes', 'Skip confirmation prompts', false)
 		.option('--sync', 'Prune server variables not present locally', false)
 		.option('--replace', 'Alias for --sync', false)
-                .option('--prune-server', 'Alias for --sync', false)
-                .action(async (opts: PushOptions) => runEnvPush(opts));
+		.option('--prune-server', 'Alias for --sync', false)
+		.action(async (opts: PushOptions) => runEnvPush(opts));
 }
 
 export async function runEnvPush(opts: PushOptions): Promise<void> {
-        // 1) Load manifest
-        let projectId: string, projectName: string, manifestEnvs: string[];
-        try {
-                projectId = Manifest.id();
-                projectName = Manifest.name();
-                manifestEnvs = Manifest.environmentNames();
-        } catch (error) {
-                log.error(toErrorMessage(error));
-                process.exit(1);
-                return;
-        }
-        if (!manifestEnvs.length) {
-                log.error('❌ No environments defined in ghostable.yml.');
-                process.exit(1);
-        }
+	// 1) Load manifest
+	let projectId: string, projectName: string, manifestEnvs: string[];
+	try {
+		projectId = Manifest.id();
+		projectName = Manifest.name();
+		manifestEnvs = Manifest.environmentNames();
+	} catch (error) {
+		log.error(toErrorMessage(error));
+		process.exit(1);
+		return;
+	}
+	if (!manifestEnvs.length) {
+		log.error('❌ No environments defined in ghostable.yml.');
+		process.exit(1);
+	}
 
-        // 2) Pick env (flag → prompt)
-        let envName = opts.env;
-        if (!envName) {
-                envName = await select({
-                        message: 'Which environment would you like to push?',
-                        choices: manifestEnvs.sort().map((n) => ({ name: n, value: n })),
-                });
-        }
+	// 2) Pick env (flag → prompt)
+	let envName = opts.env;
+	if (!envName) {
+		envName = await select({
+			message: 'Which environment would you like to push?',
+			choices: manifestEnvs.sort().map((n) => ({ name: n, value: n })),
+		});
+	}
 
-        // 3) Resolve token, and org from session if needed
-        const sessionSvc = new SessionService();
-        const sess = await sessionSvc.load();
-        if (!sess?.accessToken) {
-                log.error('❌ No API token. Run `ghostable login`.');
-                process.exit(1);
-        }
-        let token = sess.accessToken;
-        let orgId = sess.organizationId;
+	// 3) Resolve token, and org from session if needed
+	const sessionSvc = new SessionService();
+	const sess = await sessionSvc.load();
+	if (!sess?.accessToken) {
+		log.error('❌ No API token. Run `ghostable login`.');
+		process.exit(1);
+	}
+	let token = sess.accessToken;
+	let orgId = sess.organizationId;
 
-        // 4) Resolve .env file path
-        const filePath = resolveEnvFile(envName!, opts.file, true);
-        if (!fs.existsSync(filePath)) {
-                log.error(`❌ .env file not found at ${filePath}`);
-                process.exit(1);
-        }
+	// 4) Resolve .env file path
+	const filePath = resolveEnvFile(envName!, opts.file, true);
+	if (!fs.existsSync(filePath)) {
+		log.error(`❌ .env file not found at ${filePath}`);
+		process.exit(1);
+	}
 
-        // 5) Read variables
-        const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
-        const ignored = getIgnoredKeys(envName);
-        const filteredVars = filterIgnoredKeys(envMap, ignored);
-        const sync = Boolean(opts.sync || opts.replace || opts.pruneServer);
+	// 5) Read variables
+	const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
+	const ignored = getIgnoredKeys(envName);
+	const filteredVars = filterIgnoredKeys(envMap, ignored);
+	const sync = Boolean(opts.sync || opts.replace || opts.pruneServer);
 
-        const entries = Object.entries(filteredVars).map(([name, parsedValue]) => ({
-                name,
-                parsedValue,
-                plaintext: resolvePlaintext(parsedValue, snapshots[name]),
-        }));
-        if (!entries.length) {
-                log.warn('⚠️  No variables found in the .env file.');
-                return;
-        }
+	const entries = Object.entries(filteredVars).map(([name, parsedValue]) => ({
+		name,
+		parsedValue,
+		plaintext: resolvePlaintext(parsedValue, snapshots[name]),
+	}));
+	if (!entries.length) {
+		log.warn('⚠️  No variables found in the .env file.');
+		return;
+	}
 
-        if (!opts.assumeYes) {
-                log.info(
-                        `About to push ${entries.length} variables from ${chalk.bold(filePath)}\n` +
-                                `→ project ${chalk.bold(projectName)} (${projectId})\n` +
-                                (orgId ? `→ org ${chalk.bold(orgId)}\n` : ''),
-                );
-        }
+	if (!opts.assumeYes) {
+		log.info(
+			`About to push ${entries.length} variables from ${chalk.bold(filePath)}\n` +
+				`→ project ${chalk.bold(projectName)} (${projectId})\n` +
+				(orgId ? `→ org ${chalk.bold(orgId)}\n` : ''),
+		);
+	}
 
-        // 6) Prep crypto + client
-        await initSodium(); // no-op with stablelib
-        const keyBundle = await loadOrCreateKeys();
-        const masterSeed = Buffer.from(keyBundle.masterSeedB64.replace(/^b64:/, ''), 'base64');
-        const edPriv = Buffer.from(keyBundle.ed25519PrivB64.replace(/^b64:/, ''), 'base64');
+	// 6) Prep crypto + client
+	await initSodium(); // no-op with stablelib
+	const keyBundle = await loadOrCreateKeys();
+	const masterSeed = Buffer.from(keyBundle.masterSeedB64.replace(/^b64:/, ''), 'base64');
+	const edPriv = Buffer.from(keyBundle.ed25519PrivB64.replace(/^b64:/, ''), 'base64');
 
-        const client = GhostableClient.unauthenticated(config.apiBase).withToken(token);
+	const client = GhostableClient.unauthenticated(config.apiBase).withToken(token);
 
-        // 7) Encrypt + push per variable
-        const tasks = new Listr(
-                entries.map(({ name, parsedValue, plaintext }) => ({
-                        title: `${name}`,
-                        task: async (_ctx, task) => {
-                                const validators: ValidatorRecord = {
-                                        non_empty: parsedValue.length > 0,
-                                };
-                                if (name === 'APP_KEY') {
-                                        validators.regex = {
-                                                id: 'base64_44char_v1',
-                                                ok: /^base64:/.test(parsedValue) && parsedValue.length >= 44,
-                                        };
-                                        validators.length = parsedValue.length;
-                                }
+	// 7) Encrypt + push per variable
+	const tasks = new Listr(
+		entries.map(({ name, parsedValue, plaintext }) => ({
+			title: `${name}`,
+			task: async (_ctx, task) => {
+				const validators: ValidatorRecord = {
+					non_empty: parsedValue.length > 0,
+				};
+				if (name === 'APP_KEY') {
+					validators.regex = {
+						id: 'base64_44char_v1',
+						ok: /^base64:/.test(parsedValue) && parsedValue.length >= 44,
+					};
+					validators.length = parsedValue.length;
+				}
 
-                                const payload = await buildSecretPayload({
-                                        name,
-                                        env: envName!, // from manifest selection
-                                        org: orgId ?? '', // server can infer if token is org-scoped
-                                        project: projectId, // from manifest
-                                        plaintext,
-                                        masterSeed,
-                                        edPriv,
-                                        validators,
-                                        // ifVersion?: number  // add later for optimistic concurrency
-                                });
+				const payload = await buildSecretPayload({
+					name,
+					env: envName!, // from manifest selection
+					org: orgId ?? '', // server can infer if token is org-scoped
+					project: projectId, // from manifest
+					plaintext,
+					masterSeed,
+					edPriv,
+					validators,
+					// ifVersion?: number  // add later for optimistic concurrency
+				});
 
-                                await client.uploadSecret(
-                                        projectId,
-                                        envName,
-                                        payload,
-                                        sync ? { sync: true } : undefined,
-                                );
-                                task.title = `${name}  ${chalk.green('✓')}`;
-                        },
-                })),
-                { concurrent: false, exitOnError: true },
-        );
+				await client.uploadSecret(
+					projectId,
+					envName,
+					payload,
+					sync ? { sync: true } : undefined,
+				);
+				task.title = `${name}  ${chalk.green('✓')}`;
+			},
+		})),
+		{ concurrent: false, exitOnError: true },
+	);
 
-        try {
-                await tasks.run();
-                log.ok(
-                        `\n✅ Pushed ${entries.length} variables to ${projectId}:${envName} (encrypted locally).`,
-                );
-        } catch (error) {
-                log.error(error);
-                log.error(`\n❌ env:push failed: ${toErrorMessage(error)}`);
-                process.exit(1);
-        }
+	try {
+		await tasks.run();
+		log.ok(
+			`\n✅ Pushed ${entries.length} variables to ${projectId}:${envName} (encrypted locally).`,
+		);
+	} catch (error) {
+		log.error(error);
+		log.error(`\n❌ env:push failed: ${toErrorMessage(error)}`);
+		process.exit(1);
+	}
 }

--- a/src/commands/env-sync.ts
+++ b/src/commands/env-sync.ts
@@ -3,15 +3,15 @@ import { Command } from 'commander';
 import { runEnvPush, type PushOptions } from './env-push.js';
 
 export function registerEnvSyncCommand(program: Command) {
-        program
-                .command('env:sync')
-                .description(
-                        'Encrypt and push a local .env file to Ghostable, pruning remote variables not present locally.',
-                )
-                .option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
-                .option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
-                .option('-y, --assume-yes', 'Skip confirmation prompts', false)
-                .action(async (opts: PushOptions) => {
-                        await runEnvPush({ ...opts, replace: true });
-                });
+	program
+		.command('env:sync')
+		.description(
+			'Encrypt and push a local .env file to Ghostable, pruning remote variables not present locally.',
+		)
+		.option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
+		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
+		.option('-y, --assume-yes', 'Skip confirmation prompts', false)
+		.action(async (opts: PushOptions) => {
+			await runEnvPush({ ...opts, replace: true });
+		});
 }

--- a/src/commands/env-sync.ts
+++ b/src/commands/env-sync.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+
+import { runEnvPush, type PushOptions } from './env-push.js';
+
+export function registerEnvSyncCommand(program: Command) {
+        program
+                .command('env:sync')
+                .description(
+                        'Encrypt and push a local .env file to Ghostable, pruning remote variables not present locally.',
+                )
+                .option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
+                .option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
+                .option('-y, --assume-yes', 'Skip confirmation prompts', false)
+                .action(async (opts: PushOptions) => {
+                        await runEnvPush({ ...opts, replace: true });
+                });
+}

--- a/test/env-sync.test.ts
+++ b/test/env-sync.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+
+const runEnvPushMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/commands/env-push.js', () => ({
+        runEnvPush: runEnvPushMock,
+}));
+
+describe('env:sync command', () => {
+        beforeEach(() => {
+                runEnvPushMock.mockReset();
+                runEnvPushMock.mockResolvedValue(undefined);
+        });
+
+        it('forces replace flag when delegating to env:push', async () => {
+                const program = new Command();
+                program.exitOverride();
+
+                const { registerEnvSyncCommand } = await import('../src/commands/env-sync.js');
+                registerEnvSyncCommand(program);
+
+                await program.parseAsync(['env:sync', '--env', 'prod'], { from: 'user' });
+
+                expect(runEnvPushMock).toHaveBeenCalledTimes(1);
+                expect(runEnvPushMock).toHaveBeenCalledWith(
+                        expect.objectContaining({ env: 'prod', replace: true }),
+                );
+        });
+});

--- a/test/env-sync.test.ts
+++ b/test/env-sync.test.ts
@@ -4,27 +4,27 @@ import { Command } from 'commander';
 const runEnvPushMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/commands/env-push.js', () => ({
-        runEnvPush: runEnvPushMock,
+	runEnvPush: runEnvPushMock,
 }));
 
 describe('env:sync command', () => {
-        beforeEach(() => {
-                runEnvPushMock.mockReset();
-                runEnvPushMock.mockResolvedValue(undefined);
-        });
+	beforeEach(() => {
+		runEnvPushMock.mockReset();
+		runEnvPushMock.mockResolvedValue(undefined);
+	});
 
-        it('forces replace flag when delegating to env:push', async () => {
-                const program = new Command();
-                program.exitOverride();
+	it('forces replace flag when delegating to env:push', async () => {
+		const program = new Command();
+		program.exitOverride();
 
-                const { registerEnvSyncCommand } = await import('../src/commands/env-sync.js');
-                registerEnvSyncCommand(program);
+		const { registerEnvSyncCommand } = await import('../src/commands/env-sync.js');
+		registerEnvSyncCommand(program);
 
-                await program.parseAsync(['env:sync', '--env', 'prod'], { from: 'user' });
+		await program.parseAsync(['env:sync', '--env', 'prod'], { from: 'user' });
 
-                expect(runEnvPushMock).toHaveBeenCalledTimes(1);
-                expect(runEnvPushMock).toHaveBeenCalledWith(
-                        expect.objectContaining({ env: 'prod', replace: true }),
-                );
-        });
+		expect(runEnvPushMock).toHaveBeenCalledTimes(1);
+		expect(runEnvPushMock).toHaveBeenCalledWith(
+			expect.objectContaining({ env: 'prod', replace: true }),
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- add an env:sync wrapper that calls env:push with --replace enabled to prune remote secrets
- export the shared env push handler so both commands share the same implementation
- cover the new command with a unit test that verifies the replace flag is always forwarded

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f1330a4a1c8333a04434d619447a1f