### PR TITLE
Add keychain storage, server crypto APIs, and tests

### DIFF
--- a/src/crypto/KeyService.ts
+++ b/src/crypto/KeyService.ts
@@ -14,12 +14,13 @@ import { OneTimePrekey } from './types/OneTimePrekey';
 import { EncryptedEnvelope } from './types/EncryptedEnvelope';
 
 export class KeyService {
-	private static keyStore: KeyStore;
+        private static keyStore: KeyStore;
+        private static readonly SIGNED_PREKEY_TTL_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
 
-	/** Initializes the KeyService with a KeyStore implementation. */
-	static initialize(keyStore: KeyStore) {
-		this.keyStore = keyStore;
-	}
+        /** Initializes the KeyService with a KeyStore implementation. */
+        static initialize(keyStore: KeyStore) {
+                this.keyStore = keyStore;
+        }
 
 	/** Generates a SHA-256 thumbprint (hex) of a public key. */
 	private static thumbprint(publicKeyB64: string): string {
@@ -63,35 +64,65 @@ export class KeyService {
 	}
 
 	/** Creates a signed prekey (X25519 keypair signed by device’s Ed25519 signing key). */
-	public static async createSignedPrekey(identity: DeviceIdentity): Promise<SignedPrekey> {
-		const keypair = x25519.generateKeyPair();
-		const pubEnc = keypair.publicKey;
-		const privSign = await this.keyStore.getKey(`device:${identity.deviceId}:signingKey`);
-		if (!privSign) throw new Error('Signing key not found');
-		const signature = await ed25519.sign(pubEnc, privSign);
-		const id = uuid();
+        public static async createSignedPrekey(identity: DeviceIdentity): Promise<SignedPrekey> {
+                const keypair = x25519.generateKeyPair();
+                const pubEnc = keypair.publicKey;
+                const privSign = await this.keyStore.getKey(`device:${identity.deviceId}:signingKey`);
+                if (!privSign) throw new Error('Signing key not found');
+                const signature = await ed25519.sign(pubEnc, privSign);
+                const id = uuid();
+                const expiresAt = new Date(Date.now() + this.SIGNED_PREKEY_TTL_MS).toISOString();
 
-		const prekey: SignedPrekey = {
-			id,
-			publicKey: toBase64(pubEnc),
-			privateKey: toBase64(keypair.secretKey),
-			signatureFromSigningKey: toBase64(signature),
-			signerKid: this.thumbprint(identity.signingKey.publicKey),
-			createdAtIso: new Date().toISOString(),
-			revoked: false,
-		};
+                const prekey: SignedPrekey = {
+                        id,
+                        publicKey: toBase64(pubEnc),
+                        privateKey: toBase64(keypair.secretKey),
+                        signatureFromSigningKey: toBase64(signature),
+                        signerKid: this.thumbprint(identity.signingKey.publicKey),
+                        createdAtIso: new Date().toISOString(),
+                        expiresAtIso: expiresAt,
+                        revoked: false,
+                };
 
-		// Store private key
-		await this.keyStore.setKey(`signedPrekey:${id}`, keypair.secretKey);
-		return prekey;
-	}
+                // Store private key
+                await this.keyStore.setKey(`signedPrekey:${id}`, keypair.secretKey);
+                return prekey;
+        }
+
+        /**
+         * Rotates the provided signed prekey when it has expired.
+         * Returns the active prekey along with metadata describing whether a rotation occurred.
+         */
+        public static async rotateSignedPrekeyIfExpired(
+                identity: DeviceIdentity,
+                current: SignedPrekey | null | undefined,
+                now: Date = new Date(),
+        ): Promise<{ active: SignedPrekey; rotated: boolean; retired?: SignedPrekey }> {
+                if (!current) {
+                        const fresh = await this.createSignedPrekey(identity);
+                        return { active: fresh, rotated: true };
+                }
+
+                if (!current.expiresAtIso) {
+                        return { active: current, rotated: false };
+                }
+
+                const expiresAt = Date.parse(current.expiresAtIso);
+                if (Number.isNaN(expiresAt) || now.getTime() < expiresAt) {
+                        return { active: current, rotated: false };
+                }
+
+                const retired: SignedPrekey = { ...current, revoked: true };
+                const fresh = await this.createSignedPrekey(identity);
+                return { active: fresh, rotated: true, retired };
+        }
 
 	/** Generates N one-time prekeys (X25519 keypairs) for single use. */
-	public static async createOneTimePrekeys(count: number): Promise<OneTimePrekey[]> {
-		if (count < 0) throw new TypeError('count must be non-negative');
-		const keys: OneTimePrekey[] = [];
-		for (let i = 0; i < count; i++) {
-			const keypair = x25519.generateKeyPair();
+        public static async createOneTimePrekeys(count: number): Promise<OneTimePrekey[]> {
+                if (count < 0) throw new TypeError('count must be non-negative');
+                const keys: OneTimePrekey[] = [];
+                for (let i = 0; i < count; i++) {
+                        const keypair = x25519.generateKeyPair();
 			const id = uuid();
 			const prekey: OneTimePrekey = {
 				id,
@@ -102,9 +133,27 @@ export class KeyService {
 			};
 			await this.keyStore.setKey(`oneTimePrekey:${id}`, keypair.secretKey);
 			keys.push(prekey);
-		}
-		return keys;
-	}
+                }
+                return keys;
+        }
+
+        /**
+         * Removes private key material for consumed one-time prekeys from secure storage.
+         * Returns a sanitized list that no longer exposes the private key values.
+         */
+        public static async scrubConsumedOneTimePrekeys(prekeys: OneTimePrekey[]): Promise<OneTimePrekey[]> {
+                const sanitized: OneTimePrekey[] = [];
+                for (const prekey of prekeys) {
+                        if (prekey.consumedAtIso) {
+                                await this.keyStore.deleteKey(`oneTimePrekey:${prekey.id}`);
+                                const { privateKey: _ignored, ...rest } = prekey;
+                                sanitized.push({ ...rest, privateKey: undefined });
+                        } else {
+                                sanitized.push(prekey);
+                        }
+                }
+                return sanitized;
+        }
 
 	/** Encrypts data for a recipient device using XChaCha20-Poly1305. */
 	public static async encryptForDevice(

--- a/src/crypto/KeyStore.ts
+++ b/src/crypto/KeyStore.ts
@@ -3,9 +3,9 @@ import { toBase64, fromBase64 } from './utils';
 import { KeyStore } from './types/KeyStore';
 
 type KeytarLike = {
-        getPassword(service: string, account: string): Promise<string | null>;
-        setPassword(service: string, account: string, password: string): Promise<void>;
-        deletePassword(service: string, account: string): Promise<boolean>;
+	getPassword(service: string, account: string): Promise<string | null>;
+	setPassword(service: string, account: string, password: string): Promise<void>;
+	deletePassword(service: string, account: string): Promise<boolean>;
 };
 
 /**
@@ -14,7 +14,7 @@ type KeytarLike = {
  * Keys are stored as Base64 strings internally for consistency with the codebase.
  */
 export class MemoryKeyStore implements KeyStore {
-        private map = new Map<string, string>();
+	private map = new Map<string, string>();
 
 	async getKey(name: string): Promise<Uint8Array | null> {
 		if (!name) throw new TypeError('name must not be empty');
@@ -39,27 +39,30 @@ export class MemoryKeyStore implements KeyStore {
  * Stores binary values as Base64 strings to remain consistent with the rest of the codebase.
  */
 export class KeytarKeyStore implements KeyStore {
-        private readonly keytar: KeytarLike;
+	private readonly keytar: KeytarLike;
 
-        constructor(private readonly service = 'ghostable-cli', keytarImpl: KeytarLike = keytarModule) {
-                if (!service) throw new TypeError('service must not be empty');
-                this.keytar = keytarImpl;
-        }
+	constructor(
+		private readonly service = 'ghostable-cli',
+		keytarImpl: KeytarLike = keytarModule,
+	) {
+		if (!service) throw new TypeError('service must not be empty');
+		this.keytar = keytarImpl;
+	}
 
-        async getKey(name: string): Promise<Uint8Array | null> {
-                if (!name) throw new TypeError('name must not be empty');
-                const value = await this.keytar.getPassword(this.service, name);
-                return value ? fromBase64(value) : null;
-        }
+	async getKey(name: string): Promise<Uint8Array | null> {
+		if (!name) throw new TypeError('name must not be empty');
+		const value = await this.keytar.getPassword(this.service, name);
+		return value ? fromBase64(value) : null;
+	}
 
-        async setKey(name: string, value: Uint8Array): Promise<void> {
-                if (!name) throw new TypeError('name must not be empty');
-                if (!(value instanceof Uint8Array)) throw new TypeError('value must be a Uint8Array');
-                await this.keytar.setPassword(this.service, name, toBase64(value));
-        }
+	async setKey(name: string, value: Uint8Array): Promise<void> {
+		if (!name) throw new TypeError('name must not be empty');
+		if (!(value instanceof Uint8Array)) throw new TypeError('value must be a Uint8Array');
+		await this.keytar.setPassword(this.service, name, toBase64(value));
+	}
 
-        async deleteKey(name: string): Promise<void> {
-                if (!name) throw new TypeError('name must not be empty');
-                await this.keytar.deletePassword(this.service, name);
-        }
+	async deleteKey(name: string): Promise<void> {
+		if (!name) throw new TypeError('name must not be empty');
+		await this.keytar.deletePassword(this.service, name);
+	}
 }

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -1,39 +1,39 @@
 import { HttpClient } from '../http/HttpClient.js';
 
 import {
-        Environment,
-        EnvironmentSecretBundle,
-        EnvironmentSuggestedName,
-        EnvironmentType,
-        Organization,
-        Project,
+	Environment,
+	EnvironmentSecretBundle,
+	EnvironmentSuggestedName,
+	EnvironmentType,
+	Organization,
+	Project,
 } from '@/domain';
 import type { EncryptedEnvelope, OneTimePrekey, SignedPrekey } from '@/crypto';
 
 import type {
-        EnvironmentJson,
-        EnvironmentKeysResponse,
-        EnvironmentKeysResponseJson,
-        EnvironmentSecretBundleJson,
-        EnvironmentSuggestedNameJson,
-        EnvironmentTypeJson,
-        DevicePrekeyBundle,
-        DevicePrekeyBundleJson,
-        EncryptedEnvelopeJson,
-        SignedPrekeyJson,
-        OrganizationJson,
-        ProjectJson,
-        SignedEnvironmentSecretBatchUploadRequest,
-        SignedEnvironmentSecretUploadRequest,
+	EnvironmentJson,
+	EnvironmentKeysResponse,
+	EnvironmentKeysResponseJson,
+	EnvironmentSecretBundleJson,
+	EnvironmentSuggestedNameJson,
+	EnvironmentTypeJson,
+	DevicePrekeyBundle,
+	DevicePrekeyBundleJson,
+	EncryptedEnvelopeJson,
+	SignedPrekeyJson,
+	OrganizationJson,
+	ProjectJson,
+	SignedEnvironmentSecretBatchUploadRequest,
+	SignedEnvironmentSecretUploadRequest,
 } from '@/types';
 import {
-        devicePrekeyBundleFromJSON,
-        encryptedEnvelopeFromJSON,
-        encryptedEnvelopeToJSON,
-        environmentKeysFromJSON,
-        oneTimePrekeyToJSON,
-        signedPrekeyFromJSON,
-        signedPrekeyToJSON,
+	devicePrekeyBundleFromJSON,
+	encryptedEnvelopeFromJSON,
+	encryptedEnvelopeToJSON,
+	environmentKeysFromJSON,
+	oneTimePrekeyToJSON,
+	signedPrekeyFromJSON,
+	signedPrekeyToJSON,
 } from '@/types';
 
 type LoginResponse = { token?: string; two_factor?: boolean };
@@ -181,11 +181,11 @@ export class GhostableClient {
 		return environmentKeysFromJSON(json);
 	}
 
-        async deploy(opts?: {
-                only?: string[];
-                includeMeta?: boolean;
-                includeVersions?: boolean;
-        }): Promise<EnvironmentSecretBundle> {
+	async deploy(opts?: {
+		only?: string[];
+		includeMeta?: boolean;
+		includeVersions?: boolean;
+	}): Promise<EnvironmentSecretBundle> {
 		const qs = new URLSearchParams();
 		if (opts?.includeMeta) qs.set('include_meta', '1');
 		if (opts?.includeVersions) qs.set('include_versions', '1');
@@ -195,48 +195,48 @@ export class GhostableClient {
 
 		const json = await this.http.get<EnvironmentSecretBundleJson>(`/ci/deploy${suffix}`);
 
-                return EnvironmentSecretBundle.fromJSON(json);
-        }
+		return EnvironmentSecretBundle.fromJSON(json);
+	}
 
-        async publishSignedPrekey(deviceId: string, prekey: SignedPrekey): Promise<SignedPrekey> {
-                const d = encodeURIComponent(deviceId);
-                const json = await this.http.post<SignedPrekeyJson>(
-                        `/devices/${d}/signed-prekey`,
-                        signedPrekeyToJSON(prekey),
-                );
-                return signedPrekeyFromJSON(json);
-        }
+	async publishSignedPrekey(deviceId: string, prekey: SignedPrekey): Promise<SignedPrekey> {
+		const d = encodeURIComponent(deviceId);
+		const json = await this.http.post<SignedPrekeyJson>(
+			`/devices/${d}/signed-prekey`,
+			signedPrekeyToJSON(prekey),
+		);
+		return signedPrekeyFromJSON(json);
+	}
 
-        async publishOneTimePrekeys(deviceId: string, prekeys: OneTimePrekey[]): Promise<void> {
-                const d = encodeURIComponent(deviceId);
-                await this.http.post(`/devices/${d}/one-time-prekeys`, {
-                        one_time_prekeys: prekeys.map(oneTimePrekeyToJSON),
-                });
-        }
+	async publishOneTimePrekeys(deviceId: string, prekeys: OneTimePrekey[]): Promise<void> {
+		const d = encodeURIComponent(deviceId);
+		await this.http.post(`/devices/${d}/one-time-prekeys`, {
+			one_time_prekeys: prekeys.map(oneTimePrekeyToJSON),
+		});
+	}
 
-        async getDevicePrekeys(deviceId: string): Promise<DevicePrekeyBundle> {
-                const d = encodeURIComponent(deviceId);
-                const json = await this.http.get<DevicePrekeyBundleJson>(`/devices/${d}/prekeys`);
-                return devicePrekeyBundleFromJSON(json);
-        }
+	async getDevicePrekeys(deviceId: string): Promise<DevicePrekeyBundle> {
+		const d = encodeURIComponent(deviceId);
+		const json = await this.http.get<DevicePrekeyBundleJson>(`/devices/${d}/prekeys`);
+		return devicePrekeyBundleFromJSON(json);
+	}
 
-        async sendEnvelope(deviceId: string, envelope: EncryptedEnvelope): Promise<void> {
-                const d = encodeURIComponent(deviceId);
-                await this.http.post(`/devices/${d}/envelopes`, encryptedEnvelopeToJSON(envelope));
-        }
+	async sendEnvelope(deviceId: string, envelope: EncryptedEnvelope): Promise<void> {
+		const d = encodeURIComponent(deviceId);
+		await this.http.post(`/devices/${d}/envelopes`, encryptedEnvelopeToJSON(envelope));
+	}
 
-        async getEnvelopes(
-                deviceId: string,
-                opts?: { limit?: number; since?: string },
-        ): Promise<EncryptedEnvelope[]> {
-                const d = encodeURIComponent(deviceId);
-                const qs = new URLSearchParams();
-                if (opts?.limit !== undefined) qs.set('limit', String(opts.limit));
-                if (opts?.since) qs.set('since', opts.since);
-                const suffix = qs.toString() ? `?${qs.toString()}` : '';
-                const res = await this.http.get<ListResp<EncryptedEnvelopeJson>>(
-                        `/devices/${d}/envelopes${suffix}`,
-                );
-                return (res.data ?? []).map(encryptedEnvelopeFromJSON);
-        }
+	async getEnvelopes(
+		deviceId: string,
+		opts?: { limit?: number; since?: string },
+	): Promise<EncryptedEnvelope[]> {
+		const d = encodeURIComponent(deviceId);
+		const qs = new URLSearchParams();
+		if (opts?.limit !== undefined) qs.set('limit', String(opts.limit));
+		if (opts?.since) qs.set('since', opts.since);
+		const suffix = qs.toString() ? `?${qs.toString()}` : '';
+		const res = await this.http.get<ListResp<EncryptedEnvelopeJson>>(
+			`/devices/${d}/envelopes${suffix}`,
+		);
+		return (res.data ?? []).map(encryptedEnvelopeFromJSON);
+	}
 }

--- a/src/types/api/crypto.ts
+++ b/src/types/api/crypto.ts
@@ -1,138 +1,138 @@
 import type { EncryptedEnvelope, OneTimePrekey, SignedPrekey } from '@/crypto';
 
 export type SignedPrekeyJson = {
-        id: string;
-        public_key: string;
-        signature_from_signing_key: string;
-        signer_kid?: string;
-        created_at: string;
-        expires_at?: string;
-        revoked?: boolean;
+	id: string;
+	public_key: string;
+	signature_from_signing_key: string;
+	signer_kid?: string;
+	created_at: string;
+	expires_at?: string;
+	revoked?: boolean;
 };
 
 export type OneTimePrekeyJson = {
-        id: string;
-        public_key: string;
-        created_at: string;
-        consumed_at?: string;
-        consumed_by?: string;
-        expires_at?: string;
-        revoked?: boolean;
+	id: string;
+	public_key: string;
+	created_at: string;
+	consumed_at?: string;
+	consumed_by?: string;
+	expires_at?: string;
+	revoked?: boolean;
 };
 
 export type DevicePrekeyBundleJson = {
-        signed_prekey: SignedPrekeyJson | null;
-        one_time_prekeys: OneTimePrekeyJson[];
+	signed_prekey: SignedPrekeyJson | null;
+	one_time_prekeys: OneTimePrekeyJson[];
 };
 
 export type DevicePrekeyBundle = {
-        signedPrekey: SignedPrekey | null;
-        oneTimePrekeys: OneTimePrekey[];
+	signedPrekey: SignedPrekey | null;
+	oneTimePrekeys: OneTimePrekey[];
 };
 
 export type EncryptedEnvelopeJson = {
-        id: string;
-        version: string;
-        alg?: string;
-        to_device_public_key: string;
-        from_ephemeral_public_key: string;
-        nonce_b64: string;
-        ciphertext_b64: string;
-        created_at: string;
-        expires_at?: string;
-        meta?: Record<string, string>;
-        aad_b64?: string;
-        sender_kid?: string;
-        signature_b64?: string;
+	id: string;
+	version: string;
+	alg?: string;
+	to_device_public_key: string;
+	from_ephemeral_public_key: string;
+	nonce_b64: string;
+	ciphertext_b64: string;
+	created_at: string;
+	expires_at?: string;
+	meta?: Record<string, string>;
+	aad_b64?: string;
+	sender_kid?: string;
+	signature_b64?: string;
 };
 
 export function signedPrekeyFromJSON(json: SignedPrekeyJson): SignedPrekey {
-        return {
-                id: json.id,
-                publicKey: json.public_key,
-                signatureFromSigningKey: json.signature_from_signing_key,
-                signerKid: json.signer_kid,
-                createdAtIso: json.created_at,
-                expiresAtIso: json.expires_at,
-                revoked: json.revoked ?? false,
-        };
+	return {
+		id: json.id,
+		publicKey: json.public_key,
+		signatureFromSigningKey: json.signature_from_signing_key,
+		signerKid: json.signer_kid,
+		createdAtIso: json.created_at,
+		expiresAtIso: json.expires_at,
+		revoked: json.revoked ?? false,
+	};
 }
 
 export function signedPrekeyToJSON(prekey: SignedPrekey): SignedPrekeyJson {
-        return {
-                id: prekey.id,
-                public_key: prekey.publicKey,
-                signature_from_signing_key: prekey.signatureFromSigningKey,
-                signer_kid: prekey.signerKid,
-                created_at: prekey.createdAtIso,
-                expires_at: prekey.expiresAtIso,
-                revoked: prekey.revoked,
-        };
+	return {
+		id: prekey.id,
+		public_key: prekey.publicKey,
+		signature_from_signing_key: prekey.signatureFromSigningKey,
+		signer_kid: prekey.signerKid,
+		created_at: prekey.createdAtIso,
+		expires_at: prekey.expiresAtIso,
+		revoked: prekey.revoked,
+	};
 }
 
 export function oneTimePrekeyFromJSON(json: OneTimePrekeyJson): OneTimePrekey {
-        return {
-                id: json.id,
-                publicKey: json.public_key,
-                createdAtIso: json.created_at,
-                consumedAtIso: json.consumed_at,
-                consumedBy: json.consumed_by,
-                expiresAtIso: json.expires_at,
-                revoked: json.revoked,
-        };
+	return {
+		id: json.id,
+		publicKey: json.public_key,
+		createdAtIso: json.created_at,
+		consumedAtIso: json.consumed_at,
+		consumedBy: json.consumed_by,
+		expiresAtIso: json.expires_at,
+		revoked: json.revoked,
+	};
 }
 
 export function oneTimePrekeyToJSON(prekey: OneTimePrekey): OneTimePrekeyJson {
-        return {
-                id: prekey.id,
-                public_key: prekey.publicKey,
-                created_at: prekey.createdAtIso,
-                consumed_at: prekey.consumedAtIso,
-                consumed_by: prekey.consumedBy,
-                expires_at: prekey.expiresAtIso,
-                revoked: prekey.revoked,
-        };
+	return {
+		id: prekey.id,
+		public_key: prekey.publicKey,
+		created_at: prekey.createdAtIso,
+		consumed_at: prekey.consumedAtIso,
+		consumed_by: prekey.consumedBy,
+		expires_at: prekey.expiresAtIso,
+		revoked: prekey.revoked,
+	};
 }
 
 export function devicePrekeyBundleFromJSON(json: DevicePrekeyBundleJson): DevicePrekeyBundle {
-        return {
-                signedPrekey: json.signed_prekey ? signedPrekeyFromJSON(json.signed_prekey) : null,
-                oneTimePrekeys: json.one_time_prekeys.map(oneTimePrekeyFromJSON),
-        };
+	return {
+		signedPrekey: json.signed_prekey ? signedPrekeyFromJSON(json.signed_prekey) : null,
+		oneTimePrekeys: json.one_time_prekeys.map(oneTimePrekeyFromJSON),
+	};
 }
 
 export function encryptedEnvelopeFromJSON(json: EncryptedEnvelopeJson): EncryptedEnvelope {
-        return {
-                id: json.id,
-                version: json.version,
-                alg: json.alg,
-                toDevicePublicKey: json.to_device_public_key,
-                fromEphemeralPublicKey: json.from_ephemeral_public_key,
-                nonceB64: json.nonce_b64,
-                ciphertextB64: json.ciphertext_b64,
-                createdAtIso: json.created_at,
-                expiresAtIso: json.expires_at,
-                meta: json.meta,
-                aadB64: json.aad_b64,
-                senderKid: json.sender_kid,
-                signatureB64: json.signature_b64,
-        };
+	return {
+		id: json.id,
+		version: json.version,
+		alg: json.alg,
+		toDevicePublicKey: json.to_device_public_key,
+		fromEphemeralPublicKey: json.from_ephemeral_public_key,
+		nonceB64: json.nonce_b64,
+		ciphertextB64: json.ciphertext_b64,
+		createdAtIso: json.created_at,
+		expiresAtIso: json.expires_at,
+		meta: json.meta,
+		aadB64: json.aad_b64,
+		senderKid: json.sender_kid,
+		signatureB64: json.signature_b64,
+	};
 }
 
 export function encryptedEnvelopeToJSON(envelope: EncryptedEnvelope): EncryptedEnvelopeJson {
-        return {
-                id: envelope.id,
-                version: envelope.version,
-                alg: envelope.alg,
-                to_device_public_key: envelope.toDevicePublicKey,
-                from_ephemeral_public_key: envelope.fromEphemeralPublicKey,
-                nonce_b64: envelope.nonceB64,
-                ciphertext_b64: envelope.ciphertextB64,
-                created_at: envelope.createdAtIso,
-                expires_at: envelope.expiresAtIso,
-                meta: envelope.meta,
-                aad_b64: envelope.aadB64,
-                sender_kid: envelope.senderKid,
-                signature_b64: envelope.signatureB64,
-        };
+	return {
+		id: envelope.id,
+		version: envelope.version,
+		alg: envelope.alg,
+		to_device_public_key: envelope.toDevicePublicKey,
+		from_ephemeral_public_key: envelope.fromEphemeralPublicKey,
+		nonce_b64: envelope.nonceB64,
+		ciphertext_b64: envelope.ciphertextB64,
+		created_at: envelope.createdAtIso,
+		expires_at: envelope.expiresAtIso,
+		meta: envelope.meta,
+		aad_b64: envelope.aadB64,
+		sender_kid: envelope.senderKid,
+		signature_b64: envelope.signatureB64,
+	};
 }

--- a/src/types/api/crypto.ts
+++ b/src/types/api/crypto.ts
@@ -1,0 +1,138 @@
+import type { EncryptedEnvelope, OneTimePrekey, SignedPrekey } from '@/crypto';
+
+export type SignedPrekeyJson = {
+        id: string;
+        public_key: string;
+        signature_from_signing_key: string;
+        signer_kid?: string;
+        created_at: string;
+        expires_at?: string;
+        revoked?: boolean;
+};
+
+export type OneTimePrekeyJson = {
+        id: string;
+        public_key: string;
+        created_at: string;
+        consumed_at?: string;
+        consumed_by?: string;
+        expires_at?: string;
+        revoked?: boolean;
+};
+
+export type DevicePrekeyBundleJson = {
+        signed_prekey: SignedPrekeyJson | null;
+        one_time_prekeys: OneTimePrekeyJson[];
+};
+
+export type DevicePrekeyBundle = {
+        signedPrekey: SignedPrekey | null;
+        oneTimePrekeys: OneTimePrekey[];
+};
+
+export type EncryptedEnvelopeJson = {
+        id: string;
+        version: string;
+        alg?: string;
+        to_device_public_key: string;
+        from_ephemeral_public_key: string;
+        nonce_b64: string;
+        ciphertext_b64: string;
+        created_at: string;
+        expires_at?: string;
+        meta?: Record<string, string>;
+        aad_b64?: string;
+        sender_kid?: string;
+        signature_b64?: string;
+};
+
+export function signedPrekeyFromJSON(json: SignedPrekeyJson): SignedPrekey {
+        return {
+                id: json.id,
+                publicKey: json.public_key,
+                signatureFromSigningKey: json.signature_from_signing_key,
+                signerKid: json.signer_kid,
+                createdAtIso: json.created_at,
+                expiresAtIso: json.expires_at,
+                revoked: json.revoked ?? false,
+        };
+}
+
+export function signedPrekeyToJSON(prekey: SignedPrekey): SignedPrekeyJson {
+        return {
+                id: prekey.id,
+                public_key: prekey.publicKey,
+                signature_from_signing_key: prekey.signatureFromSigningKey,
+                signer_kid: prekey.signerKid,
+                created_at: prekey.createdAtIso,
+                expires_at: prekey.expiresAtIso,
+                revoked: prekey.revoked,
+        };
+}
+
+export function oneTimePrekeyFromJSON(json: OneTimePrekeyJson): OneTimePrekey {
+        return {
+                id: json.id,
+                publicKey: json.public_key,
+                createdAtIso: json.created_at,
+                consumedAtIso: json.consumed_at,
+                consumedBy: json.consumed_by,
+                expiresAtIso: json.expires_at,
+                revoked: json.revoked,
+        };
+}
+
+export function oneTimePrekeyToJSON(prekey: OneTimePrekey): OneTimePrekeyJson {
+        return {
+                id: prekey.id,
+                public_key: prekey.publicKey,
+                created_at: prekey.createdAtIso,
+                consumed_at: prekey.consumedAtIso,
+                consumed_by: prekey.consumedBy,
+                expires_at: prekey.expiresAtIso,
+                revoked: prekey.revoked,
+        };
+}
+
+export function devicePrekeyBundleFromJSON(json: DevicePrekeyBundleJson): DevicePrekeyBundle {
+        return {
+                signedPrekey: json.signed_prekey ? signedPrekeyFromJSON(json.signed_prekey) : null,
+                oneTimePrekeys: json.one_time_prekeys.map(oneTimePrekeyFromJSON),
+        };
+}
+
+export function encryptedEnvelopeFromJSON(json: EncryptedEnvelopeJson): EncryptedEnvelope {
+        return {
+                id: json.id,
+                version: json.version,
+                alg: json.alg,
+                toDevicePublicKey: json.to_device_public_key,
+                fromEphemeralPublicKey: json.from_ephemeral_public_key,
+                nonceB64: json.nonce_b64,
+                ciphertextB64: json.ciphertext_b64,
+                createdAtIso: json.created_at,
+                expiresAtIso: json.expires_at,
+                meta: json.meta,
+                aadB64: json.aad_b64,
+                senderKid: json.sender_kid,
+                signatureB64: json.signature_b64,
+        };
+}
+
+export function encryptedEnvelopeToJSON(envelope: EncryptedEnvelope): EncryptedEnvelopeJson {
+        return {
+                id: envelope.id,
+                version: envelope.version,
+                alg: envelope.alg,
+                to_device_public_key: envelope.toDevicePublicKey,
+                from_ephemeral_public_key: envelope.fromEphemeralPublicKey,
+                nonce_b64: envelope.nonceB64,
+                ciphertext_b64: envelope.ciphertextB64,
+                created_at: envelope.createdAtIso,
+                expires_at: envelope.expiresAtIso,
+                meta: envelope.meta,
+                aad_b64: envelope.aadB64,
+                sender_kid: envelope.senderKid,
+                signature_b64: envelope.signatureB64,
+        };
+}

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,3 +1,4 @@
 export * from './organization.js';
 export * from './project.js';
 export * from './environment.js';
+export * from './crypto.js';

--- a/test/crypto/hkdf.test.ts
+++ b/test/crypto/hkdf.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+        deriveEnvKEK,
+        deriveHKDF,
+        deriveOrgKEK,
+        deriveProjKEK,
+        deriveVarDEK,
+} from '../../src/crypto/derive/hkdf.js';
+
+const ROOT = Uint8Array.from(Array.from({ length: 32 }, (_, i) => i));
+const SALT = new Uint8Array(32).fill(1);
+
+const toHex = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex');
+
+describe('HKDF utilities', () => {
+        it('derives deterministic output for given inputs', () => {
+                const derived = deriveHKDF(ROOT, 'ghostable:test', SALT, 32);
+                expect(toHex(derived)).toBe('b0e4680633855c8a1a61c97a0c758ceb1317f69ae82bcc2b298239297b367cd8');
+        });
+
+        it('enforces input validation rules', () => {
+                expect(() => deriveHKDF(ROOT, '', SALT)).toThrow(TypeError);
+                expect(() => deriveHKDF(ROOT, 'info', SALT, 0)).toThrow(RangeError);
+        });
+
+        it('uses context strings to domain-separate derived keys', () => {
+                const org = deriveOrgKEK(ROOT, 'org-123');
+                const proj = deriveProjKEK(org, 'proj-456');
+                const env = deriveEnvKEK(proj, 'production');
+                const dekV1 = deriveVarDEK(env, 'API_KEY', 1);
+                const dekV2 = deriveVarDEK(env, 'API_KEY', 2);
+
+                expect(toHex(org)).toBe('aa69c02ba044136ac5b4e3bbec26dcda1287e51fdfe5480959cc3b6c78281bf4');
+                expect(toHex(proj)).toBe('7a58d432f259c900d84503274b312424acdd7b014c6756660bf7190f0cf2a338');
+                expect(toHex(env)).toBe('20bfa2bb725d91864b4bb4da4a7afcdddc2688cdc44f32a3f81e2d913069ad1d');
+                expect(toHex(dekV2)).toBe('5c56d4c430926fb3762c69280e16e09dd0344f9927472a775219052707a750fc');
+                expect(toHex(dekV1)).not.toBe(toHex(dekV2));
+        });
+});

--- a/test/crypto/hkdf.test.ts
+++ b/test/crypto/hkdf.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-        deriveEnvKEK,
-        deriveHKDF,
-        deriveOrgKEK,
-        deriveProjKEK,
-        deriveVarDEK,
+	deriveEnvKEK,
+	deriveHKDF,
+	deriveOrgKEK,
+	deriveProjKEK,
+	deriveVarDEK,
 } from '../../src/crypto/derive/hkdf.js';
 
 const ROOT = Uint8Array.from(Array.from({ length: 32 }, (_, i) => i));
@@ -14,27 +14,33 @@ const SALT = new Uint8Array(32).fill(1);
 const toHex = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex');
 
 describe('HKDF utilities', () => {
-        it('derives deterministic output for given inputs', () => {
-                const derived = deriveHKDF(ROOT, 'ghostable:test', SALT, 32);
-                expect(toHex(derived)).toBe('b0e4680633855c8a1a61c97a0c758ceb1317f69ae82bcc2b298239297b367cd8');
-        });
+	it('derives deterministic output for given inputs', () => {
+		const derived = deriveHKDF(ROOT, 'ghostable:test', SALT, 32);
+		expect(toHex(derived)).toBe(
+			'b0e4680633855c8a1a61c97a0c758ceb1317f69ae82bcc2b298239297b367cd8',
+		);
+	});
 
-        it('enforces input validation rules', () => {
-                expect(() => deriveHKDF(ROOT, '', SALT)).toThrow(TypeError);
-                expect(() => deriveHKDF(ROOT, 'info', SALT, 0)).toThrow(RangeError);
-        });
+	it('enforces input validation rules', () => {
+		expect(() => deriveHKDF(ROOT, '', SALT)).toThrow(TypeError);
+		expect(() => deriveHKDF(ROOT, 'info', SALT, 0)).toThrow(RangeError);
+	});
 
-        it('uses context strings to domain-separate derived keys', () => {
-                const org = deriveOrgKEK(ROOT, 'org-123');
-                const proj = deriveProjKEK(org, 'proj-456');
-                const env = deriveEnvKEK(proj, 'production');
-                const dekV1 = deriveVarDEK(env, 'API_KEY', 1);
-                const dekV2 = deriveVarDEK(env, 'API_KEY', 2);
+	it('uses context strings to domain-separate derived keys', () => {
+		const org = deriveOrgKEK(ROOT, 'org-123');
+		const proj = deriveProjKEK(org, 'proj-456');
+		const env = deriveEnvKEK(proj, 'production');
+		const dekV1 = deriveVarDEK(env, 'API_KEY', 1);
+		const dekV2 = deriveVarDEK(env, 'API_KEY', 2);
 
-                expect(toHex(org)).toBe('aa69c02ba044136ac5b4e3bbec26dcda1287e51fdfe5480959cc3b6c78281bf4');
-                expect(toHex(proj)).toBe('7a58d432f259c900d84503274b312424acdd7b014c6756660bf7190f0cf2a338');
-                expect(toHex(env)).toBe('20bfa2bb725d91864b4bb4da4a7afcdddc2688cdc44f32a3f81e2d913069ad1d');
-                expect(toHex(dekV2)).toBe('5c56d4c430926fb3762c69280e16e09dd0344f9927472a775219052707a750fc');
-                expect(toHex(dekV1)).not.toBe(toHex(dekV2));
-        });
+		expect(toHex(org)).toBe('aa69c02ba044136ac5b4e3bbec26dcda1287e51fdfe5480959cc3b6c78281bf4');
+		expect(toHex(proj)).toBe(
+			'7a58d432f259c900d84503274b312424acdd7b014c6756660bf7190f0cf2a338',
+		);
+		expect(toHex(env)).toBe('20bfa2bb725d91864b4bb4da4a7afcdddc2688cdc44f32a3f81e2d913069ad1d');
+		expect(toHex(dekV2)).toBe(
+			'5c56d4c430926fb3762c69280e16e09dd0344f9927472a775219052707a750fc',
+		);
+		expect(toHex(dekV1)).not.toBe(toHex(dekV2));
+	});
 });

--- a/test/crypto/key-service.test.ts
+++ b/test/crypto/key-service.test.ts
@@ -1,0 +1,170 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type X25519Mock = {
+        generateKeyPair: ReturnType<typeof vi.fn<() => { publicKey: Uint8Array; secretKey: Uint8Array }>>;
+        sharedKey: ReturnType<typeof vi.fn<(secret: Uint8Array, pub: Uint8Array) => Uint8Array>>;
+        __reset: () => void;
+};
+
+type Ed25519Mock = {
+        utils: {
+                randomPrivateKey: ReturnType<typeof vi.fn<() => Uint8Array>>;
+        };
+        getPublicKey: ReturnType<typeof vi.fn<(priv: Uint8Array) => Promise<Uint8Array>>>;
+        sign: ReturnType<typeof vi.fn<(msg: Uint8Array, priv: Uint8Array) => Promise<Uint8Array>>>;
+        verify: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
+        __reset: () => void;
+};
+
+type KeytarMock = {
+        getPassword: ReturnType<typeof vi.fn<(service: string, account: string) => Promise<string | null>>>;
+        setPassword: ReturnType<
+                typeof vi.fn<(service: string, account: string, password: string) => Promise<void>>
+        >;
+        deletePassword: ReturnType<typeof vi.fn<(service: string, account: string) => Promise<boolean>>>;
+};
+
+const x25519Stub = vi.hoisted(() => {
+        let counter = 0;
+        return {
+                generateKeyPair: vi.fn(() => {
+                        const base = counter++;
+                        return {
+                                publicKey: new Uint8Array(32).fill(base + 1),
+                                secretKey: new Uint8Array(32).fill(base + 2),
+                        };
+                }),
+                sharedKey: vi.fn(() => new Uint8Array(32).fill(7)),
+                __reset: () => {
+                        counter = 0;
+                },
+        } satisfies X25519Mock;
+}) as X25519Mock;
+
+const ed25519Stub = vi.hoisted(() => {
+        let counter = 0;
+        return {
+                utils: {
+                        randomPrivateKey: vi.fn(() => new Uint8Array(32).fill(++counter)),
+                },
+                getPublicKey: vi.fn(async (priv: Uint8Array) => Uint8Array.from(priv, (v) => v ^ 0xff)),
+                sign: vi.fn(async (_msg: Uint8Array, priv: Uint8Array) => {
+                        const signature = new Uint8Array(64);
+                        signature.set(priv.slice(0, 32), 0);
+                        signature.set(priv.slice(0, 32), 32);
+                        return signature;
+                }),
+                verify: vi.fn(async () => true),
+                __reset: () => {
+                        counter = 0;
+                },
+        } satisfies Ed25519Mock;
+}) as Ed25519Mock;
+
+vi.mock('@stablelib/x25519', () => x25519Stub);
+vi.mock('@noble/ed25519', () => ed25519Stub);
+
+const keytarStub = vi.hoisted(() => ({
+        getPassword: vi.fn(async () => null),
+        setPassword: vi.fn(async () => {}),
+        deletePassword: vi.fn(async () => true),
+})) as KeytarMock;
+
+vi.mock('keytar', () => keytarStub);
+
+const uuidStub = vi.hoisted(() => {
+        let counter = 0;
+        return {
+                v4: vi.fn(() => `uuid-${++counter}`),
+        };
+}) as { v4: ReturnType<typeof vi.fn<() => string>> };
+
+vi.mock('uuid', () => uuidStub);
+
+type KeyServiceModule = typeof import('../../src/crypto/KeyService.js');
+type KeyStoreModule = typeof import('../../src/crypto/KeyStore.js');
+
+let KeyService: KeyServiceModule['KeyService'];
+let MemoryKeyStore: KeyStoreModule['MemoryKeyStore'];
+
+beforeAll(async () => {
+        ({ KeyService } = await import('../../src/crypto/KeyService.js'));
+        ({ MemoryKeyStore } = await import('../../src/crypto/KeyStore.js'));
+});
+
+const toHex = (value: Uint8Array | null) => (value ? Buffer.from(value).toString('hex') : null);
+
+describe('KeyService', () => {
+        let store: MemoryKeyStore;
+
+        beforeEach(() => {
+                store = new MemoryKeyStore();
+                KeyService.initialize(store);
+                x25519Stub.__reset();
+                ed25519Stub.__reset();
+        });
+
+        it('creates device identities and persists private keys', async () => {
+                const identity = await KeyService.createDeviceIdentity('CLI', 'linux');
+
+                const signing = await store.getKey(`device:${identity.deviceId}:signingKey`);
+                const encryption = await store.getKey(`device:${identity.deviceId}:encryptionKey`);
+
+                expect(signing).not.toBeNull();
+                expect(encryption).not.toBeNull();
+                expect(Buffer.from(signing!).toString('base64')).toBe(identity.signingKey.privateKey);
+                expect(Buffer.from(encryption!).toString('base64')).toBe(identity.encryptionKey.privateKey);
+        });
+
+        it('creates signed prekeys with expirations and stores private material', async () => {
+                const identity = await KeyService.createDeviceIdentity();
+                const prekey = await KeyService.createSignedPrekey(identity);
+
+                expect(prekey.expiresAtIso).toBeDefined();
+                const stored = await store.getKey(`signedPrekey:${prekey.id}`);
+                expect(stored).not.toBeNull();
+                expect(Buffer.from(stored!).toString('base64')).toBe(prekey.privateKey);
+        });
+
+        it('does not rotate signed prekeys before expiry', async () => {
+                const identity = await KeyService.createDeviceIdentity();
+                const prekey = await KeyService.createSignedPrekey(identity);
+
+                const future = new Date(Date.parse(prekey.expiresAtIso ?? '') - 1000);
+                const { active, rotated } = await KeyService.rotateSignedPrekeyIfExpired(identity, prekey, future);
+
+                expect(rotated).toBe(false);
+                expect(active).toBe(prekey);
+        });
+
+        it('rotates signed prekeys that have expired', async () => {
+                const identity = await KeyService.createDeviceIdentity();
+                const prekey = await KeyService.createSignedPrekey(identity);
+                prekey.expiresAtIso = new Date(Date.now() - 1000).toISOString();
+
+                const { active, rotated, retired } = await KeyService.rotateSignedPrekeyIfExpired(
+                        identity,
+                        prekey,
+                        new Date(),
+                );
+
+                expect(rotated).toBe(true);
+                expect(active.id).not.toBe(prekey.id);
+                expect(retired?.revoked).toBe(true);
+                const stored = await store.getKey(`signedPrekey:${active.id}`);
+                expect(stored).not.toBeNull();
+        });
+
+        it('scrubs private keys for consumed one-time prekeys', async () => {
+                const [prekey] = await KeyService.createOneTimePrekeys(1);
+                const storedBefore = await store.getKey(`oneTimePrekey:${prekey.id}`);
+                expect(toHex(storedBefore)).not.toBeNull();
+
+                const consumed = { ...prekey, consumedAtIso: new Date().toISOString() };
+                const sanitized = await KeyService.scrubConsumedOneTimePrekeys([consumed]);
+                expect(sanitized[0].privateKey).toBeUndefined();
+
+                const storedAfter = await store.getKey(`oneTimePrekey:${prekey.id}`);
+                expect(storedAfter).toBeNull();
+        });
+});

--- a/test/crypto/key-service.test.ts
+++ b/test/crypto/key-service.test.ts
@@ -1,82 +1,88 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type X25519Mock = {
-        generateKeyPair: ReturnType<typeof vi.fn<() => { publicKey: Uint8Array; secretKey: Uint8Array }>>;
-        sharedKey: ReturnType<typeof vi.fn<(secret: Uint8Array, pub: Uint8Array) => Uint8Array>>;
-        __reset: () => void;
+	generateKeyPair: ReturnType<
+		typeof vi.fn<() => { publicKey: Uint8Array; secretKey: Uint8Array }>
+	>;
+	sharedKey: ReturnType<typeof vi.fn<(secret: Uint8Array, pub: Uint8Array) => Uint8Array>>;
+	__reset: () => void;
 };
 
 type Ed25519Mock = {
-        utils: {
-                randomPrivateKey: ReturnType<typeof vi.fn<() => Uint8Array>>;
-        };
-        getPublicKey: ReturnType<typeof vi.fn<(priv: Uint8Array) => Promise<Uint8Array>>>;
-        sign: ReturnType<typeof vi.fn<(msg: Uint8Array, priv: Uint8Array) => Promise<Uint8Array>>>;
-        verify: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
-        __reset: () => void;
+	utils: {
+		randomPrivateKey: ReturnType<typeof vi.fn<() => Uint8Array>>;
+	};
+	getPublicKey: ReturnType<typeof vi.fn<(priv: Uint8Array) => Promise<Uint8Array>>>;
+	sign: ReturnType<typeof vi.fn<(msg: Uint8Array, priv: Uint8Array) => Promise<Uint8Array>>>;
+	verify: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
+	__reset: () => void;
 };
 
 type KeytarMock = {
-        getPassword: ReturnType<typeof vi.fn<(service: string, account: string) => Promise<string | null>>>;
-        setPassword: ReturnType<
-                typeof vi.fn<(service: string, account: string, password: string) => Promise<void>>
-        >;
-        deletePassword: ReturnType<typeof vi.fn<(service: string, account: string) => Promise<boolean>>>;
+	getPassword: ReturnType<
+		typeof vi.fn<(service: string, account: string) => Promise<string | null>>
+	>;
+	setPassword: ReturnType<
+		typeof vi.fn<(service: string, account: string, password: string) => Promise<void>>
+	>;
+	deletePassword: ReturnType<
+		typeof vi.fn<(service: string, account: string) => Promise<boolean>>
+	>;
 };
 
 const x25519Stub = vi.hoisted(() => {
-        let counter = 0;
-        return {
-                generateKeyPair: vi.fn(() => {
-                        const base = counter++;
-                        return {
-                                publicKey: new Uint8Array(32).fill(base + 1),
-                                secretKey: new Uint8Array(32).fill(base + 2),
-                        };
-                }),
-                sharedKey: vi.fn(() => new Uint8Array(32).fill(7)),
-                __reset: () => {
-                        counter = 0;
-                },
-        } satisfies X25519Mock;
+	let counter = 0;
+	return {
+		generateKeyPair: vi.fn(() => {
+			const base = counter++;
+			return {
+				publicKey: new Uint8Array(32).fill(base + 1),
+				secretKey: new Uint8Array(32).fill(base + 2),
+			};
+		}),
+		sharedKey: vi.fn(() => new Uint8Array(32).fill(7)),
+		__reset: () => {
+			counter = 0;
+		},
+	} satisfies X25519Mock;
 }) as X25519Mock;
 
 const ed25519Stub = vi.hoisted(() => {
-        let counter = 0;
-        return {
-                utils: {
-                        randomPrivateKey: vi.fn(() => new Uint8Array(32).fill(++counter)),
-                },
-                getPublicKey: vi.fn(async (priv: Uint8Array) => Uint8Array.from(priv, (v) => v ^ 0xff)),
-                sign: vi.fn(async (_msg: Uint8Array, priv: Uint8Array) => {
-                        const signature = new Uint8Array(64);
-                        signature.set(priv.slice(0, 32), 0);
-                        signature.set(priv.slice(0, 32), 32);
-                        return signature;
-                }),
-                verify: vi.fn(async () => true),
-                __reset: () => {
-                        counter = 0;
-                },
-        } satisfies Ed25519Mock;
+	let counter = 0;
+	return {
+		utils: {
+			randomPrivateKey: vi.fn(() => new Uint8Array(32).fill(++counter)),
+		},
+		getPublicKey: vi.fn(async (priv: Uint8Array) => Uint8Array.from(priv, (v) => v ^ 0xff)),
+		sign: vi.fn(async (_msg: Uint8Array, priv: Uint8Array) => {
+			const signature = new Uint8Array(64);
+			signature.set(priv.slice(0, 32), 0);
+			signature.set(priv.slice(0, 32), 32);
+			return signature;
+		}),
+		verify: vi.fn(async () => true),
+		__reset: () => {
+			counter = 0;
+		},
+	} satisfies Ed25519Mock;
 }) as Ed25519Mock;
 
 vi.mock('@stablelib/x25519', () => x25519Stub);
 vi.mock('@noble/ed25519', () => ed25519Stub);
 
 const keytarStub = vi.hoisted(() => ({
-        getPassword: vi.fn(async () => null),
-        setPassword: vi.fn(async () => {}),
-        deletePassword: vi.fn(async () => true),
+	getPassword: vi.fn(async () => null),
+	setPassword: vi.fn(async () => {}),
+	deletePassword: vi.fn(async () => true),
 })) as KeytarMock;
 
 vi.mock('keytar', () => keytarStub);
 
 const uuidStub = vi.hoisted(() => {
-        let counter = 0;
-        return {
-                v4: vi.fn(() => `uuid-${++counter}`),
-        };
+	let counter = 0;
+	return {
+		v4: vi.fn(() => `uuid-${++counter}`),
+	};
 }) as { v4: ReturnType<typeof vi.fn<() => string>> };
 
 vi.mock('uuid', () => uuidStub);
@@ -88,83 +94,87 @@ let KeyService: KeyServiceModule['KeyService'];
 let MemoryKeyStore: KeyStoreModule['MemoryKeyStore'];
 
 beforeAll(async () => {
-        ({ KeyService } = await import('../../src/crypto/KeyService.js'));
-        ({ MemoryKeyStore } = await import('../../src/crypto/KeyStore.js'));
+	({ KeyService } = await import('../../src/crypto/KeyService.js'));
+	({ MemoryKeyStore } = await import('../../src/crypto/KeyStore.js'));
 });
 
 const toHex = (value: Uint8Array | null) => (value ? Buffer.from(value).toString('hex') : null);
 
 describe('KeyService', () => {
-        let store: MemoryKeyStore;
+	let store: MemoryKeyStore;
 
-        beforeEach(() => {
-                store = new MemoryKeyStore();
-                KeyService.initialize(store);
-                x25519Stub.__reset();
-                ed25519Stub.__reset();
-        });
+	beforeEach(() => {
+		store = new MemoryKeyStore();
+		KeyService.initialize(store);
+		x25519Stub.__reset();
+		ed25519Stub.__reset();
+	});
 
-        it('creates device identities and persists private keys', async () => {
-                const identity = await KeyService.createDeviceIdentity('CLI', 'linux');
+	it('creates device identities and persists private keys', async () => {
+		const identity = await KeyService.createDeviceIdentity('CLI', 'linux');
 
-                const signing = await store.getKey(`device:${identity.deviceId}:signingKey`);
-                const encryption = await store.getKey(`device:${identity.deviceId}:encryptionKey`);
+		const signing = await store.getKey(`device:${identity.deviceId}:signingKey`);
+		const encryption = await store.getKey(`device:${identity.deviceId}:encryptionKey`);
 
-                expect(signing).not.toBeNull();
-                expect(encryption).not.toBeNull();
-                expect(Buffer.from(signing!).toString('base64')).toBe(identity.signingKey.privateKey);
-                expect(Buffer.from(encryption!).toString('base64')).toBe(identity.encryptionKey.privateKey);
-        });
+		expect(signing).not.toBeNull();
+		expect(encryption).not.toBeNull();
+		expect(Buffer.from(signing!).toString('base64')).toBe(identity.signingKey.privateKey);
+		expect(Buffer.from(encryption!).toString('base64')).toBe(identity.encryptionKey.privateKey);
+	});
 
-        it('creates signed prekeys with expirations and stores private material', async () => {
-                const identity = await KeyService.createDeviceIdentity();
-                const prekey = await KeyService.createSignedPrekey(identity);
+	it('creates signed prekeys with expirations and stores private material', async () => {
+		const identity = await KeyService.createDeviceIdentity();
+		const prekey = await KeyService.createSignedPrekey(identity);
 
-                expect(prekey.expiresAtIso).toBeDefined();
-                const stored = await store.getKey(`signedPrekey:${prekey.id}`);
-                expect(stored).not.toBeNull();
-                expect(Buffer.from(stored!).toString('base64')).toBe(prekey.privateKey);
-        });
+		expect(prekey.expiresAtIso).toBeDefined();
+		const stored = await store.getKey(`signedPrekey:${prekey.id}`);
+		expect(stored).not.toBeNull();
+		expect(Buffer.from(stored!).toString('base64')).toBe(prekey.privateKey);
+	});
 
-        it('does not rotate signed prekeys before expiry', async () => {
-                const identity = await KeyService.createDeviceIdentity();
-                const prekey = await KeyService.createSignedPrekey(identity);
+	it('does not rotate signed prekeys before expiry', async () => {
+		const identity = await KeyService.createDeviceIdentity();
+		const prekey = await KeyService.createSignedPrekey(identity);
 
-                const future = new Date(Date.parse(prekey.expiresAtIso ?? '') - 1000);
-                const { active, rotated } = await KeyService.rotateSignedPrekeyIfExpired(identity, prekey, future);
+		const future = new Date(Date.parse(prekey.expiresAtIso ?? '') - 1000);
+		const { active, rotated } = await KeyService.rotateSignedPrekeyIfExpired(
+			identity,
+			prekey,
+			future,
+		);
 
-                expect(rotated).toBe(false);
-                expect(active).toBe(prekey);
-        });
+		expect(rotated).toBe(false);
+		expect(active).toBe(prekey);
+	});
 
-        it('rotates signed prekeys that have expired', async () => {
-                const identity = await KeyService.createDeviceIdentity();
-                const prekey = await KeyService.createSignedPrekey(identity);
-                prekey.expiresAtIso = new Date(Date.now() - 1000).toISOString();
+	it('rotates signed prekeys that have expired', async () => {
+		const identity = await KeyService.createDeviceIdentity();
+		const prekey = await KeyService.createSignedPrekey(identity);
+		prekey.expiresAtIso = new Date(Date.now() - 1000).toISOString();
 
-                const { active, rotated, retired } = await KeyService.rotateSignedPrekeyIfExpired(
-                        identity,
-                        prekey,
-                        new Date(),
-                );
+		const { active, rotated, retired } = await KeyService.rotateSignedPrekeyIfExpired(
+			identity,
+			prekey,
+			new Date(),
+		);
 
-                expect(rotated).toBe(true);
-                expect(active.id).not.toBe(prekey.id);
-                expect(retired?.revoked).toBe(true);
-                const stored = await store.getKey(`signedPrekey:${active.id}`);
-                expect(stored).not.toBeNull();
-        });
+		expect(rotated).toBe(true);
+		expect(active.id).not.toBe(prekey.id);
+		expect(retired?.revoked).toBe(true);
+		const stored = await store.getKey(`signedPrekey:${active.id}`);
+		expect(stored).not.toBeNull();
+	});
 
-        it('scrubs private keys for consumed one-time prekeys', async () => {
-                const [prekey] = await KeyService.createOneTimePrekeys(1);
-                const storedBefore = await store.getKey(`oneTimePrekey:${prekey.id}`);
-                expect(toHex(storedBefore)).not.toBeNull();
+	it('scrubs private keys for consumed one-time prekeys', async () => {
+		const [prekey] = await KeyService.createOneTimePrekeys(1);
+		const storedBefore = await store.getKey(`oneTimePrekey:${prekey.id}`);
+		expect(toHex(storedBefore)).not.toBeNull();
 
-                const consumed = { ...prekey, consumedAtIso: new Date().toISOString() };
-                const sanitized = await KeyService.scrubConsumedOneTimePrekeys([consumed]);
-                expect(sanitized[0].privateKey).toBeUndefined();
+		const consumed = { ...prekey, consumedAtIso: new Date().toISOString() };
+		const sanitized = await KeyService.scrubConsumedOneTimePrekeys([consumed]);
+		expect(sanitized[0].privateKey).toBeUndefined();
 
-                const storedAfter = await store.getKey(`oneTimePrekey:${prekey.id}`);
-                expect(storedAfter).toBeNull();
-        });
+		const storedAfter = await store.getKey(`oneTimePrekey:${prekey.id}`);
+		expect(storedAfter).toBeNull();
+	});
 });

--- a/test/crypto/key-store.test.ts
+++ b/test/crypto/key-store.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type KeytarMock = {
+        getPassword: ReturnType<
+                typeof vi.fn<(service: string, account: string) => Promise<string | null>>
+        >;
+        setPassword: ReturnType<
+                typeof vi.fn<(service: string, account: string, password: string) => Promise<void>>
+        >;
+        deletePassword: ReturnType<
+                typeof vi.fn<(service: string, account: string) => Promise<boolean>>
+        >;
+};
+
+const keytarStub = vi.hoisted(() => ({
+        getPassword: vi.fn<(service: string, account: string) => Promise<string | null>>(),
+        setPassword: vi.fn<(service: string, account: string, password: string) => Promise<void>>(),
+        deletePassword: vi.fn<(service: string, account: string) => Promise<boolean>>(),
+})) as KeytarMock;
+
+vi.mock('keytar', () => ({
+        default: keytarStub,
+}));
+
+import { KeytarKeyStore, MemoryKeyStore } from '../../src/crypto/KeyStore.js';
+
+const SAMPLE_KEY = new Uint8Array([1, 2, 3, 4]);
+const SAMPLE_B64 = 'AQIDBA==';
+
+describe('MemoryKeyStore', () => {
+        let store: MemoryKeyStore;
+
+        beforeEach(() => {
+                store = new MemoryKeyStore();
+        });
+
+        it('stores and retrieves values as Base64', async () => {
+                await store.setKey('example', SAMPLE_KEY);
+                expect(await store.getKey('example')).toEqual(SAMPLE_KEY);
+        });
+
+        it('deletes keys', async () => {
+                await store.setKey('temp', SAMPLE_KEY);
+                await store.deleteKey('temp');
+                expect(await store.getKey('temp')).toBeNull();
+        });
+
+        it('validates input arguments', async () => {
+                await expect(store.getKey('')).rejects.toThrow(TypeError);
+                await expect(store.setKey('name', 'bad' as unknown as Uint8Array)).rejects.toThrow(
+                        TypeError,
+                );
+        });
+});
+
+describe('KeytarKeyStore', () => {
+        beforeEach(() => {
+                keytarStub.getPassword.mockReset();
+                keytarStub.setPassword.mockReset();
+                keytarStub.deletePassword.mockReset();
+                keytarStub.setPassword.mockResolvedValue();
+                keytarStub.getPassword.mockResolvedValue(null);
+                keytarStub.deletePassword.mockResolvedValue(true);
+        });
+
+        it('uses the OS keychain to store and retrieve Base64 values', async () => {
+                const store = new KeytarKeyStore();
+                keytarStub.getPassword.mockResolvedValueOnce(SAMPLE_B64);
+
+                await store.setKey('example', SAMPLE_KEY);
+                expect(keytarStub.setPassword).toHaveBeenCalledWith('ghostable-cli', 'example', SAMPLE_B64);
+
+                const value = await store.getKey('example');
+                expect(value).toEqual(SAMPLE_KEY);
+                expect(keytarStub.getPassword).toHaveBeenCalledWith('ghostable-cli', 'example');
+        });
+
+        it('supports custom service names', async () => {
+                const store = new KeytarKeyStore('custom-service');
+                await store.setKey('example', SAMPLE_KEY);
+                expect(keytarStub.setPassword).toHaveBeenCalledWith('custom-service', 'example', SAMPLE_B64);
+        });
+
+        it('validates input arguments', async () => {
+                const store = new KeytarKeyStore();
+                await expect(store.getKey('')).rejects.toThrow(TypeError);
+                await expect(store.setKey('', SAMPLE_KEY)).rejects.toThrow(TypeError);
+                await expect(store.deleteKey('')).rejects.toThrow(TypeError);
+        });
+});

--- a/test/crypto/key-store.test.ts
+++ b/test/crypto/key-store.test.ts
@@ -1,25 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 type KeytarMock = {
-        getPassword: ReturnType<
-                typeof vi.fn<(service: string, account: string) => Promise<string | null>>
-        >;
-        setPassword: ReturnType<
-                typeof vi.fn<(service: string, account: string, password: string) => Promise<void>>
-        >;
-        deletePassword: ReturnType<
-                typeof vi.fn<(service: string, account: string) => Promise<boolean>>
-        >;
+	getPassword: ReturnType<
+		typeof vi.fn<(service: string, account: string) => Promise<string | null>>
+	>;
+	setPassword: ReturnType<
+		typeof vi.fn<(service: string, account: string, password: string) => Promise<void>>
+	>;
+	deletePassword: ReturnType<
+		typeof vi.fn<(service: string, account: string) => Promise<boolean>>
+	>;
 };
 
 const keytarStub = vi.hoisted(() => ({
-        getPassword: vi.fn<(service: string, account: string) => Promise<string | null>>(),
-        setPassword: vi.fn<(service: string, account: string, password: string) => Promise<void>>(),
-        deletePassword: vi.fn<(service: string, account: string) => Promise<boolean>>(),
+	getPassword: vi.fn<(service: string, account: string) => Promise<string | null>>(),
+	setPassword: vi.fn<(service: string, account: string, password: string) => Promise<void>>(),
+	deletePassword: vi.fn<(service: string, account: string) => Promise<boolean>>(),
 })) as KeytarMock;
 
 vi.mock('keytar', () => ({
-        default: keytarStub,
+	default: keytarStub,
 }));
 
 import { KeytarKeyStore, MemoryKeyStore } from '../../src/crypto/KeyStore.js';
@@ -28,63 +28,67 @@ const SAMPLE_KEY = new Uint8Array([1, 2, 3, 4]);
 const SAMPLE_B64 = 'AQIDBA==';
 
 describe('MemoryKeyStore', () => {
-        let store: MemoryKeyStore;
+	let store: MemoryKeyStore;
 
-        beforeEach(() => {
-                store = new MemoryKeyStore();
-        });
+	beforeEach(() => {
+		store = new MemoryKeyStore();
+	});
 
-        it('stores and retrieves values as Base64', async () => {
-                await store.setKey('example', SAMPLE_KEY);
-                expect(await store.getKey('example')).toEqual(SAMPLE_KEY);
-        });
+	it('stores and retrieves values as Base64', async () => {
+		await store.setKey('example', SAMPLE_KEY);
+		expect(await store.getKey('example')).toEqual(SAMPLE_KEY);
+	});
 
-        it('deletes keys', async () => {
-                await store.setKey('temp', SAMPLE_KEY);
-                await store.deleteKey('temp');
-                expect(await store.getKey('temp')).toBeNull();
-        });
+	it('deletes keys', async () => {
+		await store.setKey('temp', SAMPLE_KEY);
+		await store.deleteKey('temp');
+		expect(await store.getKey('temp')).toBeNull();
+	});
 
-        it('validates input arguments', async () => {
-                await expect(store.getKey('')).rejects.toThrow(TypeError);
-                await expect(store.setKey('name', 'bad' as unknown as Uint8Array)).rejects.toThrow(
-                        TypeError,
-                );
-        });
+	it('validates input arguments', async () => {
+		await expect(store.getKey('')).rejects.toThrow(TypeError);
+		await expect(store.setKey('name', 'bad' as unknown as Uint8Array)).rejects.toThrow(
+			TypeError,
+		);
+	});
 });
 
 describe('KeytarKeyStore', () => {
-        beforeEach(() => {
-                keytarStub.getPassword.mockReset();
-                keytarStub.setPassword.mockReset();
-                keytarStub.deletePassword.mockReset();
-                keytarStub.setPassword.mockResolvedValue();
-                keytarStub.getPassword.mockResolvedValue(null);
-                keytarStub.deletePassword.mockResolvedValue(true);
-        });
+	beforeEach(() => {
+		keytarStub.getPassword.mockReset();
+		keytarStub.setPassword.mockReset();
+		keytarStub.deletePassword.mockReset();
+		keytarStub.setPassword.mockResolvedValue();
+		keytarStub.getPassword.mockResolvedValue(null);
+		keytarStub.deletePassword.mockResolvedValue(true);
+	});
 
-        it('uses the OS keychain to store and retrieve Base64 values', async () => {
-                const store = new KeytarKeyStore();
-                keytarStub.getPassword.mockResolvedValueOnce(SAMPLE_B64);
+	it('uses the OS keychain to store and retrieve Base64 values', async () => {
+		const store = new KeytarKeyStore();
+		keytarStub.getPassword.mockResolvedValueOnce(SAMPLE_B64);
 
-                await store.setKey('example', SAMPLE_KEY);
-                expect(keytarStub.setPassword).toHaveBeenCalledWith('ghostable-cli', 'example', SAMPLE_B64);
+		await store.setKey('example', SAMPLE_KEY);
+		expect(keytarStub.setPassword).toHaveBeenCalledWith('ghostable-cli', 'example', SAMPLE_B64);
 
-                const value = await store.getKey('example');
-                expect(value).toEqual(SAMPLE_KEY);
-                expect(keytarStub.getPassword).toHaveBeenCalledWith('ghostable-cli', 'example');
-        });
+		const value = await store.getKey('example');
+		expect(value).toEqual(SAMPLE_KEY);
+		expect(keytarStub.getPassword).toHaveBeenCalledWith('ghostable-cli', 'example');
+	});
 
-        it('supports custom service names', async () => {
-                const store = new KeytarKeyStore('custom-service');
-                await store.setKey('example', SAMPLE_KEY);
-                expect(keytarStub.setPassword).toHaveBeenCalledWith('custom-service', 'example', SAMPLE_B64);
-        });
+	it('supports custom service names', async () => {
+		const store = new KeytarKeyStore('custom-service');
+		await store.setKey('example', SAMPLE_KEY);
+		expect(keytarStub.setPassword).toHaveBeenCalledWith(
+			'custom-service',
+			'example',
+			SAMPLE_B64,
+		);
+	});
 
-        it('validates input arguments', async () => {
-                const store = new KeytarKeyStore();
-                await expect(store.getKey('')).rejects.toThrow(TypeError);
-                await expect(store.setKey('', SAMPLE_KEY)).rejects.toThrow(TypeError);
-                await expect(store.deleteKey('')).rejects.toThrow(TypeError);
-        });
+	it('validates input arguments', async () => {
+		const store = new KeytarKeyStore();
+		await expect(store.getKey('')).rejects.toThrow(TypeError);
+		await expect(store.setKey('', SAMPLE_KEY)).rejects.toThrow(TypeError);
+		await expect(store.deleteKey('')).rejects.toThrow(TypeError);
+	});
 });


### PR DESCRIPTION
## Summary
- implement a keytar-backed key store and signed/one-time prekey maintenance logic
- add GhostableClient endpoints and type-safe mappers for prekeys and encrypted envelopes
- cover the crypto utilities with unit tests for key storage, key service, and HKDF derivations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbb77a28708333a86bbdf6eeff1d9d