### PR TITLE
Batch env push uploads

### DIFF
--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -1,12 +1,11 @@
 import { Command } from 'commander';
 import { select } from '@inquirer/prompts';
-import { Listr } from 'listr2';
+import { Listr, ListrTaskWrapper, ListrDefaultRenderer, ListrSimpleRenderer } from 'listr2';
 import fs from 'node:fs';
 import chalk from 'chalk';
 
 import { initSodium } from '../crypto.js';
 import { loadOrCreateKeys } from '../keys.js';
-
 import { config } from '../config/index.js';
 import { SessionService } from '../services/SessionService.js';
 import { GhostableClient } from '../services/GhostableClient.js';
@@ -14,7 +13,6 @@ import { Manifest } from '../support/Manifest.js';
 import { log } from '../support/logger.js';
 import { toErrorMessage } from '../support/errors.js';
 import { getIgnoredKeys, filterIgnoredKeys } from '../support/ignore.js';
-
 import {
 	EnvVarSnapshot,
 	resolveEnvFile,
@@ -23,6 +21,9 @@ import {
 import { buildSecretPayload } from '../support/secret-payload.js';
 
 import type { SignedEnvironmentSecretUploadRequest, ValidatorRecord } from '@/types';
+
+// Listr context (extend as needed)
+type Ctx = Record<string, unknown>;
 
 export type PushOptions = {
 	api?: string;
@@ -87,15 +88,15 @@ export async function runEnvPush(opts: PushOptions): Promise<void> {
 		});
 	}
 
-	// 3) Resolve token, and org from session if needed
+	// 3) Resolve token / org
 	const sessionSvc = new SessionService();
 	const sess = await sessionSvc.load();
 	if (!sess?.accessToken) {
 		log.error('❌ No API token. Run `ghostable login`.');
 		process.exit(1);
 	}
-	let token = sess.accessToken;
-	let orgId = sess.organizationId;
+	const token = sess.accessToken;
+	const orgId = sess.organizationId;
 
 	// 4) Resolve .env file path
 	const filePath = resolveEnvFile(envName!, opts.file, true);
@@ -104,7 +105,7 @@ export async function runEnvPush(opts: PushOptions): Promise<void> {
 		process.exit(1);
 	}
 
-	// 5) Read variables
+	// 5) Read variables + apply ignore list
 	const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
 	const ignored = getIgnoredKeys(envName);
 	const filteredVars = filterIgnoredKeys(envMap, ignored);
@@ -129,63 +130,67 @@ export async function runEnvPush(opts: PushOptions): Promise<void> {
 	}
 
 	// 6) Prep crypto + client
-	await initSodium(); // no-op with stablelib
+	await initSodium();
 	const keyBundle = await loadOrCreateKeys();
 	const masterSeed = Buffer.from(keyBundle.masterSeedB64.replace(/^b64:/, ''), 'base64');
 	const edPriv = Buffer.from(keyBundle.ed25519PrivB64.replace(/^b64:/, ''), 'base64');
 
 	const client = GhostableClient.unauthenticated(config.apiBase).withToken(token);
 
-        // 7) Encrypt variables locally then upload as a single batch
-        const payloads: SignedEnvironmentSecretUploadRequest[] = [];
+	// 7) Encrypt & upload via Listr
+	const payloads: SignedEnvironmentSecretUploadRequest[] = [];
 
-        const tasks = new Listr(
-                [
-                        ...entries.map(({ name, parsedValue, plaintext }) => ({
-                                title: `${name}`,
-                                task: async (_ctx, task) => {
-                                        const validators: ValidatorRecord = {
-                                                non_empty: parsedValue.length > 0,
-                                        };
-                                        if (name === 'APP_KEY') {
-                                                validators.regex = {
-                                                        id: 'base64_44char_v1',
-                                                        ok: /^base64:/.test(parsedValue) && parsedValue.length >= 44,
-                                                };
-                                                validators.length = parsedValue.length;
-                                        }
+	const tasks = new Listr<Ctx, ListrDefaultRenderer, ListrSimpleRenderer>(
+		[
+			...entries.map(({ name, parsedValue, plaintext }) => ({
+				title: `${name}`,
+				task: async (
+					_ctx: Ctx,
+					task: ListrTaskWrapper<Ctx, ListrDefaultRenderer, ListrSimpleRenderer>,
+				) => {
+					const validators: ValidatorRecord = { non_empty: parsedValue.length > 0 };
 
-                                        const payload = await buildSecretPayload({
-                                                name,
-                                                env: envName!, // from manifest selection
-                                                org: orgId ?? '', // server can infer if token is org-scoped
-                                                project: projectId, // from manifest
-                                                plaintext,
-                                                masterSeed,
-                                                edPriv,
-                                                validators,
-                                                // ifVersion?: number  // add later for optimistic concurrency
-                                        });
+					if (name === 'APP_KEY') {
+						validators.regex = {
+							id: 'base64_44char_v1',
+							ok: /^base64:/.test(parsedValue) && parsedValue.length >= 44,
+						};
+						validators.length = parsedValue.length;
+					}
 
-                                        payloads.push(payload);
-                                        task.title = `${name}  ${chalk.green('✓')}`;
-                                },
-                        })),
-                        {
-                                title: `Upload ${entries.length} variables`,
-                                task: async (_ctx, task) => {
-                                        await client.uploadSecrets(
-                                                projectId,
-                                                envName!,
-                                                { secrets: payloads },
-                                                sync ? { sync: true } : undefined,
-                                        );
-                                        task.title = `Upload ${entries.length} variables  ${chalk.green('✓')}`;
-                                },
-                        },
-                ],
-                { concurrent: false, exitOnError: true },
-        );
+					const payload = await buildSecretPayload({
+						name,
+						env: envName!, // from manifest selection
+						org: orgId ?? '', // server may infer if token is org-scoped
+						project: projectId, // from manifest
+						plaintext,
+						masterSeed,
+						edPriv,
+						validators,
+					});
+
+					payloads.push(payload);
+					task.title = `${name}  ${chalk.green('✓')}`;
+				},
+			})),
+			{
+				title: `Upload ${entries.length} variables`,
+				task: async (
+					_ctx: Ctx,
+					task: ListrTaskWrapper<Ctx, ListrDefaultRenderer, ListrSimpleRenderer>,
+				) => {
+					await client.push(
+						projectId,
+						envName!,
+						{ secrets: payloads },
+						sync ? { sync: true } : undefined,
+					);
+					task.title = `Upload ${entries.length} variables  ${chalk.green('✓')}`;
+				},
+			},
+		],
+		{ concurrent: false, exitOnError: true },
+	);
 
 	try {
 		await tasks.run();

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -10,15 +10,16 @@ import {
 } from '@/domain';
 
 import type {
-	EnvironmentJson,
-	EnvironmentKeysResponse,
-	EnvironmentKeysResponseJson,
-	EnvironmentSecretBundleJson,
-	EnvironmentSuggestedNameJson,
-	EnvironmentTypeJson,
-	OrganizationJson,
-	ProjectJson,
-	SignedEnvironmentSecretUploadRequest,
+        EnvironmentJson,
+        EnvironmentKeysResponse,
+        EnvironmentKeysResponseJson,
+        EnvironmentSecretBundleJson,
+        EnvironmentSuggestedNameJson,
+        EnvironmentTypeJson,
+        OrganizationJson,
+        ProjectJson,
+        SignedEnvironmentSecretBatchUploadRequest,
+        SignedEnvironmentSecretUploadRequest,
 } from '@/types';
 import { environmentKeysFromJSON } from '@/types';
 
@@ -106,17 +107,29 @@ export class GhostableClient {
 		return Environment.fromJSON(res);
 	}
 
-	async uploadSecret(
-		projectId: string,
-		envName: string,
-		payload: SignedEnvironmentSecretUploadRequest,
-		opts?: { sync?: boolean },
-	): Promise<{ id?: string; version?: number }> {
-		const p = encodeURIComponent(projectId);
-		const e = encodeURIComponent(envName);
-		const suffix = opts?.sync ? '?sync=1' : '';
-		return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
-	}
+        async uploadSecret(
+                projectId: string,
+                envName: string,
+                payload: SignedEnvironmentSecretUploadRequest,
+                opts?: { sync?: boolean },
+        ): Promise<{ id?: string; version?: number }> {
+                const p = encodeURIComponent(projectId);
+                const e = encodeURIComponent(envName);
+                const suffix = opts?.sync ? '?sync=1' : '';
+                return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
+        }
+
+        async uploadSecrets(
+                projectId: string,
+                envName: string,
+                payloads: SignedEnvironmentSecretBatchUploadRequest,
+                opts?: { sync?: boolean },
+        ): Promise<void> {
+                const p = encodeURIComponent(projectId);
+                const e = encodeURIComponent(envName);
+                const suffix = opts?.sync ? '?sync=1' : '';
+                await this.http.post(`/projects/${p}/environments/${e}/secrets/batch${suffix}`, payloads);
+        }
 
 	async pull(
 		projectId: string,

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -10,16 +10,16 @@ import {
 } from '@/domain';
 
 import type {
-        EnvironmentJson,
-        EnvironmentKeysResponse,
-        EnvironmentKeysResponseJson,
-        EnvironmentSecretBundleJson,
-        EnvironmentSuggestedNameJson,
-        EnvironmentTypeJson,
-        OrganizationJson,
-        ProjectJson,
-        SignedEnvironmentSecretBatchUploadRequest,
-        SignedEnvironmentSecretUploadRequest,
+	EnvironmentJson,
+	EnvironmentKeysResponse,
+	EnvironmentKeysResponseJson,
+	EnvironmentSecretBundleJson,
+	EnvironmentSuggestedNameJson,
+	EnvironmentTypeJson,
+	OrganizationJson,
+	ProjectJson,
+	SignedEnvironmentSecretBatchUploadRequest,
+	SignedEnvironmentSecretUploadRequest,
 } from '@/types';
 import { environmentKeysFromJSON } from '@/types';
 
@@ -107,29 +107,29 @@ export class GhostableClient {
 		return Environment.fromJSON(res);
 	}
 
-        async uploadSecret(
-                projectId: string,
-                envName: string,
-                payload: SignedEnvironmentSecretUploadRequest,
-                opts?: { sync?: boolean },
-        ): Promise<{ id?: string; version?: number }> {
-                const p = encodeURIComponent(projectId);
-                const e = encodeURIComponent(envName);
-                const suffix = opts?.sync ? '?sync=1' : '';
-                return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
-        }
+	async uploadSecret(
+		projectId: string,
+		envName: string,
+		payload: SignedEnvironmentSecretUploadRequest,
+		opts?: { sync?: boolean },
+	): Promise<{ id?: string; version?: number }> {
+		const p = encodeURIComponent(projectId);
+		const e = encodeURIComponent(envName);
+		const suffix = opts?.sync ? '?sync=1' : '';
+		return this.http.post(`/projects/${p}/environments/${e}/secrets${suffix}`, payload);
+	}
 
-        async uploadSecrets(
-                projectId: string,
-                envName: string,
-                payloads: SignedEnvironmentSecretBatchUploadRequest,
-                opts?: { sync?: boolean },
-        ): Promise<void> {
-                const p = encodeURIComponent(projectId);
-                const e = encodeURIComponent(envName);
-                const suffix = opts?.sync ? '?sync=1' : '';
-                await this.http.post(`/projects/${p}/environments/${e}/secrets/batch${suffix}`, payloads);
-        }
+	async push(
+		projectId: string,
+		envName: string,
+		payloads: SignedEnvironmentSecretBatchUploadRequest,
+		opts?: { sync?: boolean },
+	): Promise<void> {
+		const p = encodeURIComponent(projectId);
+		const e = encodeURIComponent(envName);
+		const suffix = opts?.sync ? '?sync=1' : '';
+		await this.http.post(`/projects/${p}/environments/${e}/push${suffix}`, payloads);
+	}
 
 	async pull(
 		projectId: string,

--- a/src/types/api/environment.ts
+++ b/src/types/api/environment.ts
@@ -186,10 +186,10 @@ export type EnvironmentSecretUploadRequest = EnvironmentSecretCommon & {
  * Signed upload request the CLI submits to the API.
  */
 export type SignedEnvironmentSecretUploadRequest = EnvironmentSecretUploadRequest & {
-        /** Ed25519 signature over the JSON body (excluding this field). */
-        client_sig: string;
+	/** Ed25519 signature over the JSON body (excluding this field). */
+	client_sig: string;
 };
 
 export type SignedEnvironmentSecretBatchUploadRequest = {
-        secrets: SignedEnvironmentSecretUploadRequest[];
+	secrets: SignedEnvironmentSecretUploadRequest[];
 };

--- a/src/types/api/environment.ts
+++ b/src/types/api/environment.ts
@@ -186,6 +186,10 @@ export type EnvironmentSecretUploadRequest = EnvironmentSecretCommon & {
  * Signed upload request the CLI submits to the API.
  */
 export type SignedEnvironmentSecretUploadRequest = EnvironmentSecretUploadRequest & {
-	/** Ed25519 signature over the JSON body (excluding this field). */
-	client_sig: string;
+        /** Ed25519 signature over the JSON body (excluding this field). */
+        client_sig: string;
+};
+
+export type SignedEnvironmentSecretBatchUploadRequest = {
+        secrets: SignedEnvironmentSecretUploadRequest[];
 };

--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -54,18 +54,13 @@ vi.mock('../src/services/SessionService.js', () => ({
 }));
 
 const client = {
-        pull: vi.fn(async () => remoteBundle),
-        uploadSecret: vi.fn(),
-        uploadSecrets: vi.fn(
-                async (
-                        _projectId: string,
-                        _env: string,
-                        payload: any,
-                        options?: { sync?: boolean },
-                ) => {
-                        uploadCalls.push({ payload, options: options ?? {} });
-                },
-        ),
+	pull: vi.fn(async () => remoteBundle),
+	uploadSecret: vi.fn(),
+	push: vi.fn(
+		async (_projectId: string, _env: string, payload: any, options?: { sync?: boolean }) => {
+			uploadCalls.push({ payload, options: options ?? {} });
+		},
+	),
 };
 
 vi.mock('../src/services/GhostableClient.js', () => ({
@@ -193,16 +188,16 @@ beforeEach(() => {
 	snapshots = {};
 	remoteBundle = { chain: ['prod'], secrets: [] };
 	decryptedSecrets = [];
-        uploadCalls.splice(0, uploadCalls.length);
+	uploadCalls.splice(0, uploadCalls.length);
 	writeFileCalls.splice(0, writeFileCalls.length);
-        copyFileCalls.splice(0, copyFileCalls.length);
-        logOutputs.info.length = 0;
-        logOutputs.warn.length = 0;
-        logOutputs.error.length = 0;
-        logOutputs.ok.length = 0;
-        client.pull.mockClear();
-        client.uploadSecret.mockClear();
-        client.uploadSecrets.mockClear();
+	copyFileCalls.splice(0, copyFileCalls.length);
+	logOutputs.info.length = 0;
+	logOutputs.warn.length = 0;
+	logOutputs.error.length = 0;
+	logOutputs.ok.length = 0;
+	client.pull.mockClear();
+	client.uploadSecret.mockClear();
+	client.push.mockClear();
 	existsSyncMock.mockClear();
 	existsSyncMock.mockReturnValue(true);
 	writeFileSyncMock.mockClear();
@@ -331,10 +326,10 @@ describe('env:push ignore behaviour', () => {
 		registerEnvPushCommand(program);
 		await program.parseAsync(['node', 'test', 'env:push', '--env', 'prod', '--assume-yes']);
 
-                expect(uploadCalls).toHaveLength(1);
-                const uploadedNames = uploadCalls[0]?.payload.secrets.map((payload: any) => payload.name);
-                expect(uploadedNames).toEqual(['FOO']);
-                expect(uploadCalls[0]?.options).toEqual({});
+		expect(uploadCalls).toHaveLength(1);
+		const uploadedNames = uploadCalls[0]?.payload.secrets.map((payload: any) => payload.name);
+		expect(uploadedNames).toEqual(['FOO']);
+		expect(uploadCalls[0]?.options).toEqual({});
 	});
 
 	it('passes sync flag to upload when requested', async () => {
@@ -357,8 +352,8 @@ describe('env:push ignore behaviour', () => {
 			'--sync',
 		]);
 
-                expect(uploadCalls).toHaveLength(1);
-                expect(uploadCalls[0]?.options).toEqual({ sync: true });
+		expect(uploadCalls).toHaveLength(1);
+		expect(uploadCalls[0]?.options).toEqual({ sync: true });
 	});
 });
 


### PR DESCRIPTION
## Summary
- encrypt and stage env:push variables before issuing a single batch upload
- add Ghostable client helper and types for batched secret uploads
- refresh env push tests to exercise the batch behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2502ed2a083339f5f8a3ff0610b02