### PR TITLE
Align device client with v2.2 API endpoints

### DIFF
--- a/src/crypto/types/OneTimePrekey.ts
+++ b/src/crypto/types/OneTimePrekey.ts
@@ -23,9 +23,12 @@ export type OneTimePrekey = {
 	// Device or session ID that consumed the prekey, set by server
 	consumedBy?: string;
 
-	// Optional expiration timestamp (ISO 8601)
-	expiresAtIso?: string;
+        // Optional expiration timestamp (ISO 8601)
+        expiresAtIso?: string;
 
-	// Whether the prekey is revoked
-	revoked?: boolean;
+        // Whether the prekey is revoked
+        revoked?: boolean;
+
+        // SHA-256 fingerprint (hex) derived from the public key
+        fingerprint?: string;
 };

--- a/src/crypto/types/SignedPrekey.ts
+++ b/src/crypto/types/SignedPrekey.ts
@@ -13,11 +13,14 @@ export type SignedPrekey = {
 	// X25519 private key (Base64), local-only
 	privateKey?: string;
 
-	// Ed25519 signature over the public key (Base64)
-	signatureFromSigningKey: string;
+        // Ed25519 signature over the public key (Base64)
+        signatureFromSigningKey: string;
 
-	// SHA-256 thumbprint (hex) of the signing public key
-	signerKid?: string;
+        // SHA-256 thumbprint (hex) of the signing public key
+        signerKid?: string;
+
+        // SHA-256 fingerprint (hex) derived from the public key
+        fingerprint?: string;
 
 	// Creation timestamp (ISO 8601)
 	createdAtIso: string;

--- a/src/domain/Device.ts
+++ b/src/domain/Device.ts
@@ -1,0 +1,28 @@
+import type { DeviceResourceJson } from '@/types';
+
+export type DeviceStatus = 'active' | 'revoked';
+
+export class Device {
+        constructor(
+                public readonly id: string,
+                public readonly publicKey: string,
+                public readonly platform: string,
+                public readonly status: DeviceStatus,
+                public readonly createdAt: Date,
+                public readonly lastSeenAt: Date | null,
+                public readonly revokedAt: Date | null,
+        ) {}
+
+        static fromResource(resource: DeviceResourceJson): Device {
+                const attrs = resource.attributes;
+                return new Device(
+                        resource.id,
+                        attrs.public_key,
+                        attrs.platform,
+                        (attrs.status ?? 'active') as DeviceStatus,
+                        new Date(attrs.created_at),
+                        attrs.last_seen_at ? new Date(attrs.last_seen_at) : null,
+                        attrs.revoked_at ? new Date(attrs.revoked_at) : null,
+                );
+        }
+}

--- a/src/domain/DeviceEnvelope.ts
+++ b/src/domain/DeviceEnvelope.ts
@@ -1,0 +1,5 @@
+export type DeviceEnvelope = {
+        id: string;
+        ciphertext: string;
+        createdAt: Date;
+};

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -5,3 +5,5 @@ export * from './EnvironmentSuggestedName.js';
 export * from './EnvironmentType.js';
 export * from './Organization.js';
 export * from './Project.js';
+export * from './Device.js';
+export * from './DeviceEnvelope.js';

--- a/src/http/HttpClient.ts
+++ b/src/http/HttpClient.ts
@@ -4,37 +4,62 @@ type HeadersInit = Record<string, string>;
 import { HttpError } from './errors.js';
 
 export class HttpClient {
-	constructor(
-		private baseUrl: string,
-		private bearer?: string,
-	) {}
+        constructor(
+                private baseUrl: string,
+                private bearer?: string,
+        ) {}
 
-	withBearer(token?: string) {
-		return new HttpClient(this.baseUrl, token ?? this.bearer);
-	}
+        withBearer(token?: string) {
+                return new HttpClient(this.baseUrl, token ?? this.bearer);
+        }
 
-	async get<T>(path: string, headers: HeadersInit = {}): Promise<T> {
-		const res = await fetch(`${this.baseUrl}${path}`, {
-			headers: {
-				...(this.bearer ? { authorization: `Bearer ${this.bearer}` } : {}),
-				...headers,
-			},
-		});
-		if (!res.ok) throw new HttpError(res.status, await res.text(), `GET ${path} failed`);
-		return (await res.json()) as T;
-	}
+        private buildHeaders(extra: HeadersInit = {}, withJson = false): HeadersInit {
+                return {
+                        ...(withJson ? { 'content-type': 'application/json' } : {}),
+                        ...(this.bearer ? { authorization: `Bearer ${this.bearer}` } : {}),
+                        ...extra,
+                };
+        }
 
-	async post<T>(path: string, body: unknown, headers: HeadersInit = {}): Promise<T> {
-		const res = await fetch(`${this.baseUrl}${path}`, {
-			method: 'POST',
-			headers: {
-				'content-type': 'application/json',
-				...(this.bearer ? { authorization: `Bearer ${this.bearer}` } : {}),
-				...headers,
-			},
-			body: JSON.stringify(body),
-		});
-		if (!res.ok) throw new HttpError(res.status, await res.text(), `POST ${path} failed`);
-		return (await res.json().catch(() => ({}))) as T;
-	}
+        async get<T>(path: string, headers: HeadersInit = {}): Promise<T> {
+                const res = await fetch(`${this.baseUrl}${path}`, {
+                        headers: this.buildHeaders(headers),
+                });
+                if (!res.ok) throw new HttpError(res.status, await res.text(), `GET ${path} failed`);
+                return (await res.json()) as T;
+        }
+
+        async post<T>(path: string, body?: unknown, headers: HeadersInit = {}): Promise<T> {
+                const init: {
+                        method: 'POST';
+                        headers: HeadersInit;
+                        body?: string;
+                } = {
+                        method: 'POST',
+                        headers: this.buildHeaders(headers, body !== undefined),
+                };
+
+                if (body !== undefined) {
+                        init.body = JSON.stringify(body);
+                }
+
+                const res = await fetch(`${this.baseUrl}${path}`, init);
+                if (!res.ok) throw new HttpError(res.status, await res.text(), `POST ${path} failed`);
+                return (await res.json().catch(() => ({}))) as T;
+        }
+
+        async delete<T>(path: string, headers: HeadersInit = {}): Promise<T> {
+                const res = await fetch(`${this.baseUrl}${path}`, {
+                        method: 'DELETE',
+                        headers: this.buildHeaders(headers),
+                });
+                if (!res.ok) throw new HttpError(res.status, await res.text(), `DELETE ${path} failed`);
+                const text = await res.text();
+                if (!text) return {} as T;
+                try {
+                        return JSON.parse(text) as T;
+                } catch {
+                        return {} as T;
+                }
+        }
 }

--- a/src/types/api/crypto.ts
+++ b/src/types/api/crypto.ts
@@ -1,29 +1,13 @@
 import type { EncryptedEnvelope, OneTimePrekey, SignedPrekey } from '@/crypto';
+import type {
+        DevicePrekeyBundleJson,
+        DeviceSignedPrekeyJson,
+        DeviceOneTimePrekeyJson,
+} from './device.js';
 
-export type SignedPrekeyJson = {
-	id: string;
-	public_key: string;
-	signature_from_signing_key: string;
-	signer_kid?: string;
-	created_at: string;
-	expires_at?: string;
-	revoked?: boolean;
-};
+export type SignedPrekeyJson = DeviceSignedPrekeyJson;
 
-export type OneTimePrekeyJson = {
-	id: string;
-	public_key: string;
-	created_at: string;
-	consumed_at?: string;
-	consumed_by?: string;
-	expires_at?: string;
-	revoked?: boolean;
-};
-
-export type DevicePrekeyBundleJson = {
-	signed_prekey: SignedPrekeyJson | null;
-	one_time_prekeys: OneTimePrekeyJson[];
-};
+export type OneTimePrekeyJson = DeviceOneTimePrekeyJson;
 
 export type DevicePrekeyBundle = {
 	signedPrekey: SignedPrekey | null;
@@ -47,58 +31,35 @@ export type EncryptedEnvelopeJson = {
 };
 
 export function signedPrekeyFromJSON(json: SignedPrekeyJson): SignedPrekey {
-	return {
-		id: json.id,
-		publicKey: json.public_key,
-		signatureFromSigningKey: json.signature_from_signing_key,
-		signerKid: json.signer_kid,
-		createdAtIso: json.created_at,
-		expiresAtIso: json.expires_at,
-		revoked: json.revoked ?? false,
-	};
-}
-
-export function signedPrekeyToJSON(prekey: SignedPrekey): SignedPrekeyJson {
-	return {
-		id: prekey.id,
-		public_key: prekey.publicKey,
-		signature_from_signing_key: prekey.signatureFromSigningKey,
-		signer_kid: prekey.signerKid,
-		created_at: prekey.createdAtIso,
-		expires_at: prekey.expiresAtIso,
-		revoked: prekey.revoked,
-	};
+        return {
+                id: json.id,
+                publicKey: json.public_key,
+                signatureFromSigningKey: json.signature,
+                createdAtIso: json.created_at,
+                expiresAtIso: json.expires_at ?? undefined,
+                fingerprint: json.fingerprint,
+                revoked: false,
+        };
 }
 
 export function oneTimePrekeyFromJSON(json: OneTimePrekeyJson): OneTimePrekey {
-	return {
-		id: json.id,
-		publicKey: json.public_key,
-		createdAtIso: json.created_at,
-		consumedAtIso: json.consumed_at,
-		consumedBy: json.consumed_by,
-		expiresAtIso: json.expires_at,
-		revoked: json.revoked,
-	};
-}
-
-export function oneTimePrekeyToJSON(prekey: OneTimePrekey): OneTimePrekeyJson {
-	return {
-		id: prekey.id,
-		public_key: prekey.publicKey,
-		created_at: prekey.createdAtIso,
-		consumed_at: prekey.consumedAtIso,
-		consumed_by: prekey.consumedBy,
-		expires_at: prekey.expiresAtIso,
-		revoked: prekey.revoked,
-	};
+        return {
+                id: json.id,
+                publicKey: json.public_key,
+                createdAtIso: json.created_at,
+                expiresAtIso: json.expires_at ?? undefined,
+                fingerprint: json.fingerprint,
+                consumedAtIso: undefined,
+                consumedBy: undefined,
+                revoked: false,
+        };
 }
 
 export function devicePrekeyBundleFromJSON(json: DevicePrekeyBundleJson): DevicePrekeyBundle {
-	return {
-		signedPrekey: json.signed_prekey ? signedPrekeyFromJSON(json.signed_prekey) : null,
-		oneTimePrekeys: json.one_time_prekeys.map(oneTimePrekeyFromJSON),
-	};
+        return {
+                signedPrekey: json.signed_prekey ? signedPrekeyFromJSON(json.signed_prekey) : null,
+                oneTimePrekeys: json.one_time_prekeys.map(oneTimePrekeyFromJSON),
+        };
 }
 
 export function encryptedEnvelopeFromJSON(json: EncryptedEnvelopeJson): EncryptedEnvelope {

--- a/src/types/api/device.ts
+++ b/src/types/api/device.ts
@@ -1,0 +1,78 @@
+export type DeviceStatusJson = 'active' | 'revoked';
+
+export type DeviceAttributesJson = {
+        public_key: string;
+        platform: string;
+        status?: DeviceStatusJson;
+        last_seen_at?: string | null;
+        revoked_at?: string | null;
+        created_at: string;
+};
+
+export type DeviceResourceJson = {
+        type: 'devices';
+        id: string;
+        attributes: DeviceAttributesJson;
+};
+
+export type DeviceDocumentJson = {
+        data: DeviceResourceJson;
+};
+
+export type DeviceDeleteResponseJson = {
+        data: {
+                type: 'devices';
+                id: string;
+                attributes: {
+                        status: DeviceStatusJson;
+                        revoked_at: string | null;
+                };
+        };
+        meta?: { success?: boolean };
+};
+
+export type PublishSignedPrekeyResponseJson = {
+        fingerprint: string;
+        updated_at: string;
+};
+
+export type PublishOneTimePrekeysResponseJson = {
+        queued: number;
+};
+
+export type DeviceSignedPrekeyJson = {
+        id: string;
+        public_key: string;
+        signature: string;
+        fingerprint: string;
+        expires_at?: string | null;
+        created_at: string;
+};
+
+export type DeviceOneTimePrekeyJson = {
+        id: string;
+        public_key: string;
+        fingerprint: string;
+        expires_at?: string | null;
+        created_at: string;
+};
+
+export type DevicePrekeyBundleJson = {
+        signed_prekey: DeviceSignedPrekeyJson | null;
+        one_time_prekeys: DeviceOneTimePrekeyJson[];
+};
+
+export type QueueEnvelopeResponseJson = {
+        id: string;
+        queued: boolean;
+};
+
+export type DeviceEnvelopeJson = {
+        id: string;
+        ciphertext: string;
+        created_at: string;
+};
+
+export type ConsumeEnvelopeResponseJson = {
+        success: boolean;
+};

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -2,3 +2,4 @@ export * from './organization.js';
 export * from './project.js';
 export * from './environment.js';
 export * from './crypto.js';
+export * from './device.js';


### PR DESCRIPTION
## Summary
- add device domain models and TypeScript helpers for the v2.2 JSON:API device payloads
- update the Ghostable client to call the Sanctum-scoped /api/v2.2 device routes and map their request/response formats
- extend the HTTP client and crypto prekey mappings to support the new device workflows

## Testing
- npm run build *(fails: missing @stablelib/x25519, uuid, and NodeNext extension mappings in upstream project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68fd41e30ac883338209450108521df8