### PR TITLE
Refactor env schema validation to modular rule registry

### DIFF
--- a/src/support/env-rules/boolean.ts
+++ b/src/support/env-rules/boolean.ts
@@ -1,0 +1,16 @@
+import type { RuleDefinition } from './types.js';
+
+const valid = ['true', 'false', '1', '0'];
+
+const booleanRule: RuleDefinition = {
+        name: 'boolean',
+        validate(value) {
+                const normalized = value.toLowerCase();
+                if (!valid.includes(normalized)) {
+                        return 'must be a boolean (true/false or 1/0)';
+                }
+                return undefined;
+        },
+};
+
+export default booleanRule;

--- a/src/support/env-rules/boolean.ts
+++ b/src/support/env-rules/boolean.ts
@@ -3,14 +3,14 @@ import type { RuleDefinition } from './types.js';
 const valid = ['true', 'false', '1', '0'];
 
 const booleanRule: RuleDefinition = {
-        name: 'boolean',
-        validate(value) {
-                const normalized = value.toLowerCase();
-                if (!valid.includes(normalized)) {
-                        return 'must be a boolean (true/false or 1/0)';
-                }
-                return undefined;
-        },
+	name: 'boolean',
+	validate(value) {
+		const normalized = value.toLowerCase();
+		if (!valid.includes(normalized)) {
+			return 'must be a boolean (true/false or 1/0)';
+		}
+		return undefined;
+	},
 };
 
 export default booleanRule;

--- a/src/support/env-rules/email.ts
+++ b/src/support/env-rules/email.ts
@@ -1,0 +1,14 @@
+import type { RuleDefinition } from './types.js';
+
+const emailRule: RuleDefinition = {
+        name: 'email',
+        validate(value) {
+                const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+                if (!pattern.test(value)) {
+                        return 'must be a valid email address';
+                }
+                return undefined;
+        },
+};
+
+export default emailRule;

--- a/src/support/env-rules/email.ts
+++ b/src/support/env-rules/email.ts
@@ -1,14 +1,14 @@
 import type { RuleDefinition } from './types.js';
 
 const emailRule: RuleDefinition = {
-        name: 'email',
-        validate(value) {
-                const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-                if (!pattern.test(value)) {
-                        return 'must be a valid email address';
-                }
-                return undefined;
-        },
+	name: 'email',
+	validate(value) {
+		const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+		if (!pattern.test(value)) {
+			return 'must be a valid email address';
+		}
+		return undefined;
+	},
 };
 
 export default emailRule;

--- a/src/support/env-rules/ends-with.ts
+++ b/src/support/env-rules/ends-with.ts
@@ -1,0 +1,18 @@
+import type { RuleDefinition } from './types.js';
+import { stripDelimiters } from './utils.js';
+
+const endsWithRule: RuleDefinition = {
+        name: 'ends_with',
+        validate(value, rule) {
+                const argument = stripDelimiters(rule.argument);
+                if (!argument) {
+                        return 'has an invalid ends_with rule';
+                }
+                if (!value.endsWith(argument)) {
+                        return `must end with "${argument}"`;
+                }
+                return undefined;
+        },
+};
+
+export default endsWithRule;

--- a/src/support/env-rules/ends-with.ts
+++ b/src/support/env-rules/ends-with.ts
@@ -2,17 +2,17 @@ import type { RuleDefinition } from './types.js';
 import { stripDelimiters } from './utils.js';
 
 const endsWithRule: RuleDefinition = {
-        name: 'ends_with',
-        validate(value, rule) {
-                const argument = stripDelimiters(rule.argument);
-                if (!argument) {
-                        return 'has an invalid ends_with rule';
-                }
-                if (!value.endsWith(argument)) {
-                        return `must end with "${argument}"`;
-                }
-                return undefined;
-        },
+	name: 'ends_with',
+	validate(value, rule) {
+		const argument = stripDelimiters(rule.argument);
+		if (!argument) {
+			return 'has an invalid ends_with rule';
+		}
+		if (!value.endsWith(argument)) {
+			return `must end with "${argument}"`;
+		}
+		return undefined;
+	},
 };
 
 export default endsWithRule;

--- a/src/support/env-rules/in.ts
+++ b/src/support/env-rules/in.ts
@@ -2,17 +2,17 @@ import type { RuleDefinition } from './types.js';
 import { parseList } from './utils.js';
 
 const inRule: RuleDefinition = {
-        name: 'in',
-        validate(value, rule) {
-                const candidates = parseList(rule.argument);
-                if (!candidates.length) {
-                        return 'has an invalid in rule';
-                }
-                if (!candidates.includes(value)) {
-                        return `must be one of: ${candidates.join(', ')}`;
-                }
-                return undefined;
-        },
+	name: 'in',
+	validate(value, rule) {
+		const candidates = parseList(rule.argument);
+		if (!candidates.length) {
+			return 'has an invalid in rule';
+		}
+		if (!candidates.includes(value)) {
+			return `must be one of: ${candidates.join(', ')}`;
+		}
+		return undefined;
+	},
 };
 
 export default inRule;

--- a/src/support/env-rules/in.ts
+++ b/src/support/env-rules/in.ts
@@ -1,0 +1,18 @@
+import type { RuleDefinition } from './types.js';
+import { parseList } from './utils.js';
+
+const inRule: RuleDefinition = {
+        name: 'in',
+        validate(value, rule) {
+                const candidates = parseList(rule.argument);
+                if (!candidates.length) {
+                        return 'has an invalid in rule';
+                }
+                if (!candidates.includes(value)) {
+                        return `must be one of: ${candidates.join(', ')}`;
+                }
+                return undefined;
+        },
+};
+
+export default inRule;

--- a/src/support/env-rules/index.ts
+++ b/src/support/env-rules/index.ts
@@ -1,0 +1,41 @@
+import booleanRule from './boolean.js';
+import emailRule from './email.js';
+import endsWithRule from './ends-with.js';
+import inRule from './in.js';
+import integerRule from './integer.js';
+import maxRule from './max.js';
+import minRule from './min.js';
+import nullableRule from './nullable.js';
+import numericRule from './numeric.js';
+import regexRule from './regex.js';
+import requiredRule from './required.js';
+import startsWithRule from './starts-with.js';
+import stringRule from './string.js';
+import urlRule from './url.js';
+import type { RuleDefinition, RuleValidator } from './types.js';
+
+const definitions: RuleDefinition[] = [
+        booleanRule,
+        emailRule,
+        endsWithRule,
+        inRule,
+        integerRule,
+        maxRule,
+        minRule,
+        nullableRule,
+        numericRule,
+        regexRule,
+        requiredRule,
+        startsWithRule,
+        stringRule,
+        urlRule,
+];
+
+const registry = new Map<string, RuleValidator>();
+for (const { name, validate } of definitions) {
+        registry.set(name, validate);
+}
+
+export function getRuleValidator(name: string): RuleValidator | undefined {
+        return registry.get(name);
+}

--- a/src/support/env-rules/index.ts
+++ b/src/support/env-rules/index.ts
@@ -15,27 +15,27 @@ import urlRule from './url.js';
 import type { RuleDefinition, RuleValidator } from './types.js';
 
 const definitions: RuleDefinition[] = [
-        booleanRule,
-        emailRule,
-        endsWithRule,
-        inRule,
-        integerRule,
-        maxRule,
-        minRule,
-        nullableRule,
-        numericRule,
-        regexRule,
-        requiredRule,
-        startsWithRule,
-        stringRule,
-        urlRule,
+	booleanRule,
+	emailRule,
+	endsWithRule,
+	inRule,
+	integerRule,
+	maxRule,
+	minRule,
+	nullableRule,
+	numericRule,
+	regexRule,
+	requiredRule,
+	startsWithRule,
+	stringRule,
+	urlRule,
 ];
 
 const registry = new Map<string, RuleValidator>();
 for (const { name, validate } of definitions) {
-        registry.set(name, validate);
+	registry.set(name, validate);
 }
 
 export function getRuleValidator(name: string): RuleValidator | undefined {
-        return registry.get(name);
+	return registry.get(name);
 }

--- a/src/support/env-rules/integer.ts
+++ b/src/support/env-rules/integer.ts
@@ -1,0 +1,13 @@
+import type { RuleDefinition } from './types.js';
+
+const integerRule: RuleDefinition = {
+        name: 'integer',
+        validate(value) {
+                if (!/^[-+]?\d+$/.test(value.trim())) {
+                        return 'must be an integer value';
+                }
+                return undefined;
+        },
+};
+
+export default integerRule;

--- a/src/support/env-rules/integer.ts
+++ b/src/support/env-rules/integer.ts
@@ -1,13 +1,13 @@
 import type { RuleDefinition } from './types.js';
 
 const integerRule: RuleDefinition = {
-        name: 'integer',
-        validate(value) {
-                if (!/^[-+]?\d+$/.test(value.trim())) {
-                        return 'must be an integer value';
-                }
-                return undefined;
-        },
+	name: 'integer',
+	validate(value) {
+		if (!/^[-+]?\d+$/.test(value.trim())) {
+			return 'must be an integer value';
+		}
+		return undefined;
+	},
 };
 
 export default integerRule;

--- a/src/support/env-rules/max.ts
+++ b/src/support/env-rules/max.ts
@@ -1,0 +1,27 @@
+import type { RuleDefinition } from './types.js';
+import { isNumeric, parseNumber } from './utils.js';
+
+const maxRule: RuleDefinition = {
+        name: 'max',
+        validate(value, rule) {
+                const limit = parseNumber(rule.argument);
+                if (limit === undefined) {
+                        return 'has an invalid max rule';
+                }
+
+                if (isNumeric(value)) {
+                        if (Number(value) > limit) {
+                                return `must be at most ${limit}`;
+                        }
+                        return undefined;
+                }
+
+                if (value.length > limit) {
+                        return `must be at most ${limit} characters long`;
+                }
+
+                return undefined;
+        },
+};
+
+export default maxRule;

--- a/src/support/env-rules/max.ts
+++ b/src/support/env-rules/max.ts
@@ -2,26 +2,26 @@ import type { RuleDefinition } from './types.js';
 import { isNumeric, parseNumber } from './utils.js';
 
 const maxRule: RuleDefinition = {
-        name: 'max',
-        validate(value, rule) {
-                const limit = parseNumber(rule.argument);
-                if (limit === undefined) {
-                        return 'has an invalid max rule';
-                }
+	name: 'max',
+	validate(value, rule) {
+		const limit = parseNumber(rule.argument);
+		if (limit === undefined) {
+			return 'has an invalid max rule';
+		}
 
-                if (isNumeric(value)) {
-                        if (Number(value) > limit) {
-                                return `must be at most ${limit}`;
-                        }
-                        return undefined;
-                }
+		if (isNumeric(value)) {
+			if (Number(value) > limit) {
+				return `must be at most ${limit}`;
+			}
+			return undefined;
+		}
 
-                if (value.length > limit) {
-                        return `must be at most ${limit} characters long`;
-                }
+		if (value.length > limit) {
+			return `must be at most ${limit} characters long`;
+		}
 
-                return undefined;
-        },
+		return undefined;
+	},
 };
 
 export default maxRule;

--- a/src/support/env-rules/min.ts
+++ b/src/support/env-rules/min.ts
@@ -1,0 +1,27 @@
+import type { RuleDefinition } from './types.js';
+import { isNumeric, parseNumber } from './utils.js';
+
+const minRule: RuleDefinition = {
+        name: 'min',
+        validate(value, rule) {
+                const limit = parseNumber(rule.argument);
+                if (limit === undefined) {
+                        return 'has an invalid min rule';
+                }
+
+                if (isNumeric(value)) {
+                        if (Number(value) < limit) {
+                                return `must be at least ${limit}`;
+                        }
+                        return undefined;
+                }
+
+                if (value.length < limit) {
+                        return `must be at least ${limit} characters long`;
+                }
+
+                return undefined;
+        },
+};
+
+export default minRule;

--- a/src/support/env-rules/min.ts
+++ b/src/support/env-rules/min.ts
@@ -2,26 +2,26 @@ import type { RuleDefinition } from './types.js';
 import { isNumeric, parseNumber } from './utils.js';
 
 const minRule: RuleDefinition = {
-        name: 'min',
-        validate(value, rule) {
-                const limit = parseNumber(rule.argument);
-                if (limit === undefined) {
-                        return 'has an invalid min rule';
-                }
+	name: 'min',
+	validate(value, rule) {
+		const limit = parseNumber(rule.argument);
+		if (limit === undefined) {
+			return 'has an invalid min rule';
+		}
 
-                if (isNumeric(value)) {
-                        if (Number(value) < limit) {
-                                return `must be at least ${limit}`;
-                        }
-                        return undefined;
-                }
+		if (isNumeric(value)) {
+			if (Number(value) < limit) {
+				return `must be at least ${limit}`;
+			}
+			return undefined;
+		}
 
-                if (value.length < limit) {
-                        return `must be at least ${limit} characters long`;
-                }
+		if (value.length < limit) {
+			return `must be at least ${limit} characters long`;
+		}
 
-                return undefined;
-        },
+		return undefined;
+	},
 };
 
 export default minRule;

--- a/src/support/env-rules/nullable.ts
+++ b/src/support/env-rules/nullable.ts
@@ -1,10 +1,10 @@
 import type { RuleDefinition } from './types.js';
 
 const nullableRule: RuleDefinition = {
-        name: 'nullable',
-        validate() {
-                return undefined;
-        },
+	name: 'nullable',
+	validate() {
+		return undefined;
+	},
 };
 
 export default nullableRule;

--- a/src/support/env-rules/nullable.ts
+++ b/src/support/env-rules/nullable.ts
@@ -1,0 +1,10 @@
+import type { RuleDefinition } from './types.js';
+
+const nullableRule: RuleDefinition = {
+        name: 'nullable',
+        validate() {
+                return undefined;
+        },
+};
+
+export default nullableRule;

--- a/src/support/env-rules/numeric.ts
+++ b/src/support/env-rules/numeric.ts
@@ -2,13 +2,13 @@ import type { RuleDefinition } from './types.js';
 import { isNumeric } from './utils.js';
 
 const numericRule: RuleDefinition = {
-        name: 'numeric',
-        validate(value) {
-                if (!isNumeric(value)) {
-                        return 'must be numeric';
-                }
-                return undefined;
-        },
+	name: 'numeric',
+	validate(value) {
+		if (!isNumeric(value)) {
+			return 'must be numeric';
+		}
+		return undefined;
+	},
 };
 
 export default numericRule;

--- a/src/support/env-rules/numeric.ts
+++ b/src/support/env-rules/numeric.ts
@@ -1,0 +1,14 @@
+import type { RuleDefinition } from './types.js';
+import { isNumeric } from './utils.js';
+
+const numericRule: RuleDefinition = {
+        name: 'numeric',
+        validate(value) {
+                if (!isNumeric(value)) {
+                        return 'must be numeric';
+                }
+                return undefined;
+        },
+};
+
+export default numericRule;

--- a/src/support/env-rules/regex.ts
+++ b/src/support/env-rules/regex.ts
@@ -2,17 +2,17 @@ import type { RuleDefinition } from './types.js';
 import { buildRegex } from './utils.js';
 
 const regexRule: RuleDefinition = {
-        name: 'regex',
-        validate(value, rule) {
-                const pattern = buildRegex(rule.argument);
-                if (!pattern) {
-                        return 'has an invalid regex rule';
-                }
-                if (!pattern.test(value)) {
-                        return `must match regex ${pattern}`;
-                }
-                return undefined;
-        },
+	name: 'regex',
+	validate(value, rule) {
+		const pattern = buildRegex(rule.argument);
+		if (!pattern) {
+			return 'has an invalid regex rule';
+		}
+		if (!pattern.test(value)) {
+			return `must match regex ${pattern}`;
+		}
+		return undefined;
+	},
 };
 
 export default regexRule;

--- a/src/support/env-rules/regex.ts
+++ b/src/support/env-rules/regex.ts
@@ -1,0 +1,18 @@
+import type { RuleDefinition } from './types.js';
+import { buildRegex } from './utils.js';
+
+const regexRule: RuleDefinition = {
+        name: 'regex',
+        validate(value, rule) {
+                const pattern = buildRegex(rule.argument);
+                if (!pattern) {
+                        return 'has an invalid regex rule';
+                }
+                if (!pattern.test(value)) {
+                        return `must match regex ${pattern}`;
+                }
+                return undefined;
+        },
+};
+
+export default regexRule;

--- a/src/support/env-rules/required.ts
+++ b/src/support/env-rules/required.ts
@@ -1,10 +1,10 @@
 import type { RuleDefinition } from './types.js';
 
 const requiredRule: RuleDefinition = {
-        name: 'required',
-        validate() {
-                return undefined;
-        },
+	name: 'required',
+	validate() {
+		return undefined;
+	},
 };
 
 export default requiredRule;

--- a/src/support/env-rules/required.ts
+++ b/src/support/env-rules/required.ts
@@ -1,0 +1,10 @@
+import type { RuleDefinition } from './types.js';
+
+const requiredRule: RuleDefinition = {
+        name: 'required',
+        validate() {
+                return undefined;
+        },
+};
+
+export default requiredRule;

--- a/src/support/env-rules/starts-with.ts
+++ b/src/support/env-rules/starts-with.ts
@@ -2,17 +2,17 @@ import type { RuleDefinition } from './types.js';
 import { stripDelimiters } from './utils.js';
 
 const startsWithRule: RuleDefinition = {
-        name: 'starts_with',
-        validate(value, rule) {
-                const argument = stripDelimiters(rule.argument);
-                if (!argument) {
-                        return 'has an invalid starts_with rule';
-                }
-                if (!value.startsWith(argument)) {
-                        return `must start with "${argument}"`;
-                }
-                return undefined;
-        },
+	name: 'starts_with',
+	validate(value, rule) {
+		const argument = stripDelimiters(rule.argument);
+		if (!argument) {
+			return 'has an invalid starts_with rule';
+		}
+		if (!value.startsWith(argument)) {
+			return `must start with "${argument}"`;
+		}
+		return undefined;
+	},
 };
 
 export default startsWithRule;

--- a/src/support/env-rules/starts-with.ts
+++ b/src/support/env-rules/starts-with.ts
@@ -1,0 +1,18 @@
+import type { RuleDefinition } from './types.js';
+import { stripDelimiters } from './utils.js';
+
+const startsWithRule: RuleDefinition = {
+        name: 'starts_with',
+        validate(value, rule) {
+                const argument = stripDelimiters(rule.argument);
+                if (!argument) {
+                        return 'has an invalid starts_with rule';
+                }
+                if (!value.startsWith(argument)) {
+                        return `must start with "${argument}"`;
+                }
+                return undefined;
+        },
+};
+
+export default startsWithRule;

--- a/src/support/env-rules/string.ts
+++ b/src/support/env-rules/string.ts
@@ -1,10 +1,10 @@
 import type { RuleDefinition } from './types.js';
 
 const stringRule: RuleDefinition = {
-        name: 'string',
-        validate() {
-                return undefined;
-        },
+	name: 'string',
+	validate() {
+		return undefined;
+	},
 };
 
 export default stringRule;

--- a/src/support/env-rules/string.ts
+++ b/src/support/env-rules/string.ts
@@ -1,0 +1,10 @@
+import type { RuleDefinition } from './types.js';
+
+const stringRule: RuleDefinition = {
+        name: 'string',
+        validate() {
+                return undefined;
+        },
+};
+
+export default stringRule;

--- a/src/support/env-rules/types.ts
+++ b/src/support/env-rules/types.ts
@@ -1,11 +1,11 @@
 export type ParsedRule = {
-        type: string;
-        argument?: string;
+	type: string;
+	argument?: string;
 };
 
 export type RuleValidator = (value: string, rule: ParsedRule) => string | undefined;
 
 export type RuleDefinition = {
-        name: string;
-        validate: RuleValidator;
+	name: string;
+	validate: RuleValidator;
 };

--- a/src/support/env-rules/types.ts
+++ b/src/support/env-rules/types.ts
@@ -1,0 +1,11 @@
+export type ParsedRule = {
+        type: string;
+        argument?: string;
+};
+
+export type RuleValidator = (value: string, rule: ParsedRule) => string | undefined;
+
+export type RuleDefinition = {
+        name: string;
+        validate: RuleValidator;
+};

--- a/src/support/env-rules/url.ts
+++ b/src/support/env-rules/url.ts
@@ -1,15 +1,15 @@
 import type { RuleDefinition } from './types.js';
 
 const urlRule: RuleDefinition = {
-        name: 'url',
-        validate(value) {
-                try {
-                        new URL(value);
-                        return undefined;
-                } catch {
-                        return 'must be a valid URL';
-                }
-        },
+	name: 'url',
+	validate(value) {
+		try {
+			new URL(value);
+			return undefined;
+		} catch {
+			return 'must be a valid URL';
+		}
+	},
 };
 
 export default urlRule;

--- a/src/support/env-rules/url.ts
+++ b/src/support/env-rules/url.ts
@@ -1,0 +1,15 @@
+import type { RuleDefinition } from './types.js';
+
+const urlRule: RuleDefinition = {
+        name: 'url',
+        validate(value) {
+                try {
+                        new URL(value);
+                        return undefined;
+                } catch {
+                        return 'must be a valid URL';
+                }
+        },
+};
+
+export default urlRule;

--- a/src/support/env-rules/utils.ts
+++ b/src/support/env-rules/utils.ts
@@ -1,0 +1,55 @@
+export function stripDelimiters(value: string | undefined): string | undefined {
+        if (!value) return value;
+
+        const trimmed = value.trim();
+
+        if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+                return trimmed.slice(1, -1).trim();
+        }
+
+        return trimmed;
+}
+
+export function parseNumber(argument: string | undefined): number | undefined {
+        if (argument === undefined) return undefined;
+
+        const cleaned = Number(stripDelimiters(argument));
+        return Number.isFinite(cleaned) ? cleaned : undefined;
+}
+
+export function parseList(argument: string | undefined): string[] {
+        const inner = stripDelimiters(argument);
+        if (!inner) return [];
+
+        return inner
+                .split(',')
+                .map((entry) => entry.trim())
+                .filter(Boolean);
+}
+
+export function buildRegex(argument: string | undefined): RegExp | undefined {
+        const inner = stripDelimiters(argument);
+        if (!inner) return undefined;
+
+        if (inner.startsWith('/') && inner.lastIndexOf('/') > 0) {
+                const lastSlash = inner.lastIndexOf('/');
+                const pattern = inner.slice(1, lastSlash);
+                const flags = inner.slice(lastSlash + 1);
+                try {
+                        return new RegExp(pattern, flags);
+                } catch {
+                        return undefined;
+                }
+        }
+
+        try {
+                return new RegExp(inner);
+        } catch {
+                return undefined;
+        }
+}
+
+export function isNumeric(value: string): boolean {
+        if (!value.trim()) return false;
+        return !Number.isNaN(Number(value));
+}

--- a/src/support/env-rules/utils.ts
+++ b/src/support/env-rules/utils.ts
@@ -1,55 +1,55 @@
 export function stripDelimiters(value: string | undefined): string | undefined {
-        if (!value) return value;
+	if (!value) return value;
 
-        const trimmed = value.trim();
+	const trimmed = value.trim();
 
-        if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
-                return trimmed.slice(1, -1).trim();
-        }
+	if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+		return trimmed.slice(1, -1).trim();
+	}
 
-        return trimmed;
+	return trimmed;
 }
 
 export function parseNumber(argument: string | undefined): number | undefined {
-        if (argument === undefined) return undefined;
+	if (argument === undefined) return undefined;
 
-        const cleaned = Number(stripDelimiters(argument));
-        return Number.isFinite(cleaned) ? cleaned : undefined;
+	const cleaned = Number(stripDelimiters(argument));
+	return Number.isFinite(cleaned) ? cleaned : undefined;
 }
 
 export function parseList(argument: string | undefined): string[] {
-        const inner = stripDelimiters(argument);
-        if (!inner) return [];
+	const inner = stripDelimiters(argument);
+	if (!inner) return [];
 
-        return inner
-                .split(',')
-                .map((entry) => entry.trim())
-                .filter(Boolean);
+	return inner
+		.split(',')
+		.map((entry) => entry.trim())
+		.filter(Boolean);
 }
 
 export function buildRegex(argument: string | undefined): RegExp | undefined {
-        const inner = stripDelimiters(argument);
-        if (!inner) return undefined;
+	const inner = stripDelimiters(argument);
+	if (!inner) return undefined;
 
-        if (inner.startsWith('/') && inner.lastIndexOf('/') > 0) {
-                const lastSlash = inner.lastIndexOf('/');
-                const pattern = inner.slice(1, lastSlash);
-                const flags = inner.slice(lastSlash + 1);
-                try {
-                        return new RegExp(pattern, flags);
-                } catch {
-                        return undefined;
-                }
-        }
+	if (inner.startsWith('/') && inner.lastIndexOf('/') > 0) {
+		const lastSlash = inner.lastIndexOf('/');
+		const pattern = inner.slice(1, lastSlash);
+		const flags = inner.slice(lastSlash + 1);
+		try {
+			return new RegExp(pattern, flags);
+		} catch {
+			return undefined;
+		}
+	}
 
-        try {
-                return new RegExp(inner);
-        } catch {
-                return undefined;
-        }
+	try {
+		return new RegExp(inner);
+	} catch {
+		return undefined;
+	}
 }
 
 export function isNumeric(value: string): boolean {
-        if (!value.trim()) return false;
-        return !Number.isNaN(Number(value));
+	if (!value.trim()) return false;
+	return !Number.isNaN(Number(value));
 }

--- a/src/support/env-schema.ts
+++ b/src/support/env-schema.ts
@@ -10,8 +10,8 @@ export type SchemaRule = string;
 export type SchemaDefinition = Record<string, SchemaRule[]>;
 
 export type ValidationIssue = {
-        variable: string;
-        message: string;
+	variable: string;
+	message: string;
 };
 
 const GLOBAL_SCHEMA_FILENAMES = ['schema.yaml', 'schema.yml'];
@@ -137,12 +137,12 @@ function parseRule(rule: SchemaRule): ParsedRule {
 }
 
 function validateRule(value: string, rule: ParsedRule): string | undefined {
-        const validator = getRuleValidator(rule.type);
-        if (!validator) {
-                return `has an unknown validation rule: ${rule.type}`;
-        }
+	const validator = getRuleValidator(rule.type);
+	if (!validator) {
+		return `has an unknown validation rule: ${rule.type}`;
+	}
 
-        return validator(value, rule);
+	return validator(value, rule);
 }
 
 export function validateVariables(


### PR DESCRIPTION
## Summary
- extract environment variable validation rules into dedicated modules with a shared registry
- update the schema validator to resolve rule handlers via the registry for cleaner extensibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2a4892b288333bc8d8f52c2b52318