### PR TITLE
Add environment keys endpoint to Ghostable client

### DIFF
--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -10,14 +10,17 @@ import {
 } from '@/domain';
 
 import type {
-	EnvironmentJson,
-	EnvironmentSecretBundleJson,
-	EnvironmentSuggestedNameJson,
-	EnvironmentTypeJson,
-	OrganizationJson,
-	ProjectJson,
-	SignedEnvironmentSecretUploadRequest,
+        EnvironmentJson,
+        EnvironmentKeysResponse,
+        EnvironmentKeysResponseJson,
+        EnvironmentSecretBundleJson,
+        EnvironmentSuggestedNameJson,
+        EnvironmentTypeJson,
+        OrganizationJson,
+        ProjectJson,
+        SignedEnvironmentSecretUploadRequest,
 } from '@/types';
+import { environmentKeysFromJSON } from '@/types';
 
 type LoginResponse = { token?: string; two_factor?: boolean };
 type ListResp<T> = { data?: T[] };
@@ -115,11 +118,11 @@ export class GhostableClient {
 		return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
 	}
 
-	async pull(
-		projectId: string,
-		envName: string,
-		opts?: {
-			only?: string[];
+        async pull(
+                projectId: string,
+                envName: string,
+                opts?: {
+                        only?: string[];
 			includeMeta?: boolean;
 			includeVersions?: boolean;
 		},
@@ -138,14 +141,28 @@ export class GhostableClient {
 			`/projects/${p}/environments/${e}/pull${suffix}`,
 		);
 
-		return EnvironmentSecretBundle.fromJSON(json);
-	}
+                return EnvironmentSecretBundle.fromJSON(json);
+        }
 
-	async deploy(opts?: {
-		only?: string[];
-		includeMeta?: boolean;
-		includeVersions?: boolean;
-	}): Promise<EnvironmentSecretBundle> {
+        async getEnvironmentKeys(
+                projectId: string,
+                envName: string,
+        ): Promise<EnvironmentKeysResponse> {
+                const p = encodeURIComponent(projectId);
+                const e = encodeURIComponent(envName);
+
+                const json = await this.http.get<EnvironmentKeysResponseJson>(
+                        `/projects/${p}/environments/${e}/keys`,
+                );
+
+                return environmentKeysFromJSON(json);
+        }
+
+        async deploy(opts?: {
+                only?: string[];
+                includeMeta?: boolean;
+                includeVersions?: boolean;
+        }): Promise<EnvironmentSecretBundle> {
 		const qs = new URLSearchParams();
 		if (opts?.includeMeta) qs.set('include_meta', '1');
 		if (opts?.includeVersions) qs.set('include_versions', '1');

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -10,15 +10,15 @@ import {
 } from '@/domain';
 
 import type {
-        EnvironmentJson,
-        EnvironmentKeysResponse,
-        EnvironmentKeysResponseJson,
-        EnvironmentSecretBundleJson,
-        EnvironmentSuggestedNameJson,
-        EnvironmentTypeJson,
-        OrganizationJson,
-        ProjectJson,
-        SignedEnvironmentSecretUploadRequest,
+	EnvironmentJson,
+	EnvironmentKeysResponse,
+	EnvironmentKeysResponseJson,
+	EnvironmentSecretBundleJson,
+	EnvironmentSuggestedNameJson,
+	EnvironmentTypeJson,
+	OrganizationJson,
+	ProjectJson,
+	SignedEnvironmentSecretUploadRequest,
 } from '@/types';
 import { environmentKeysFromJSON } from '@/types';
 
@@ -118,11 +118,11 @@ export class GhostableClient {
 		return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
 	}
 
-        async pull(
-                projectId: string,
-                envName: string,
-                opts?: {
-                        only?: string[];
+	async pull(
+		projectId: string,
+		envName: string,
+		opts?: {
+			only?: string[];
 			includeMeta?: boolean;
 			includeVersions?: boolean;
 		},
@@ -141,28 +141,25 @@ export class GhostableClient {
 			`/projects/${p}/environments/${e}/pull${suffix}`,
 		);
 
-                return EnvironmentSecretBundle.fromJSON(json);
-        }
+		return EnvironmentSecretBundle.fromJSON(json);
+	}
 
-        async getEnvironmentKeys(
-                projectId: string,
-                envName: string,
-        ): Promise<EnvironmentKeysResponse> {
-                const p = encodeURIComponent(projectId);
-                const e = encodeURIComponent(envName);
+	async getEnvironmentKeys(projectId: string, envName: string): Promise<EnvironmentKeysResponse> {
+		const p = encodeURIComponent(projectId);
+		const e = encodeURIComponent(envName);
 
-                const json = await this.http.get<EnvironmentKeysResponseJson>(
-                        `/projects/${p}/environments/${e}/keys`,
-                );
+		const json = await this.http.get<EnvironmentKeysResponseJson>(
+			`/projects/${p}/environments/${e}/keys`,
+		);
 
-                return environmentKeysFromJSON(json);
-        }
+		return environmentKeysFromJSON(json);
+	}
 
-        async deploy(opts?: {
-                only?: string[];
-                includeMeta?: boolean;
-                includeVersions?: boolean;
-        }): Promise<EnvironmentSecretBundle> {
+	async deploy(opts?: {
+		only?: string[];
+		includeMeta?: boolean;
+		includeVersions?: boolean;
+	}): Promise<EnvironmentSecretBundle> {
 		const qs = new URLSearchParams();
 		if (opts?.includeMeta) qs.set('include_meta', '1');
 		if (opts?.includeVersions) qs.set('include_versions', '1');

--- a/src/types/api/environment.ts
+++ b/src/types/api/environment.ts
@@ -100,14 +100,14 @@ export type EnvironmentSecretJson = EnvironmentSecretCommon & {
  * Bundle of environment secrets merged across inheritance layers.
  */
 export type EnvironmentSecretBundleJson = {
-        /** Target environment name (e.g., "local"). */
-        env: string;
+	/** Target environment name (e.g., "local"). */
+	env: string;
 
-        /** Chain of inherited environments (parent → child). */
-        chain: string[];
+	/** Chain of inherited environments (parent → child). */
+	chain: string[];
 
-        /** List of encrypted secrets across the chain. */
-        secrets: EnvironmentSecretJson[];
+	/** List of encrypted secrets across the chain. */
+	secrets: EnvironmentSecretJson[];
 };
 
 /**
@@ -115,58 +115,58 @@ export type EnvironmentSecretBundleJson = {
  * Returned by GET /projects/{projectId}/environments/{envName}/keys
  */
 export type EnvironmentKeySummaryJson = {
-        name: string;
-        /** Opaque version identifier (number or string depending on backend). */
-        version: number | string | null;
-        /** ISO8601 timestamp or null if unknown. */
-        updated_at: string | null;
-        /** Email of the last updater (if available). */
-        updated_by_email: string | null;
+	name: string;
+	/** Opaque version identifier (number or string depending on backend). */
+	version: number | string | null;
+	/** ISO8601 timestamp or null if unknown. */
+	updated_at: string | null;
+	/** Email of the last updater (if available). */
+	updated_by_email: string | null;
 };
 
 export type EnvironmentKeysResponseJson = {
-        project_id: string;
-        environment: string;
-        count: number;
-        data: EnvironmentKeySummaryJson[];
+	project_id: string;
+	environment: string;
+	count: number;
+	data: EnvironmentKeySummaryJson[];
 };
 
 /** Camel-cased client shapes */
 export type EnvironmentKeySummary = {
-        name: string;
-        version: number | string | null;
-        updatedAt: string | null;
-        updatedByEmail: string | null;
+	name: string;
+	version: number | string | null;
+	updatedAt: string | null;
+	updatedByEmail: string | null;
 };
 
 export type EnvironmentKeysResponse = {
-        projectId: string;
-        environment: string;
-        count: number;
-        data: EnvironmentKeySummary[];
+	projectId: string;
+	environment: string;
+	count: number;
+	data: EnvironmentKeySummary[];
 };
 
 /** JSON → TS mappers */
 export function environmentKeysFromJSON(
-        json: EnvironmentKeysResponseJson,
+	json: EnvironmentKeysResponseJson,
 ): EnvironmentKeysResponse {
-        return {
-                projectId: json.project_id,
-                environment: json.environment,
-                count: json.count,
-                data: json.data.map(environmentKeySummaryFromJSON),
-        };
+	return {
+		projectId: json.project_id,
+		environment: json.environment,
+		count: json.count,
+		data: json.data.map(environmentKeySummaryFromJSON),
+	};
 }
 
 export function environmentKeySummaryFromJSON(
-        item: EnvironmentKeySummaryJson,
+	item: EnvironmentKeySummaryJson,
 ): EnvironmentKeySummary {
-        return {
-                name: item.name,
-                version: item.version ?? null,
-                updatedAt: item.updated_at ?? null,
-                updatedByEmail: item.updated_by_email ?? null,
-        };
+	return {
+		name: item.name,
+		version: item.version ?? null,
+		updatedAt: item.updated_at ?? null,
+		updatedByEmail: item.updated_by_email ?? null,
+	};
 }
 
 /**

--- a/src/types/api/environment.ts
+++ b/src/types/api/environment.ts
@@ -100,15 +100,74 @@ export type EnvironmentSecretJson = EnvironmentSecretCommon & {
  * Bundle of environment secrets merged across inheritance layers.
  */
 export type EnvironmentSecretBundleJson = {
-	/** Target environment name (e.g., "local"). */
-	env: string;
+        /** Target environment name (e.g., "local"). */
+        env: string;
 
-	/** Chain of inherited environments (parent → child). */
-	chain: string[];
+        /** Chain of inherited environments (parent → child). */
+        chain: string[];
 
-	/** List of encrypted secrets across the chain. */
-	secrets: EnvironmentSecretJson[];
+        /** List of encrypted secrets across the chain. */
+        secrets: EnvironmentSecretJson[];
 };
+
+/**
+ * Lightweight metadata for a single environment variable (no values).
+ * Returned by GET /projects/{projectId}/environments/{envName}/keys
+ */
+export type EnvironmentKeySummaryJson = {
+        name: string;
+        /** Opaque version identifier (number or string depending on backend). */
+        version: number | string | null;
+        /** ISO8601 timestamp or null if unknown. */
+        updated_at: string | null;
+        /** Email of the last updater (if available). */
+        updated_by_email: string | null;
+};
+
+export type EnvironmentKeysResponseJson = {
+        project_id: string;
+        environment: string;
+        count: number;
+        data: EnvironmentKeySummaryJson[];
+};
+
+/** Camel-cased client shapes */
+export type EnvironmentKeySummary = {
+        name: string;
+        version: number | string | null;
+        updatedAt: string | null;
+        updatedByEmail: string | null;
+};
+
+export type EnvironmentKeysResponse = {
+        projectId: string;
+        environment: string;
+        count: number;
+        data: EnvironmentKeySummary[];
+};
+
+/** JSON → TS mappers */
+export function environmentKeysFromJSON(
+        json: EnvironmentKeysResponseJson,
+): EnvironmentKeysResponse {
+        return {
+                projectId: json.project_id,
+                environment: json.environment,
+                count: json.count,
+                data: json.data.map(environmentKeySummaryFromJSON),
+        };
+}
+
+export function environmentKeySummaryFromJSON(
+        item: EnvironmentKeySummaryJson,
+): EnvironmentKeySummary {
+        return {
+                name: item.name,
+                version: item.version ?? null,
+                updatedAt: item.updated_at ?? null,
+                updatedByEmail: item.updated_by_email ?? null,
+        };
+}
 
 /**
  * Validator claims attached by the client during upload.


### PR DESCRIPTION
## Summary
- add type definitions and mappers for the environment keys API response
- expose a Ghostable client helper for fetching environment keys metadata

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68f149283db483339f4df1072b05f994