### PR TITLE
Add env:validate command for environment schema validation

### DIFF
--- a/src/commands/env-validate.ts
+++ b/src/commands/env-validate.ts
@@ -1,0 +1,86 @@
+import { Command } from 'commander';
+import { select } from '@inquirer/prompts';
+
+import { Manifest } from '../support/Manifest.js';
+import { log } from '../support/logger.js';
+import { toErrorMessage } from '../support/errors.js';
+import { resolveEnvFile, readEnvFileSafe } from '../support/env-files.js';
+import { loadMergedSchema, validateVariables } from '../support/env-schema.js';
+import type { SchemaDefinition } from '../support/env-schema.js';
+
+export type ValidateOptions = {
+        env?: string;
+        file?: string;
+};
+
+export function registerEnvValidateCommand(program: Command) {
+        program
+                .command('env:validate')
+                .description('Validate a local environment file using schema rules')
+                .option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
+                .option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
+                .action(async (opts: ValidateOptions) => runEnvValidate(opts));
+}
+
+export async function runEnvValidate(opts: ValidateOptions): Promise<void> {
+        let manifestEnvs: string[];
+        try {
+                manifestEnvs = Manifest.environmentNames();
+        } catch (error) {
+                log.error(toErrorMessage(error));
+                process.exit(1);
+                return;
+        }
+
+        if (!manifestEnvs.length) {
+                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+                process.exit(1);
+                return;
+        }
+
+        let envName = opts.env;
+        if (!envName) {
+                envName = await select({
+                        message: 'Which environment would you like to validate?',
+                        choices: manifestEnvs.sort().map((name) => ({ name, value: name })),
+                });
+        }
+
+        let filePath: string;
+        try {
+                filePath = resolveEnvFile(envName, opts.file, true);
+        } catch (error) {
+                log.error(toErrorMessage(error));
+                process.exit(1);
+                return;
+        }
+
+        const vars = readEnvFileSafe(filePath);
+
+        let schema: SchemaDefinition;
+        try {
+                schema = loadMergedSchema(envName);
+        } catch (error) {
+                log.error(toErrorMessage(error));
+                process.exit(1);
+                return;
+        }
+
+        if (!Object.keys(schema).length) {
+                log.warn('⚠️  No validation rules were found for this environment.');
+                return;
+        }
+
+        const issues = validateVariables(vars, schema);
+
+        if (issues.length) {
+                log.error(`❌ Validation failed for ${envName} (${filePath})`);
+                for (const issue of issues) {
+                        log.error(`   • ${issue.variable} ${issue.message}`);
+                }
+                process.exit(1);
+                return;
+        }
+
+        log.ok('✅ Environment file passed validation.');
+}

--- a/src/commands/env-validate.ts
+++ b/src/commands/env-validate.ts
@@ -9,78 +9,78 @@ import { loadMergedSchema, validateVariables } from '../support/env-schema.js';
 import type { SchemaDefinition } from '../support/env-schema.js';
 
 export type ValidateOptions = {
-        env?: string;
-        file?: string;
+	env?: string;
+	file?: string;
 };
 
 export function registerEnvValidateCommand(program: Command) {
-        program
-                .command('env:validate')
-                .description('Validate a local environment file using schema rules')
-                .option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
-                .option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
-                .action(async (opts: ValidateOptions) => runEnvValidate(opts));
+	program
+		.command('env:validate')
+		.description('Validate a local environment file using schema rules')
+		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
+		.option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
+		.action(async (opts: ValidateOptions) => runEnvValidate(opts));
 }
 
 export async function runEnvValidate(opts: ValidateOptions): Promise<void> {
-        let manifestEnvs: string[];
-        try {
-                manifestEnvs = Manifest.environmentNames();
-        } catch (error) {
-                log.error(toErrorMessage(error));
-                process.exit(1);
-                return;
-        }
+	let manifestEnvs: string[];
+	try {
+		manifestEnvs = Manifest.environmentNames();
+	} catch (error) {
+		log.error(toErrorMessage(error));
+		process.exit(1);
+		return;
+	}
 
-        if (!manifestEnvs.length) {
-                log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
-                process.exit(1);
-                return;
-        }
+	if (!manifestEnvs.length) {
+		log.error('❌ No environments defined in .ghostable/ghostable.yaml.');
+		process.exit(1);
+		return;
+	}
 
-        let envName = opts.env;
-        if (!envName) {
-                envName = await select({
-                        message: 'Which environment would you like to validate?',
-                        choices: manifestEnvs.sort().map((name) => ({ name, value: name })),
-                });
-        }
+	let envName = opts.env;
+	if (!envName) {
+		envName = await select({
+			message: 'Which environment would you like to validate?',
+			choices: manifestEnvs.sort().map((name) => ({ name, value: name })),
+		});
+	}
 
-        let filePath: string;
-        try {
-                filePath = resolveEnvFile(envName, opts.file, true);
-        } catch (error) {
-                log.error(toErrorMessage(error));
-                process.exit(1);
-                return;
-        }
+	let filePath: string;
+	try {
+		filePath = resolveEnvFile(envName, opts.file, true);
+	} catch (error) {
+		log.error(toErrorMessage(error));
+		process.exit(1);
+		return;
+	}
 
-        const vars = readEnvFileSafe(filePath);
+	const vars = readEnvFileSafe(filePath);
 
-        let schema: SchemaDefinition;
-        try {
-                schema = loadMergedSchema(envName);
-        } catch (error) {
-                log.error(toErrorMessage(error));
-                process.exit(1);
-                return;
-        }
+	let schema: SchemaDefinition;
+	try {
+		schema = loadMergedSchema(envName);
+	} catch (error) {
+		log.error(toErrorMessage(error));
+		process.exit(1);
+		return;
+	}
 
-        if (!Object.keys(schema).length) {
-                log.warn('⚠️  No validation rules were found for this environment.');
-                return;
-        }
+	if (!Object.keys(schema).length) {
+		log.warn('⚠️  No validation rules were found for this environment.');
+		return;
+	}
 
-        const issues = validateVariables(vars, schema);
+	const issues = validateVariables(vars, schema);
 
-        if (issues.length) {
-                log.error(`❌ Validation failed for ${envName} (${filePath})`);
-                for (const issue of issues) {
-                        log.error(`   • ${issue.variable} ${issue.message}`);
-                }
-                process.exit(1);
-                return;
-        }
+	if (issues.length) {
+		log.error(`❌ Validation failed for ${envName} (${filePath})`);
+		for (const issue of issues) {
+			log.error(`   • ${issue.variable} ${issue.message}`);
+		}
+		process.exit(1);
+		return;
+	}
 
-        log.ok('✅ Environment file passed validation.');
+	log.ok('✅ Environment file passed validation.');
 }

--- a/src/support/env-schema.ts
+++ b/src/support/env-schema.ts
@@ -8,359 +8,359 @@ export type SchemaRule = string;
 export type SchemaDefinition = Record<string, SchemaRule[]>;
 
 export type ValidationIssue = {
-        variable: string;
-        message: string;
+	variable: string;
+	message: string;
 };
 
 type ParsedRule = {
-        type: string;
-        argument?: string;
+	type: string;
+	argument?: string;
 };
 
 const GLOBAL_SCHEMA_FILENAMES = ['schema.yaml', 'schema.yml'];
 
 function schemaRoot(): string {
-        return path.resolve(resolveWorkDir(), '.ghostable');
+	return path.resolve(resolveWorkDir(), '.ghostable');
 }
 
 function loadYamlFile(filePath: string): unknown {
-        const raw = fs.readFileSync(filePath, 'utf8');
-        return yaml.load(raw) ?? {};
+	const raw = fs.readFileSync(filePath, 'utf8');
+	return yaml.load(raw) ?? {};
 }
 
 function normalizeRuleEntry(entry: unknown): SchemaRule[] {
-        if (Array.isArray(entry)) {
-                return entry
-                        .map((value) => (typeof value === 'string' ? value.trim() : ''))
-                        .filter((value): value is string => Boolean(value.length));
-        }
+	if (Array.isArray(entry)) {
+		return entry
+			.map((value) => (typeof value === 'string' ? value.trim() : ''))
+			.filter((value): value is string => Boolean(value.length));
+	}
 
-        if (typeof entry === 'string') {
-                const value = entry.trim();
-                return value ? [value] : [];
-        }
+	if (typeof entry === 'string') {
+		const value = entry.trim();
+		return value ? [value] : [];
+	}
 
-        return [];
+	return [];
 }
 
 function parseSchemaObject(source: unknown): SchemaDefinition {
-        if (!source || typeof source !== 'object') {
-                return {};
-        }
+	if (!source || typeof source !== 'object') {
+		return {};
+	}
 
-        const out: SchemaDefinition = {};
+	const out: SchemaDefinition = {};
 
-        for (const [key, value] of Object.entries(source)) {
-                if (typeof key !== 'string' || !key.trim()) continue;
+	for (const [key, value] of Object.entries(source)) {
+		if (typeof key !== 'string' || !key.trim()) continue;
 
-                out[key.trim()] = normalizeRuleEntry(value);
-        }
+		out[key.trim()] = normalizeRuleEntry(value);
+	}
 
-        return out;
+	return out;
 }
 
 function resolveExistingFile(paths: string[]): string | undefined {
-        for (const filePath of paths) {
-                if (fs.existsSync(filePath)) {
-                        return filePath;
-                }
-        }
-        return undefined;
+	for (const filePath of paths) {
+		if (fs.existsSync(filePath)) {
+			return filePath;
+		}
+	}
+	return undefined;
 }
 
 function loadSchemaFile(filePath: string | undefined): SchemaDefinition {
-        if (!filePath) {
-                return {};
-        }
+	if (!filePath) {
+		return {};
+	}
 
-        try {
-                return parseSchemaObject(loadYamlFile(filePath));
-        } catch (error) {
-                const message = error instanceof Error ? error.message : String(error);
-                throw new Error(`Failed to parse schema file at ${filePath}: ${message}`);
-        }
+	try {
+		return parseSchemaObject(loadYamlFile(filePath));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Failed to parse schema file at ${filePath}: ${message}`);
+	}
 }
 
 export function resolveSchemaPaths(envName?: string): {
-        global?: string;
-        environment?: string;
+	global?: string;
+	environment?: string;
 } {
-        const root = schemaRoot();
+	const root = schemaRoot();
 
-        const global = resolveExistingFile(
-                GLOBAL_SCHEMA_FILENAMES.map((filename) => path.join(root, filename)),
-        );
+	const global = resolveExistingFile(
+		GLOBAL_SCHEMA_FILENAMES.map((filename) => path.join(root, filename)),
+	);
 
-        if (!envName) {
-                return { global };
-        }
+	if (!envName) {
+		return { global };
+	}
 
-        const envDir = path.join(root, 'schemas');
-        const candidates = [`${envName}.yaml`, `${envName}.yml`].map((filename) =>
-                path.join(envDir, filename),
-        );
+	const envDir = path.join(root, 'schemas');
+	const candidates = [`${envName}.yaml`, `${envName}.yml`].map((filename) =>
+		path.join(envDir, filename),
+	);
 
-        return {
-                global,
-                environment: resolveExistingFile(candidates),
-        };
+	return {
+		global,
+		environment: resolveExistingFile(candidates),
+	};
 }
 
 export function loadMergedSchema(envName?: string): SchemaDefinition {
-        const { global, environment } = resolveSchemaPaths(envName);
+	const { global, environment } = resolveSchemaPaths(envName);
 
-        if (!global && !environment) {
-                const root = schemaRoot();
-                const envHint = envName
-                        ? ` or ${path.join(root, 'schemas', `${envName}.yaml`)} (.yml also supported)`
-                        : '';
-                throw new Error(
-                        `No schema definitions were found in ${path.join(root, 'schema.yaml')} (.yml also supported)${envHint}.`,
-                );
-        }
+	if (!global && !environment) {
+		const root = schemaRoot();
+		const envHint = envName
+			? ` or ${path.join(root, 'schemas', `${envName}.yaml`)} (.yml also supported)`
+			: '';
+		throw new Error(
+			`No schema definitions were found in ${path.join(root, 'schema.yaml')} (.yml also supported)${envHint}.`,
+		);
+	}
 
-        const base = loadSchemaFile(global);
-        const overrides = loadSchemaFile(environment);
+	const base = loadSchemaFile(global);
+	const overrides = loadSchemaFile(environment);
 
-        return { ...base, ...overrides };
+	return { ...base, ...overrides };
 }
 
 function parseRule(rule: SchemaRule): ParsedRule {
-        const trimmed = rule.trim();
-        const colonIndex = trimmed.indexOf(':');
+	const trimmed = rule.trim();
+	const colonIndex = trimmed.indexOf(':');
 
-        if (colonIndex === -1) {
-                return { type: trimmed };
-        }
+	if (colonIndex === -1) {
+		return { type: trimmed };
+	}
 
-        return {
-                type: trimmed.slice(0, colonIndex).trim(),
-                argument: trimmed.slice(colonIndex + 1).trim(),
-        };
+	return {
+		type: trimmed.slice(0, colonIndex).trim(),
+		argument: trimmed.slice(colonIndex + 1).trim(),
+	};
 }
 
 function stripDelimiters(value: string | undefined): string | undefined {
-        if (!value) return value;
+	if (!value) return value;
 
-        const trimmed = value.trim();
+	const trimmed = value.trim();
 
-        if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
-                return trimmed.slice(1, -1).trim();
-        }
+	if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+		return trimmed.slice(1, -1).trim();
+	}
 
-        return trimmed;
+	return trimmed;
 }
 
 function parseNumber(argument: string | undefined): number | undefined {
-        if (!argument) return undefined;
+	if (!argument) return undefined;
 
-        const cleaned = Number(argument);
-        return Number.isFinite(cleaned) ? cleaned : undefined;
+	const cleaned = Number(argument);
+	return Number.isFinite(cleaned) ? cleaned : undefined;
 }
 
 function parseList(argument: string | undefined): string[] {
-        const inner = stripDelimiters(argument);
-        if (!inner) return [];
+	const inner = stripDelimiters(argument);
+	if (!inner) return [];
 
-        return inner
-                .split(',')
-                .map((entry) => entry.trim())
-                .filter(Boolean);
+	return inner
+		.split(',')
+		.map((entry) => entry.trim())
+		.filter(Boolean);
 }
 
 function buildRegex(argument: string | undefined): RegExp | undefined {
-        if (!argument) return undefined;
+	if (!argument) return undefined;
 
-        const inner = stripDelimiters(argument);
-        if (!inner) return undefined;
+	const inner = stripDelimiters(argument);
+	if (!inner) return undefined;
 
-        if (inner.startsWith('/') && inner.lastIndexOf('/') > 0) {
-                const lastSlash = inner.lastIndexOf('/');
-                const pattern = inner.slice(1, lastSlash);
-                const flags = inner.slice(lastSlash + 1);
-                try {
-                        return new RegExp(pattern, flags);
-                } catch {
-                        return undefined;
-                }
-        }
+	if (inner.startsWith('/') && inner.lastIndexOf('/') > 0) {
+		const lastSlash = inner.lastIndexOf('/');
+		const pattern = inner.slice(1, lastSlash);
+		const flags = inner.slice(lastSlash + 1);
+		try {
+			return new RegExp(pattern, flags);
+		} catch {
+			return undefined;
+		}
+	}
 
-        try {
-                return new RegExp(inner);
-        } catch {
-                return undefined;
-        }
+	try {
+		return new RegExp(inner);
+	} catch {
+		return undefined;
+	}
 }
 
 function isNumeric(value: string): boolean {
-        if (!value.trim()) return false;
-        return !Number.isNaN(Number(value));
+	if (!value.trim()) return false;
+	return !Number.isNaN(Number(value));
 }
 
 function validateRule(value: string, rule: ParsedRule): string | undefined {
-        const argument = stripDelimiters(rule.argument);
+	const argument = stripDelimiters(rule.argument);
 
-        switch (rule.type) {
-                case 'boolean': {
-                        const normalized = value.toLowerCase();
-                        const valid = ['true', 'false', '1', '0'];
-                        if (!valid.includes(normalized)) {
-                                return 'must be a boolean (true/false or 1/0)';
-                        }
-                        return undefined;
-                }
-                case 'integer': {
-                        if (!/^[-+]?\d+$/.test(value.trim())) {
-                                return 'must be an integer value';
-                        }
-                        return undefined;
-                }
-                case 'numeric': {
-                        if (!isNumeric(value)) {
-                                return 'must be numeric';
-                        }
-                        return undefined;
-                }
-                case 'string': {
-                        return undefined;
-                }
-                case 'in': {
-                        const candidates = parseList(argument);
-                        if (!candidates.length) {
-                                return 'has an invalid in rule';
-                        }
-                        if (!candidates.includes(value)) {
-                                return `must be one of: ${candidates.join(', ')}`;
-                        }
-                        return undefined;
-                }
-                case 'url': {
-                        try {
-                                new URL(value);
-                                return undefined;
-                        } catch {
-                                return 'must be a valid URL';
-                        }
-                }
-                case 'email': {
-                        const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-                        if (!pattern.test(value)) {
-                                return 'must be a valid email address';
-                        }
-                        return undefined;
-                }
-                case 'regex': {
-                        const pattern = buildRegex(argument);
-                        if (!pattern) {
-                                return 'has an invalid regex rule';
-                        }
-                        if (!pattern.test(value)) {
-                                return `must match regex ${pattern}`;
-                        }
-                        return undefined;
-                }
-                case 'starts_with': {
-                        if (!argument) {
-                                return 'has an invalid starts_with rule';
-                        }
-                        if (!value.startsWith(argument)) {
-                                return `must start with "${argument}"`;
-                        }
-                        return undefined;
-                }
-                case 'ends_with': {
-                        if (!argument) {
-                                return 'has an invalid ends_with rule';
-                        }
-                        if (!value.endsWith(argument)) {
-                                return `must end with "${argument}"`;
-                        }
-                        return undefined;
-                }
-                case 'min': {
-                        const limit = parseNumber(argument);
-                        if (limit === undefined) {
-                                return 'has an invalid min rule';
-                        }
+	switch (rule.type) {
+		case 'boolean': {
+			const normalized = value.toLowerCase();
+			const valid = ['true', 'false', '1', '0'];
+			if (!valid.includes(normalized)) {
+				return 'must be a boolean (true/false or 1/0)';
+			}
+			return undefined;
+		}
+		case 'integer': {
+			if (!/^[-+]?\d+$/.test(value.trim())) {
+				return 'must be an integer value';
+			}
+			return undefined;
+		}
+		case 'numeric': {
+			if (!isNumeric(value)) {
+				return 'must be numeric';
+			}
+			return undefined;
+		}
+		case 'string': {
+			return undefined;
+		}
+		case 'in': {
+			const candidates = parseList(argument);
+			if (!candidates.length) {
+				return 'has an invalid in rule';
+			}
+			if (!candidates.includes(value)) {
+				return `must be one of: ${candidates.join(', ')}`;
+			}
+			return undefined;
+		}
+		case 'url': {
+			try {
+				new URL(value);
+				return undefined;
+			} catch {
+				return 'must be a valid URL';
+			}
+		}
+		case 'email': {
+			const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+			if (!pattern.test(value)) {
+				return 'must be a valid email address';
+			}
+			return undefined;
+		}
+		case 'regex': {
+			const pattern = buildRegex(argument);
+			if (!pattern) {
+				return 'has an invalid regex rule';
+			}
+			if (!pattern.test(value)) {
+				return `must match regex ${pattern}`;
+			}
+			return undefined;
+		}
+		case 'starts_with': {
+			if (!argument) {
+				return 'has an invalid starts_with rule';
+			}
+			if (!value.startsWith(argument)) {
+				return `must start with "${argument}"`;
+			}
+			return undefined;
+		}
+		case 'ends_with': {
+			if (!argument) {
+				return 'has an invalid ends_with rule';
+			}
+			if (!value.endsWith(argument)) {
+				return `must end with "${argument}"`;
+			}
+			return undefined;
+		}
+		case 'min': {
+			const limit = parseNumber(argument);
+			if (limit === undefined) {
+				return 'has an invalid min rule';
+			}
 
-                        if (isNumeric(value)) {
-                                if (Number(value) < limit) {
-                                        return `must be at least ${limit}`;
-                                }
-                        } else if (value.length < limit) {
-                                return `must be at least ${limit} characters long`;
-                        }
-                        return undefined;
-                }
-                case 'max': {
-                        const limit = parseNumber(argument);
-                        if (limit === undefined) {
-                                return 'has an invalid max rule';
-                        }
+			if (isNumeric(value)) {
+				if (Number(value) < limit) {
+					return `must be at least ${limit}`;
+				}
+			} else if (value.length < limit) {
+				return `must be at least ${limit} characters long`;
+			}
+			return undefined;
+		}
+		case 'max': {
+			const limit = parseNumber(argument);
+			if (limit === undefined) {
+				return 'has an invalid max rule';
+			}
 
-                        if (isNumeric(value)) {
-                                if (Number(value) > limit) {
-                                        return `must be at most ${limit}`;
-                                }
-                        } else if (value.length > limit) {
-                                return `must be at most ${limit} characters long`;
-                        }
-                        return undefined;
-                }
-                case 'required':
-                case 'nullable':
-                        return undefined;
-                default:
-                        return `has an unknown validation rule: ${rule.type}`;
-        }
+			if (isNumeric(value)) {
+				if (Number(value) > limit) {
+					return `must be at most ${limit}`;
+				}
+			} else if (value.length > limit) {
+				return `must be at most ${limit} characters long`;
+			}
+			return undefined;
+		}
+		case 'required':
+		case 'nullable':
+			return undefined;
+		default:
+			return `has an unknown validation rule: ${rule.type}`;
+	}
 }
 
 export function validateVariables(
-        vars: Record<string, string>,
-        schema: SchemaDefinition,
+	vars: Record<string, string>,
+	schema: SchemaDefinition,
 ): ValidationIssue[] {
-        const issues: ValidationIssue[] = [];
+	const issues: ValidationIssue[] = [];
 
-        for (const [variable, rules] of Object.entries(schema)) {
-                const rawValue = vars[variable];
-                const parsedRules = rules.map(parseRule);
-                const required = parsedRules.some((rule) => rule.type === 'required');
-                const nullable = parsedRules.some((rule) => rule.type === 'nullable');
+	for (const [variable, rules] of Object.entries(schema)) {
+		const rawValue = vars[variable];
+		const parsedRules = rules.map(parseRule);
+		const required = parsedRules.some((rule) => rule.type === 'required');
+		const nullable = parsedRules.some((rule) => rule.type === 'nullable');
 
-                if (rawValue === undefined) {
-                        if (required) {
-                                issues.push({
-                                        variable,
-                                        message: 'is required but was not found',
-                                });
-                        }
-                        continue;
-                }
+		if (rawValue === undefined) {
+			if (required) {
+				issues.push({
+					variable,
+					message: 'is required but was not found',
+				});
+			}
+			continue;
+		}
 
-                if (!rawValue.length) {
-                        if (required && !nullable) {
-                                issues.push({
-                                        variable,
-                                        message: 'cannot be blank',
-                                });
-                                continue;
-                        }
+		if (!rawValue.length) {
+			if (required && !nullable) {
+				issues.push({
+					variable,
+					message: 'cannot be blank',
+				});
+				continue;
+			}
 
-                        if (nullable) {
-                                continue;
-                        }
-                }
+			if (nullable) {
+				continue;
+			}
+		}
 
-                for (const rule of parsedRules) {
-                        const error = validateRule(rawValue, rule);
-                        if (error) {
-                                issues.push({
-                                        variable,
-                                        message: error,
-                                });
-                        }
-                }
-        }
+		for (const rule of parsedRules) {
+			const error = validateRule(rawValue, rule);
+			if (error) {
+				issues.push({
+					variable,
+					message: error,
+				});
+			}
+		}
+	}
 
-        return issues;
+	return issues;
 }

--- a/src/support/env-schema.ts
+++ b/src/support/env-schema.ts
@@ -1,0 +1,366 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+
+import { resolveWorkDir } from './workdir.js';
+
+export type SchemaRule = string;
+export type SchemaDefinition = Record<string, SchemaRule[]>;
+
+export type ValidationIssue = {
+        variable: string;
+        message: string;
+};
+
+type ParsedRule = {
+        type: string;
+        argument?: string;
+};
+
+const GLOBAL_SCHEMA_FILENAMES = ['schema.yaml', 'schema.yml'];
+
+function schemaRoot(): string {
+        return path.resolve(resolveWorkDir(), '.ghostable');
+}
+
+function loadYamlFile(filePath: string): unknown {
+        const raw = fs.readFileSync(filePath, 'utf8');
+        return yaml.load(raw) ?? {};
+}
+
+function normalizeRuleEntry(entry: unknown): SchemaRule[] {
+        if (Array.isArray(entry)) {
+                return entry
+                        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+                        .filter((value): value is string => Boolean(value.length));
+        }
+
+        if (typeof entry === 'string') {
+                const value = entry.trim();
+                return value ? [value] : [];
+        }
+
+        return [];
+}
+
+function parseSchemaObject(source: unknown): SchemaDefinition {
+        if (!source || typeof source !== 'object') {
+                return {};
+        }
+
+        const out: SchemaDefinition = {};
+
+        for (const [key, value] of Object.entries(source)) {
+                if (typeof key !== 'string' || !key.trim()) continue;
+
+                out[key.trim()] = normalizeRuleEntry(value);
+        }
+
+        return out;
+}
+
+function resolveExistingFile(paths: string[]): string | undefined {
+        for (const filePath of paths) {
+                if (fs.existsSync(filePath)) {
+                        return filePath;
+                }
+        }
+        return undefined;
+}
+
+function loadSchemaFile(filePath: string | undefined): SchemaDefinition {
+        if (!filePath) {
+                return {};
+        }
+
+        try {
+                return parseSchemaObject(loadYamlFile(filePath));
+        } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                throw new Error(`Failed to parse schema file at ${filePath}: ${message}`);
+        }
+}
+
+export function resolveSchemaPaths(envName?: string): {
+        global?: string;
+        environment?: string;
+} {
+        const root = schemaRoot();
+
+        const global = resolveExistingFile(
+                GLOBAL_SCHEMA_FILENAMES.map((filename) => path.join(root, filename)),
+        );
+
+        if (!envName) {
+                return { global };
+        }
+
+        const envDir = path.join(root, 'schemas');
+        const candidates = [`${envName}.yaml`, `${envName}.yml`].map((filename) =>
+                path.join(envDir, filename),
+        );
+
+        return {
+                global,
+                environment: resolveExistingFile(candidates),
+        };
+}
+
+export function loadMergedSchema(envName?: string): SchemaDefinition {
+        const { global, environment } = resolveSchemaPaths(envName);
+
+        if (!global && !environment) {
+                const root = schemaRoot();
+                const envHint = envName
+                        ? ` or ${path.join(root, 'schemas', `${envName}.yaml`)} (.yml also supported)`
+                        : '';
+                throw new Error(
+                        `No schema definitions were found in ${path.join(root, 'schema.yaml')} (.yml also supported)${envHint}.`,
+                );
+        }
+
+        const base = loadSchemaFile(global);
+        const overrides = loadSchemaFile(environment);
+
+        return { ...base, ...overrides };
+}
+
+function parseRule(rule: SchemaRule): ParsedRule {
+        const trimmed = rule.trim();
+        const colonIndex = trimmed.indexOf(':');
+
+        if (colonIndex === -1) {
+                return { type: trimmed };
+        }
+
+        return {
+                type: trimmed.slice(0, colonIndex).trim(),
+                argument: trimmed.slice(colonIndex + 1).trim(),
+        };
+}
+
+function stripDelimiters(value: string | undefined): string | undefined {
+        if (!value) return value;
+
+        const trimmed = value.trim();
+
+        if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+                return trimmed.slice(1, -1).trim();
+        }
+
+        return trimmed;
+}
+
+function parseNumber(argument: string | undefined): number | undefined {
+        if (!argument) return undefined;
+
+        const cleaned = Number(argument);
+        return Number.isFinite(cleaned) ? cleaned : undefined;
+}
+
+function parseList(argument: string | undefined): string[] {
+        const inner = stripDelimiters(argument);
+        if (!inner) return [];
+
+        return inner
+                .split(',')
+                .map((entry) => entry.trim())
+                .filter(Boolean);
+}
+
+function buildRegex(argument: string | undefined): RegExp | undefined {
+        if (!argument) return undefined;
+
+        const inner = stripDelimiters(argument);
+        if (!inner) return undefined;
+
+        if (inner.startsWith('/') && inner.lastIndexOf('/') > 0) {
+                const lastSlash = inner.lastIndexOf('/');
+                const pattern = inner.slice(1, lastSlash);
+                const flags = inner.slice(lastSlash + 1);
+                try {
+                        return new RegExp(pattern, flags);
+                } catch {
+                        return undefined;
+                }
+        }
+
+        try {
+                return new RegExp(inner);
+        } catch {
+                return undefined;
+        }
+}
+
+function isNumeric(value: string): boolean {
+        if (!value.trim()) return false;
+        return !Number.isNaN(Number(value));
+}
+
+function validateRule(value: string, rule: ParsedRule): string | undefined {
+        const argument = stripDelimiters(rule.argument);
+
+        switch (rule.type) {
+                case 'boolean': {
+                        const normalized = value.toLowerCase();
+                        const valid = ['true', 'false', '1', '0'];
+                        if (!valid.includes(normalized)) {
+                                return 'must be a boolean (true/false or 1/0)';
+                        }
+                        return undefined;
+                }
+                case 'integer': {
+                        if (!/^[-+]?\d+$/.test(value.trim())) {
+                                return 'must be an integer value';
+                        }
+                        return undefined;
+                }
+                case 'numeric': {
+                        if (!isNumeric(value)) {
+                                return 'must be numeric';
+                        }
+                        return undefined;
+                }
+                case 'string': {
+                        return undefined;
+                }
+                case 'in': {
+                        const candidates = parseList(argument);
+                        if (!candidates.length) {
+                                return 'has an invalid in rule';
+                        }
+                        if (!candidates.includes(value)) {
+                                return `must be one of: ${candidates.join(', ')}`;
+                        }
+                        return undefined;
+                }
+                case 'url': {
+                        try {
+                                new URL(value);
+                                return undefined;
+                        } catch {
+                                return 'must be a valid URL';
+                        }
+                }
+                case 'email': {
+                        const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+                        if (!pattern.test(value)) {
+                                return 'must be a valid email address';
+                        }
+                        return undefined;
+                }
+                case 'regex': {
+                        const pattern = buildRegex(argument);
+                        if (!pattern) {
+                                return 'has an invalid regex rule';
+                        }
+                        if (!pattern.test(value)) {
+                                return `must match regex ${pattern}`;
+                        }
+                        return undefined;
+                }
+                case 'starts_with': {
+                        if (!argument) {
+                                return 'has an invalid starts_with rule';
+                        }
+                        if (!value.startsWith(argument)) {
+                                return `must start with "${argument}"`;
+                        }
+                        return undefined;
+                }
+                case 'ends_with': {
+                        if (!argument) {
+                                return 'has an invalid ends_with rule';
+                        }
+                        if (!value.endsWith(argument)) {
+                                return `must end with "${argument}"`;
+                        }
+                        return undefined;
+                }
+                case 'min': {
+                        const limit = parseNumber(argument);
+                        if (limit === undefined) {
+                                return 'has an invalid min rule';
+                        }
+
+                        if (isNumeric(value)) {
+                                if (Number(value) < limit) {
+                                        return `must be at least ${limit}`;
+                                }
+                        } else if (value.length < limit) {
+                                return `must be at least ${limit} characters long`;
+                        }
+                        return undefined;
+                }
+                case 'max': {
+                        const limit = parseNumber(argument);
+                        if (limit === undefined) {
+                                return 'has an invalid max rule';
+                        }
+
+                        if (isNumeric(value)) {
+                                if (Number(value) > limit) {
+                                        return `must be at most ${limit}`;
+                                }
+                        } else if (value.length > limit) {
+                                return `must be at most ${limit} characters long`;
+                        }
+                        return undefined;
+                }
+                case 'required':
+                case 'nullable':
+                        return undefined;
+                default:
+                        return `has an unknown validation rule: ${rule.type}`;
+        }
+}
+
+export function validateVariables(
+        vars: Record<string, string>,
+        schema: SchemaDefinition,
+): ValidationIssue[] {
+        const issues: ValidationIssue[] = [];
+
+        for (const [variable, rules] of Object.entries(schema)) {
+                const rawValue = vars[variable];
+                const parsedRules = rules.map(parseRule);
+                const required = parsedRules.some((rule) => rule.type === 'required');
+                const nullable = parsedRules.some((rule) => rule.type === 'nullable');
+
+                if (rawValue === undefined) {
+                        if (required) {
+                                issues.push({
+                                        variable,
+                                        message: 'is required but was not found',
+                                });
+                        }
+                        continue;
+                }
+
+                if (!rawValue.length) {
+                        if (required && !nullable) {
+                                issues.push({
+                                        variable,
+                                        message: 'cannot be blank',
+                                });
+                                continue;
+                        }
+
+                        if (nullable) {
+                                continue;
+                        }
+                }
+
+                for (const rule of parsedRules) {
+                        const error = validateRule(rawValue, rule);
+                        if (error) {
+                                issues.push({
+                                        variable,
+                                        message: error,
+                                });
+                        }
+                }
+        }
+
+        return issues;
+}

--- a/test/env-schema.test.ts
+++ b/test/env-schema.test.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let workDir = '';
+
+vi.mock('../src/support/workdir.js', () => ({
+        resolveWorkDir: () => workDir,
+}));
+
+const { loadMergedSchema, validateVariables } = await import('../src/support/env-schema.js');
+
+const tmpDirs: string[] = [];
+
+beforeEach(() => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghostable-schema-'));
+        workDir = dir;
+        tmpDirs.push(dir);
+});
+
+afterEach(() => {
+        for (const dir of tmpDirs.splice(0)) {
+                fs.rmSync(dir, { recursive: true, force: true });
+        }
+        workDir = '';
+});
+
+describe('loadMergedSchema', () => {
+        it('merges global schema with environment overrides', () => {
+                const ghostableDir = path.join(workDir, '.ghostable');
+                fs.mkdirSync(path.join(ghostableDir, 'schemas'), { recursive: true });
+
+                fs.writeFileSync(
+                        path.join(ghostableDir, 'schema.yaml'),
+                        ['APP_NAME:', '  - required', '  - string', 'LOG_LEVEL:', '  - in:<debug,info>'].join('\n'),
+                        'utf8',
+                );
+
+                fs.writeFileSync(
+                        path.join(ghostableDir, 'schemas', 'local.yaml'),
+                        ['LOG_LEVEL:', '  - in:<debug,info,trace>', 'DEBUG:', '  - boolean'].join('\n'),
+                        'utf8',
+                );
+
+                const merged = loadMergedSchema('local');
+
+                expect(merged).toEqual({
+                        APP_NAME: ['required', 'string'],
+                        LOG_LEVEL: ['in:<debug,info,trace>'],
+                        DEBUG: ['boolean'],
+                });
+        });
+
+        it('throws when no schema files exist', () => {
+                expect(() => loadMergedSchema('local')).toThrowError(/No schema definitions were found/);
+        });
+});
+
+describe('validateVariables', () => {
+        it('collects validation issues for failing rules', () => {
+                const schema = {
+                        REQUIRED_VAR: ['required'],
+                        FEATURE_FLAG: ['boolean'],
+                        CONTACT_EMAIL: ['required', 'email'],
+                        LIMIT: ['numeric', 'min:10', 'max:20'],
+                        MODE: ['in:<read,write>'],
+                } as const;
+
+                const issues = validateVariables(
+                        {
+                                FEATURE_FLAG: 'maybe',
+                                CONTACT_EMAIL: 'invalid-email',
+                                LIMIT: '5',
+                                MODE: 'admin',
+                        },
+                        schema,
+                );
+
+                expect(issues).toEqual([
+                        {
+                                variable: 'REQUIRED_VAR',
+                                message: 'is required but was not found',
+                        },
+                        {
+                                variable: 'FEATURE_FLAG',
+                                message: 'must be a boolean (true/false or 1/0)',
+                        },
+                        {
+                                variable: 'CONTACT_EMAIL',
+                                message: 'must be a valid email address',
+                        },
+                        {
+                                variable: 'LIMIT',
+                                message: 'must be at least 10',
+                        },
+                        {
+                                variable: 'MODE',
+                                message: 'must be one of: read, write',
+                        },
+                ]);
+        });
+
+        it('skips nullable values for further validation', () => {
+                const schema = {
+                        OPTIONAL: ['required', 'nullable', 'integer'],
+                } as const;
+
+                const issues = validateVariables({ OPTIONAL: '' }, schema);
+
+                expect(issues).toEqual([]);
+        });
+});

--- a/test/env-schema.test.ts
+++ b/test/env-schema.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 let workDir = '';
 
 vi.mock('../src/support/workdir.js', () => ({
-        resolveWorkDir: () => workDir,
+	resolveWorkDir: () => workDir,
 }));
 
 const { loadMergedSchema, validateVariables } = await import('../src/support/env-schema.js');
@@ -14,100 +14,102 @@ const { loadMergedSchema, validateVariables } = await import('../src/support/env
 const tmpDirs: string[] = [];
 
 beforeEach(() => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghostable-schema-'));
-        workDir = dir;
-        tmpDirs.push(dir);
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghostable-schema-'));
+	workDir = dir;
+	tmpDirs.push(dir);
 });
 
 afterEach(() => {
-        for (const dir of tmpDirs.splice(0)) {
-                fs.rmSync(dir, { recursive: true, force: true });
-        }
-        workDir = '';
+	for (const dir of tmpDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	workDir = '';
 });
 
 describe('loadMergedSchema', () => {
-        it('merges global schema with environment overrides', () => {
-                const ghostableDir = path.join(workDir, '.ghostable');
-                fs.mkdirSync(path.join(ghostableDir, 'schemas'), { recursive: true });
+	it('merges global schema with environment overrides', () => {
+		const ghostableDir = path.join(workDir, '.ghostable');
+		fs.mkdirSync(path.join(ghostableDir, 'schemas'), { recursive: true });
 
-                fs.writeFileSync(
-                        path.join(ghostableDir, 'schema.yaml'),
-                        ['APP_NAME:', '  - required', '  - string', 'LOG_LEVEL:', '  - in:<debug,info>'].join('\n'),
-                        'utf8',
-                );
+		fs.writeFileSync(
+			path.join(ghostableDir, 'schema.yaml'),
+			['APP_NAME:', '  - required', '  - string', 'LOG_LEVEL:', '  - in:<debug,info>'].join(
+				'\n',
+			),
+			'utf8',
+		);
 
-                fs.writeFileSync(
-                        path.join(ghostableDir, 'schemas', 'local.yaml'),
-                        ['LOG_LEVEL:', '  - in:<debug,info,trace>', 'DEBUG:', '  - boolean'].join('\n'),
-                        'utf8',
-                );
+		fs.writeFileSync(
+			path.join(ghostableDir, 'schemas', 'local.yaml'),
+			['LOG_LEVEL:', '  - in:<debug,info,trace>', 'DEBUG:', '  - boolean'].join('\n'),
+			'utf8',
+		);
 
-                const merged = loadMergedSchema('local');
+		const merged = loadMergedSchema('local');
 
-                expect(merged).toEqual({
-                        APP_NAME: ['required', 'string'],
-                        LOG_LEVEL: ['in:<debug,info,trace>'],
-                        DEBUG: ['boolean'],
-                });
-        });
+		expect(merged).toEqual({
+			APP_NAME: ['required', 'string'],
+			LOG_LEVEL: ['in:<debug,info,trace>'],
+			DEBUG: ['boolean'],
+		});
+	});
 
-        it('throws when no schema files exist', () => {
-                expect(() => loadMergedSchema('local')).toThrowError(/No schema definitions were found/);
-        });
+	it('throws when no schema files exist', () => {
+		expect(() => loadMergedSchema('local')).toThrowError(/No schema definitions were found/);
+	});
 });
 
 describe('validateVariables', () => {
-        it('collects validation issues for failing rules', () => {
-                const schema = {
-                        REQUIRED_VAR: ['required'],
-                        FEATURE_FLAG: ['boolean'],
-                        CONTACT_EMAIL: ['required', 'email'],
-                        LIMIT: ['numeric', 'min:10', 'max:20'],
-                        MODE: ['in:<read,write>'],
-                } as const;
+	it('collects validation issues for failing rules', () => {
+		const schema = {
+			REQUIRED_VAR: ['required'],
+			FEATURE_FLAG: ['boolean'],
+			CONTACT_EMAIL: ['required', 'email'],
+			LIMIT: ['numeric', 'min:10', 'max:20'],
+			MODE: ['in:<read,write>'],
+		} as const;
 
-                const issues = validateVariables(
-                        {
-                                FEATURE_FLAG: 'maybe',
-                                CONTACT_EMAIL: 'invalid-email',
-                                LIMIT: '5',
-                                MODE: 'admin',
-                        },
-                        schema,
-                );
+		const issues = validateVariables(
+			{
+				FEATURE_FLAG: 'maybe',
+				CONTACT_EMAIL: 'invalid-email',
+				LIMIT: '5',
+				MODE: 'admin',
+			},
+			schema,
+		);
 
-                expect(issues).toEqual([
-                        {
-                                variable: 'REQUIRED_VAR',
-                                message: 'is required but was not found',
-                        },
-                        {
-                                variable: 'FEATURE_FLAG',
-                                message: 'must be a boolean (true/false or 1/0)',
-                        },
-                        {
-                                variable: 'CONTACT_EMAIL',
-                                message: 'must be a valid email address',
-                        },
-                        {
-                                variable: 'LIMIT',
-                                message: 'must be at least 10',
-                        },
-                        {
-                                variable: 'MODE',
-                                message: 'must be one of: read, write',
-                        },
-                ]);
-        });
+		expect(issues).toEqual([
+			{
+				variable: 'REQUIRED_VAR',
+				message: 'is required but was not found',
+			},
+			{
+				variable: 'FEATURE_FLAG',
+				message: 'must be a boolean (true/false or 1/0)',
+			},
+			{
+				variable: 'CONTACT_EMAIL',
+				message: 'must be a valid email address',
+			},
+			{
+				variable: 'LIMIT',
+				message: 'must be at least 10',
+			},
+			{
+				variable: 'MODE',
+				message: 'must be one of: read, write',
+			},
+		]);
+	});
 
-        it('skips nullable values for further validation', () => {
-                const schema = {
-                        OPTIONAL: ['required', 'nullable', 'integer'],
-                } as const;
+	it('skips nullable values for further validation', () => {
+		const schema = {
+			OPTIONAL: ['required', 'nullable', 'integer'],
+		} as const;
 
-                const issues = validateVariables({ OPTIONAL: '' }, schema);
+		const issues = validateVariables({ OPTIONAL: '' }, schema);
 
-                expect(issues).toEqual([]);
-        });
+		expect(issues).toEqual([]);
+	});
 });


### PR DESCRIPTION
## Summary
- add a new `env:validate` command that reads validation schemas before checking a local `.env` file
- implement schema loading and rule evaluation that merges global and environment-specific YAML definitions
- cover the schema loader and validator with dedicated unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2a047c52083338aac090751480f15