### PR TITLE
Move manifest into hidden .ghostable directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ temp/
 Thumbs.db
 *.swp
 *.swo
-ghostable.yml
+.ghostable/
 .env
 .env.*
 *.encrypted

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [SECURITY.md](./SECURITY.md) for our security policy.
 
 ### Ignored Keys
 
-You can specify keys per environment in `ghostable.yml → environments.<env>.ignore` that Ghostable will skip during push, pull, and diff. These keys are never synced or overwritten.
+You can specify keys per environment in `.ghostable/ghostable.yaml → environments.<env>.ignore` that Ghostable will skip during push, pull, and diff. These keys are never synced or overwritten.
 
 ```yaml
 environments:

--- a/src/commands/env-diff.ts
+++ b/src/commands/env-diff.ts
@@ -49,10 +49,10 @@ export function registerEnvDiffCommand(program: Command) {
 				process.exit(1);
 				return;
 			}
-                        if (!envNames.length) {
-                                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
-                                process.exit(1);
-                        }
+			if (!envNames.length) {
+				log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+				process.exit(1);
+			}
 
 			let envName = opts.env?.trim();
 			if (!envName) {

--- a/src/commands/env-diff.ts
+++ b/src/commands/env-diff.ts
@@ -49,10 +49,10 @@ export function registerEnvDiffCommand(program: Command) {
 				process.exit(1);
 				return;
 			}
-			if (!envNames.length) {
-				log.error('❌ No environments defined in ghostable.yml.');
-				process.exit(1);
-			}
+                        if (!envNames.length) {
+                                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+                                process.exit(1);
+                        }
 
 			let envName = opts.env?.trim();
 			if (!envName) {

--- a/src/commands/env-init.ts
+++ b/src/commands/env-init.ts
@@ -152,9 +152,7 @@ export function registerEnvInitCommand(program: Command) {
 					environments: manifestEnvs,
 				});
 
-                                log.ok(
-                                        `✅ Environment ${chalk.bold(env.name)} added to .ghostable/ghostable.yaml`,
-                                );
+				log.ok(`✅ Environment ${chalk.bold(env.name)} added to .ghostable/ghostable.yaml`);
 			} catch (error) {
 				createSpinner.fail('Failed creating environment.');
 				log.error(toErrorMessage(error));

--- a/src/commands/env-init.ts
+++ b/src/commands/env-init.ts
@@ -152,7 +152,9 @@ export function registerEnvInitCommand(program: Command) {
 					environments: manifestEnvs,
 				});
 
-				log.ok(`✅ Environment ${chalk.bold(env.name)} added to ghostable.yml`);
+                                log.ok(
+                                        `✅ Environment ${chalk.bold(env.name)} added to .ghostable/ghostable.yaml`,
+                                );
 			} catch (error) {
 				createSpinner.fail('Failed creating environment.');
 				log.error(toErrorMessage(error));

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -10,7 +10,9 @@ export function registerEnvListCommand(program: Command) {
 	program
 		.command('env:list')
 		.alias('environments:list')
-		.description('List the environments in the current project (from ghostable.yml).')
+                .description(
+                        'List the environments in the current project (from .ghostable/ghostable.yaml).',
+                )
 		.action(async () => {
 			// 1) Ensure session
 			const sessionSvc = new SessionService();

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -10,9 +10,9 @@ export function registerEnvListCommand(program: Command) {
 	program
 		.command('env:list')
 		.alias('environments:list')
-                .description(
-                        'List the environments in the current project (from .ghostable/ghostable.yaml).',
-                )
+		.description(
+			'List the environments in the current project (from .ghostable/ghostable.yaml).',
+		)
 		.action(async () => {
 			// 1) Ensure session
 			const sessionSvc = new SessionService();

--- a/src/commands/env-pull.ts
+++ b/src/commands/env-pull.ts
@@ -69,10 +69,10 @@ export function registerEnvPullCommand(program: Command) {
 				process.exit(1);
 				return;
 			}
-                        if (!envNames.length) {
-                                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
-                                process.exit(1);
-                        }
+			if (!envNames.length) {
+				log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+				process.exit(1);
+			}
 
 			// 2) Pick env (flag → prompt)
 			let envName = opts.env?.trim();

--- a/src/commands/env-pull.ts
+++ b/src/commands/env-pull.ts
@@ -69,10 +69,10 @@ export function registerEnvPullCommand(program: Command) {
 				process.exit(1);
 				return;
 			}
-			if (!envNames.length) {
-				log.error('❌ No environments defined in ghostable.yml.');
-				process.exit(1);
-			}
+                        if (!envNames.length) {
+                                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+                                process.exit(1);
+                        }
 
 			// 2) Pick env (flag → prompt)
 			let envName = opts.env?.trim();

--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -52,9 +52,9 @@ function resolvePlaintext(parsed: string, snapshot?: EnvVarSnapshot): string {
 export function registerEnvPushCommand(program: Command) {
 	program
 		.command('env:push')
-                .description(
-                        'Encrypt and push a local .env file to Ghostable (uses .ghostable/ghostable.yaml)',
-                )
+		.description(
+			'Encrypt and push a local .env file to Ghostable (uses .ghostable/ghostable.yaml)',
+		)
 		.option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
 		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
 		.option('-y, --assume-yes', 'Skip confirmation prompts', false)
@@ -76,10 +76,10 @@ export async function runEnvPush(opts: PushOptions): Promise<void> {
 		process.exit(1);
 		return;
 	}
-        if (!manifestEnvs.length) {
-                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
-                process.exit(1);
-        }
+	if (!manifestEnvs.length) {
+		log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+		process.exit(1);
+	}
 
 	// 2) Pick env (flag → prompt)
 	let envName = opts.env;

--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -52,7 +52,9 @@ function resolvePlaintext(parsed: string, snapshot?: EnvVarSnapshot): string {
 export function registerEnvPushCommand(program: Command) {
 	program
 		.command('env:push')
-		.description('Encrypt and push a local .env file to Ghostable (uses ghostable.yml)')
+                .description(
+                        'Encrypt and push a local .env file to Ghostable (uses .ghostable/ghostable.yaml)',
+                )
 		.option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
 		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
 		.option('-y, --assume-yes', 'Skip confirmation prompts', false)
@@ -74,10 +76,10 @@ export async function runEnvPush(opts: PushOptions): Promise<void> {
 		process.exit(1);
 		return;
 	}
-	if (!manifestEnvs.length) {
-		log.error('❌ No environments defined in ghostable.yml.');
-		process.exit(1);
-	}
+        if (!manifestEnvs.length) {
+                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+                process.exit(1);
+        }
 
 	// 2) Pick env (flag → prompt)
 	let envName = opts.env;

--- a/src/commands/key-export.ts
+++ b/src/commands/key-export.ts
@@ -44,18 +44,15 @@ export function registerKeyExportCommand(program: Command) {
 			try {
 				projectId = Manifest.id();
 				envNames = Manifest.environmentNames();
-                        } catch (error) {
-                                log.error(
-                                        toErrorMessage(error) ||
-                                                'Missing .ghostable/ghostable.yaml manifest.',
-                                );
-                                process.exit(1);
-                                return;
-                        }
-                        if (!envNames.length) {
-                                log.error('❌ No environments found in .ghostable/ghostable.yaml.');
-                                process.exit(1);
-                        }
+			} catch (error) {
+				log.error(toErrorMessage(error) || 'Missing .ghostable/ghostable.yaml manifest.');
+				process.exit(1);
+				return;
+			}
+			if (!envNames.length) {
+				log.error('❌ No environments found in .ghostable/ghostable.yaml.');
+				process.exit(1);
+			}
 
 			// 2) Pick env (flag → prompt)
 			const envName =

--- a/src/commands/key-export.ts
+++ b/src/commands/key-export.ts
@@ -44,15 +44,18 @@ export function registerKeyExportCommand(program: Command) {
 			try {
 				projectId = Manifest.id();
 				envNames = Manifest.environmentNames();
-			} catch (error) {
-				log.error(toErrorMessage(error) || 'Missing ghostable.yml manifest.');
-				process.exit(1);
-				return;
-			}
-			if (!envNames.length) {
-				log.error('❌ No environments found in ghostable.yml.');
-				process.exit(1);
-			}
+                        } catch (error) {
+                                log.error(
+                                        toErrorMessage(error) ||
+                                                'Missing .ghostable/ghostable.yaml manifest.',
+                                );
+                                process.exit(1);
+                                return;
+                        }
+                        if (!envNames.length) {
+                                log.error('❌ No environments found in .ghostable/ghostable.yaml.');
+                                process.exit(1);
+                        }
 
 			// 2) Pick env (flag → prompt)
 			const envName =

--- a/src/commands/var-pull.ts
+++ b/src/commands/var-pull.ts
@@ -87,11 +87,11 @@ export function registerVarPullCommand(program: Command) {
 				return;
 			}
 
-			if (!envNames.length) {
-				log.error('❌ No environments defined in ghostable.yml.');
-				process.exit(1);
-				return;
-			}
+                        if (!envNames.length) {
+                                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+                                process.exit(1);
+                                return;
+                        }
 
 			let envName = opts.env?.trim();
 			if (!envName) {

--- a/src/commands/var-pull.ts
+++ b/src/commands/var-pull.ts
@@ -87,11 +87,11 @@ export function registerVarPullCommand(program: Command) {
 				return;
 			}
 
-                        if (!envNames.length) {
-                                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
-                                process.exit(1);
-                                return;
-                        }
+			if (!envNames.length) {
+				log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+				process.exit(1);
+				return;
+			}
 
 			let envName = opts.env?.trim();
 			if (!envName) {

--- a/src/commands/var-push.ts
+++ b/src/commands/var-push.ts
@@ -64,11 +64,11 @@ export function registerVarPushCommand(program: Command) {
 				return;
 			}
 
-			if (!envNames.length) {
-				log.error('❌ No environments defined in ghostable.yml.');
-				process.exit(1);
-				return;
-			}
+                        if (!envNames.length) {
+                                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+                                process.exit(1);
+                                return;
+                        }
 
 			let envName = opts.env?.trim();
 			if (!envName) {

--- a/src/commands/var-push.ts
+++ b/src/commands/var-push.ts
@@ -64,11 +64,11 @@ export function registerVarPushCommand(program: Command) {
 				return;
 			}
 
-                        if (!envNames.length) {
-                                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
-                                process.exit(1);
-                                return;
-                        }
+			if (!envNames.length) {
+				log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+				process.exit(1);
+				return;
+			}
 
 			let envName = opts.env?.trim();
 			if (!envName) {

--- a/src/support/Manifest.ts
+++ b/src/support/Manifest.ts
@@ -24,36 +24,36 @@ export interface ManifestShape {
 }
 
 function manifestDir(): string {
-        return path.resolve(resolveWorkDir(), '.ghostable');
+	return path.resolve(resolveWorkDir(), '.ghostable');
 }
 
 function defaultPath(): string {
-        return path.resolve(manifestDir(), 'ghostable.yaml');
+	return path.resolve(manifestDir(), 'ghostable.yaml');
 }
 
 const LEGACY_MANIFEST_FILENAMES = ['ghostable.yml', 'ghostable.yaml'];
 
 /** Resolve manifest path: env var wins, else .ghostable/ghostable.yaml */
 export function resolveManifestPath(): string {
-        const override = process.env.GHOSTABLE_MANIFEST?.trim();
-        if (override) {
-                return override;
-        }
+	const override = process.env.GHOSTABLE_MANIFEST?.trim();
+	if (override) {
+		return override;
+	}
 
-        const primary = defaultPath();
-        if (fs.existsSync(primary)) {
-                return primary;
-        }
+	const primary = defaultPath();
+	if (fs.existsSync(primary)) {
+		return primary;
+	}
 
-        const workdir = resolveWorkDir();
-        for (const filename of LEGACY_MANIFEST_FILENAMES) {
-                const candidate = path.resolve(workdir, filename);
-                if (fs.existsSync(candidate)) {
-                        return candidate;
-                }
-        }
+	const workdir = resolveWorkDir();
+	for (const filename of LEGACY_MANIFEST_FILENAMES) {
+		const candidate = path.resolve(workdir, filename);
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
 
-        return primary;
+	return primary;
 }
 
 /** Throw with a helpful message (keeps commands clean) */
@@ -73,12 +73,12 @@ function readYaml(file: string): ManifestShape {
 }
 
 function writeYaml(file: string, manifest: ManifestShape) {
-        fs.mkdirSync(path.dirname(file), { recursive: true });
-        const doc = yaml.dump(manifest, {
-                indent: 2,
-                lineWidth: 120,
-                noRefs: true,
-                sortKeys: false,
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	const doc = yaml.dump(manifest, {
+		indent: 2,
+		lineWidth: 120,
+		noRefs: true,
+		sortKeys: false,
 	});
 	fs.writeFileSync(file, doc, 'utf8');
 }

--- a/src/support/deploy-helpers.ts
+++ b/src/support/deploy-helpers.ts
@@ -37,30 +37,27 @@ export async function resolveManifestContext(requestedEnv?: string): Promise<Man
 		projectId = Manifest.id();
 		projectName = Manifest.name();
 		envNames = Manifest.environmentNames();
-        } catch (error) {
-                const message =
-                        toErrorMessage(error) || 'Missing .ghostable/ghostable.yaml manifest';
-                throw new Error(chalk.red(message));
-        }
+	} catch (error) {
+		const message = toErrorMessage(error) || 'Missing .ghostable/ghostable.yaml manifest';
+		throw new Error(chalk.red(message));
+	}
 
-        if (!envNames.length) {
-                throw new Error(
-                        chalk.red('❌ No environments defined in .ghostable/ghostable.yaml'),
-                );
-        }
+	if (!envNames.length) {
+		throw new Error(chalk.red('❌ No environments defined in .ghostable/ghostable.yaml'));
+	}
 
 	let envName = requestedEnv?.trim();
 
 	if (envName) {
 		if (!envNames.includes(envName)) {
-                        throw new Error(
-                                chalk.red(
-                                        `❌ Environment "${envName}" not found in .ghostable/ghostable.yaml. Available: ${envNames
-                                                .slice()
-                                                .sort()
-                                                .join(', ')}`,
-                                ),
-                        );
+			throw new Error(
+				chalk.red(
+					`❌ Environment "${envName}" not found in .ghostable/ghostable.yaml. Available: ${envNames
+						.slice()
+						.sort()
+						.join(', ')}`,
+				),
+			);
 		}
 	} else {
 		envName = await select<string>({

--- a/src/support/deploy-helpers.ts
+++ b/src/support/deploy-helpers.ts
@@ -37,27 +37,30 @@ export async function resolveManifestContext(requestedEnv?: string): Promise<Man
 		projectId = Manifest.id();
 		projectName = Manifest.name();
 		envNames = Manifest.environmentNames();
-	} catch (error) {
-		const message = toErrorMessage(error) || 'Missing ghostable.yml manifest';
-		throw new Error(chalk.red(message));
-	}
+        } catch (error) {
+                const message =
+                        toErrorMessage(error) || 'Missing .ghostable/ghostable.yaml manifest';
+                throw new Error(chalk.red(message));
+        }
 
-	if (!envNames.length) {
-		throw new Error(chalk.red('❌ No environments defined in ghostable.yml'));
-	}
+        if (!envNames.length) {
+                throw new Error(
+                        chalk.red('❌ No environments defined in .ghostable/ghostable.yaml'),
+                );
+        }
 
 	let envName = requestedEnv?.trim();
 
 	if (envName) {
 		if (!envNames.includes(envName)) {
-			throw new Error(
-				chalk.red(
-					`❌ Environment "${envName}" not found in ghostable.yml. Available: ${envNames
-						.slice()
-						.sort()
-						.join(', ')}`,
-				),
-			);
+                        throw new Error(
+                                chalk.red(
+                                        `❌ Environment "${envName}" not found in .ghostable/ghostable.yaml. Available: ${envNames
+                                                .slice()
+                                                .sort()
+                                                .join(', ')}`,
+                                ),
+                        );
 		}
 	} else {
 		envName = await select<string>({


### PR DESCRIPTION
## Summary
- update manifest resolution to prefer `.ghostable/ghostable.yaml` while supporting legacy files and ensuring the directory exists when writing
- refresh CLI messaging and documentation to reference the new manifest location

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68f2971264708333aaff3bcd9efb3ada