### PR TITLE
Refactor device command modules

### DIFF
--- a/src/commands/_autoregister.ts
+++ b/src/commands/_autoregister.ts
@@ -12,34 +12,46 @@ import type { Command } from 'commander';
  * Export function registerFooCommand(program: Command) { ... }
  * or export default (program: Command) => { ... }
  */
+async function loadModule(file: string, program: Command) {
+        const mod = await import(pathToFileURL(file).href);
+
+        if (typeof mod.default === 'function') {
+                mod.default(program);
+                return;
+        }
+
+        for (const [name, value] of Object.entries(mod)) {
+                if (typeof value === 'function' && /^register[A-Z]/.test(name)) {
+                        value(program);
+                }
+        }
+}
+
+async function walkModules(dir: string, program: Command) {
+        const entries = fs
+                .readdirSync(dir, { withFileTypes: true })
+                .filter((entry) => !entry.name.startsWith('_'))
+                .sort((a, b) => a.name.localeCompare(b.name));
+
+        for (const entry of entries) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                        await walkModules(full, program);
+                        continue;
+                }
+
+                if (
+                        entry.isFile() &&
+                        entry.name.endsWith('.js') &&
+                        !entry.name.endsWith('.d.ts') &&
+                        !entry.name.endsWith('.map')
+                ) {
+                        await loadModule(full, program);
+                }
+        }
+}
+
 export async function registerAllCommands(program: Command) {
-	const here = fileURLToPath(new URL('.', import.meta.url)); // .../dist/commands/
-	const files = fs
-		.readdirSync(here)
-		.filter(
-			(f) =>
-				f.endsWith('.js') && // compiled files
-				!f.startsWith('_') && // skip registry itself
-				!f.endsWith('.d.ts') &&
-				!f.endsWith('.map'),
-		)
-		.sort();
-
-	for (const file of files) {
-		const full = path.join(here, file);
-		const mod = await import(pathToFileURL(full).href);
-
-		// If module exports a default function, call it
-		if (typeof mod.default === 'function') {
-			mod.default(program);
-			continue;
-		}
-
-		// Otherwise call any exported function starting with "register"
-		for (const [name, value] of Object.entries(mod)) {
-			if (typeof value === 'function' && /^register[A-Z]/.test(name)) {
-				value(program);
-			}
-		}
-	}
+        const here = fileURLToPath(new URL('.', import.meta.url)); // .../dist/commands/
+        await walkModules(here, program);
 }

--- a/src/commands/device/common.ts
+++ b/src/commands/device/common.ts
@@ -1,0 +1,53 @@
+import { config } from '../../config/index.js';
+import { SessionService } from '../../services/SessionService.js';
+import { GhostableClient } from '../../services/GhostableClient.js';
+import { log } from '../../support/logger.js';
+import { DeviceIdentityService } from '../../services/DeviceIdentityService.js';
+import type { OneTimePrekey } from '@/crypto';
+import type { DevicePrekeyBundle } from '@/types';
+
+export const DEFAULT_PREKEY_BATCH = 20;
+
+export type AuthedClient = { client: GhostableClient };
+export type LinkedIdentity = Awaited<ReturnType<DeviceIdentityService['requireIdentity']>>;
+
+export async function getAuthedClient(): Promise<AuthedClient> {
+        const session = await new SessionService().load();
+        if (!session?.accessToken) {
+                log.error('❌ Not authenticated. Run `ghostable login`.');
+                process.exit(1);
+        }
+
+        const client = GhostableClient.unauthenticated(config.apiBase).withToken(session.accessToken);
+        return { client };
+}
+
+export async function ensureDeviceService(): Promise<DeviceIdentityService> {
+        return DeviceIdentityService.create();
+}
+
+export async function persistOneTimePrekeys(
+        service: DeviceIdentityService,
+        bundle: DevicePrekeyBundle,
+): Promise<void> {
+        const prekeys = bundle.oneTimePrekeys;
+        const existing = await service.loadOneTimePrekeys();
+        const serverIds = new Set(prekeys.map((p) => p.id));
+
+        for (const stale of existing) {
+                if (!serverIds.has(stale.id)) {
+                        await service.getKeyStore().deleteKey(`oneTimePrekey:${stale.id}`);
+                }
+        }
+
+        const withPriv: OneTimePrekey[] = [];
+        for (const prekey of prekeys) {
+                const priv = await service.getKeyStore().getKey(`oneTimePrekey:${prekey.id}`);
+                withPriv.push({
+                        ...prekey,
+                        privateKey: priv ? Buffer.from(priv).toString('base64') : undefined,
+                });
+        }
+
+        await service.saveOneTimePrekeys(withPriv);
+}

--- a/src/commands/device/envelopes.ts
+++ b/src/commands/device/envelopes.ts
@@ -1,0 +1,191 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Command } from 'commander';
+import ora from 'ora';
+import { confirm } from '@inquirer/prompts';
+import { log } from '../../support/logger.js';
+import { DeviceIdentityService } from '../../services/DeviceIdentityService.js';
+import { KeyService } from '@/crypto';
+import {
+        ensureDeviceService,
+        getAuthedClient,
+        type LinkedIdentity,
+} from './common.js';
+import { encryptedEnvelopeFromJSON, encryptedEnvelopeToJSON } from '@/types';
+
+function encodeEnvelopeForTransport(envelope: ReturnType<typeof encryptedEnvelopeToJSON>): string {
+        return Buffer.from(JSON.stringify(envelope), 'utf8').toString('base64');
+}
+
+function decodeEnvelope(ciphertext: string) {
+        const raw = Buffer.from(ciphertext, 'base64').toString('utf8');
+        return encryptedEnvelopeFromJSON(JSON.parse(raw));
+}
+
+export function configureEnvelopeCommands(device: Command) {
+        const envelopes = device
+                .command('envelopes')
+                .description('Inspect and exchange encrypted device envelopes.');
+
+        envelopes
+                .command('pull')
+                .description('Fetch and decrypt queued envelopes for this device.')
+                .action(async () => {
+                        const { client } = await getAuthedClient();
+                        let service: DeviceIdentityService;
+                        try {
+                                service = await ensureDeviceService();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                        let identity: LinkedIdentity;
+                        try {
+                                identity = await service.requireIdentity();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+
+                        const spinner = ora('Fetching envelopes…').start();
+                        try {
+                                const envelopesList = await client.getEnvelopes(identity.deviceId);
+                                spinner.stop();
+
+                                if (!envelopesList.length) {
+                                        log.ok('✅ No envelopes queued.');
+                                        return;
+                                }
+
+                                for (const env of envelopesList) {
+                                        const decoded = decodeEnvelope(env.ciphertext);
+                                        const plaintext = await KeyService.decryptOnThisDevice(
+                                                decoded,
+                                                identity.deviceId,
+                                        );
+                                        const payload = Buffer.from(plaintext);
+                                        const preview = payload.toString('utf8');
+                                        log.info('Envelope:');
+                                        log.info(`  ID: ${env.id}`);
+                                        log.info(`  Created: ${env.createdAt.toISOString()}`);
+                                        log.info(`  Algorithm: ${decoded.alg ?? 'n/a'}`);
+                                        log.info(`  Meta: ${JSON.stringify(decoded.meta ?? {}, null, 2)}`);
+                                        log.info('  Payload:');
+                                        log.info(preview.trim() ? `    ${preview}` : `    (base64) ${payload.toString('base64')}`);
+                                }
+                        } catch (error) {
+                                spinner.fail('Failed to pull envelopes.');
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
+
+        envelopes
+                .command('ack')
+                .description('Acknowledge and remove queued envelopes.')
+                .option('-i, --id <id>', 'Only acknowledge a specific envelope ID')
+                .action(async (opts: { id?: string }) => {
+                        const { client } = await getAuthedClient();
+                        let service: DeviceIdentityService;
+                        try {
+                                service = await ensureDeviceService();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                        let identity: LinkedIdentity;
+                        try {
+                                identity = await service.requireIdentity();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+
+                        const spinner = ora('Fetching envelopes…').start();
+                        try {
+                                const envelopesList = await client.getEnvelopes(identity.deviceId);
+                                spinner.stop();
+
+                                const targets = opts.id
+                                        ? envelopesList.filter((env) => env.id === opts.id)
+                                        : envelopesList;
+
+                                if (!targets.length) {
+                                        log.warn('No envelopes to acknowledge.');
+                                        return;
+                                }
+
+                                const proceed = opts.id
+                                        ? true
+                                        : await confirm({
+                                                  message: `Acknowledge ${targets.length} envelopes?`,
+                                                  default: true,
+                                          });
+                                if (!proceed) {
+                                        log.warn('Acknowledgement aborted.');
+                                        return;
+                                }
+
+                                const ackSpinner = ora('Acknowledging envelopes…').start();
+                                for (const env of targets) {
+                                        await client.consumeEnvelope(identity.deviceId, env.id);
+                                }
+                                ackSpinner.succeed('Envelopes acknowledged.');
+                        } catch (error) {
+                                spinner.fail('Failed to acknowledge envelopes.');
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
+
+        envelopes
+                .command('send')
+                .description('Encrypt a payload for another device and queue it via Ghostable.')
+                .requiredOption('--to <deviceId>', 'Recipient device ID')
+                .requiredOption('--file <path>', 'Path to payload file')
+                .action(async (opts: { to: string; file: string }) => {
+                        const { client } = await getAuthedClient();
+                        let service: DeviceIdentityService;
+                        try {
+                                service = await ensureDeviceService();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                        let identity: LinkedIdentity;
+                        try {
+                                identity = await service.requireIdentity();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+
+                        const spinner = ora('Preparing payload…').start();
+                        try {
+                                const target = await client.getDevice(opts.to);
+                                const filePath = path.resolve(opts.file);
+                                const payload = await fs.readFile(filePath);
+
+                                spinner.text = 'Encrypting envelope…';
+                                const envelope = await KeyService.encryptForDevice(
+                                        identity,
+                                        target.publicKey,
+                                        new Uint8Array(payload),
+                                        { filename: path.basename(filePath) },
+                                );
+
+                                const encoded = encodeEnvelopeForTransport(encryptedEnvelopeToJSON(envelope));
+                                spinner.text = 'Queueing envelope with Ghostable…';
+                                await client.queueEnvelope(opts.to, {
+                                        ciphertext: encoded,
+                                        senderDeviceId: identity.deviceId,
+                                });
+
+                                spinner.succeed('Envelope queued successfully.');
+                        } catch (error) {
+                                spinner.fail('Failed to send envelope.');
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
+}

--- a/src/commands/device/index.ts
+++ b/src/commands/device/index.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander';
+import { configureLinkCommand, linkDeviceFlow } from './link.js';
+import { configureStatusCommand } from './status.js';
+import { configurePrekeysCommands } from './prekeys.js';
+import { configureUnlinkCommand } from './unlink.js';
+import { configureEnvelopeCommands } from './envelopes.js';
+
+export function registerDeviceCommands(program: Command) {
+        const device = program
+                .command('device')
+                .description('Manage Ghostable end-to-end encryption devices.');
+
+        configureLinkCommand(device);
+        configureStatusCommand(device);
+        configurePrekeysCommands(device);
+        configureUnlinkCommand(device);
+        configureEnvelopeCommands(device);
+}
+
+export { linkDeviceFlow } from './link.js';

--- a/src/commands/device/link.ts
+++ b/src/commands/device/link.ts
@@ -1,0 +1,112 @@
+import os from 'node:os';
+import { Command } from 'commander';
+import ora from 'ora';
+import { input } from '@inquirer/prompts';
+import { log } from '../../support/logger.js';
+import { DeviceIdentityService } from '../../services/DeviceIdentityService.js';
+import type { GhostableClient } from '../../services/GhostableClient.js';
+import { KeyService, type OneTimePrekey, type SignedPrekey } from '@/crypto';
+import {
+        DEFAULT_PREKEY_BATCH,
+        ensureDeviceService,
+        getAuthedClient,
+        persistOneTimePrekeys,
+} from './common.js';
+
+function defaultPlatformLabel(): string {
+        return `${process.platform}-${os.arch()} (${os.release()})`;
+}
+
+async function promptForDeviceMetadata() {
+        const suggestedName = os.hostname();
+        const name = await input({
+                message: 'Device label',
+                default: suggestedName,
+        });
+
+        const platform = await input({
+                message: 'Platform (reported to Ghostable)',
+                default: defaultPlatformLabel(),
+        });
+
+        return { name: name.trim() || suggestedName, platform: platform.trim() || defaultPlatformLabel() };
+}
+
+export async function linkDeviceFlow(client: GhostableClient): Promise<void> {
+        const service = await ensureDeviceService();
+        const existing = await service.loadIdentity();
+        if (existing) {
+                log.ok('✅ Device identity already linked on this machine.');
+                return;
+        }
+
+        const { name, platform } = await promptForDeviceMetadata();
+        const spinner = ora('Minting device identity…').start();
+        let identity = await KeyService.createDeviceIdentity(name, platform);
+        let signedPrekey: SignedPrekey | null = null;
+        let oneTimes: OneTimePrekey[] = [];
+
+        try {
+                spinner.text = 'Registering device with Ghostable…';
+                const registered = await client.registerDevice({
+                        publicKey: identity.encryptionKey.publicKey,
+                        platform,
+                });
+
+                if (registered.id !== identity.deviceId) {
+                        await service.renameDeviceKeys(identity.deviceId, registered.id);
+                        identity = {
+                                ...identity,
+                                deviceId: registered.id,
+                        };
+                }
+
+                spinner.text = 'Persisting device identity locally…';
+                await service.saveIdentity(identity);
+
+                spinner.text = 'Creating signed prekey…';
+                signedPrekey = await KeyService.createSignedPrekey(identity);
+                const publish = await client.publishSignedPrekey(identity.deviceId, signedPrekey);
+                signedPrekey = { ...signedPrekey, fingerprint: publish.fingerprint };
+                await service.saveSignedPrekey(signedPrekey);
+
+                spinner.text = `Uploading ${DEFAULT_PREKEY_BATCH} one-time prekeys…`;
+                oneTimes = await KeyService.createOneTimePrekeys(DEFAULT_PREKEY_BATCH);
+                await client.publishOneTimePrekeys(identity.deviceId, oneTimes);
+                const bundle = await client.getDevicePrekeys(identity.deviceId);
+                await persistOneTimePrekeys(service, bundle);
+
+                spinner.succeed('Device linked successfully.');
+                log.ok(`✅ Device ID: ${identity.deviceId}`);
+                log.ok(
+                        `🔑 Encryption fingerprint: ${DeviceIdentityService.fingerprint(identity.encryptionKey.publicKey)}`,
+                );
+        } catch (error) {
+                spinner.fail('Device linking failed.');
+                await service.clearIdentity(identity.deviceId);
+                if (signedPrekey) {
+                        await service.clearSignedPrekey(signedPrekey.id);
+                }
+                await service.clearSignedPrekey();
+                if (oneTimes.length) {
+                        await service.dropOneTimePrekeys(oneTimes.map((prekey) => prekey.id));
+                }
+                throw error;
+        }
+}
+
+export function configureLinkCommand(device: Command) {
+        device
+                .command('link')
+                .alias('init')
+                .description('Provision a new device identity and register it with Ghostable.')
+                .action(async () => {
+                        const { client } = await getAuthedClient();
+                        try {
+                                await linkDeviceFlow(client);
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
+}

--- a/src/commands/device/prekeys.ts
+++ b/src/commands/device/prekeys.ts
@@ -1,0 +1,113 @@
+import { Command } from 'commander';
+import ora from 'ora';
+import { log } from '../../support/logger.js';
+import { DeviceIdentityService } from '../../services/DeviceIdentityService.js';
+import { KeyService } from '@/crypto';
+import {
+        DEFAULT_PREKEY_BATCH,
+        ensureDeviceService,
+        getAuthedClient,
+        persistOneTimePrekeys,
+        type LinkedIdentity,
+} from './common.js';
+
+export function configurePrekeysCommands(device: Command) {
+        const prekeys = device
+                .command('prekeys')
+                .description('Manage signed and one-time prekeys for this device.');
+
+        prekeys
+                .command('rotate')
+                .description('Rotate the signed prekey if it has expired.')
+                .action(async () => {
+                        const { client } = await getAuthedClient();
+                        let service: DeviceIdentityService;
+                        try {
+                                service = await ensureDeviceService();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                        let identity: LinkedIdentity;
+                        try {
+                                identity = await service.requireIdentity();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+
+                        const spinner = ora('Checking signed prekey…').start();
+                        try {
+                                const current = await service.loadSignedPrekey();
+                                const { active, rotated, retired } = await KeyService.rotateSignedPrekeyIfExpired(
+                                        identity,
+                                        current ?? undefined,
+                                );
+
+                                if (!rotated) {
+                                        spinner.succeed('Signed prekey is still valid. No rotation needed.');
+                                        return;
+                                }
+
+                                spinner.text = 'Publishing new signed prekey…';
+                                const publish = await client.publishSignedPrekey(identity.deviceId, active);
+                                const updated = { ...active, fingerprint: publish.fingerprint };
+                                await service.saveSignedPrekey(updated);
+
+                                if (retired) {
+                                        await service.clearSignedPrekey(retired.id);
+                                }
+
+                                spinner.succeed('Signed prekey rotated successfully.');
+                        } catch (error) {
+                                spinner.fail('Signed prekey rotation failed.');
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
+
+        prekeys
+                .command('top-up')
+                .description('Generate and upload additional one-time prekeys.')
+                .argument('[count]', 'Number of one-time prekeys to generate', `${DEFAULT_PREKEY_BATCH}`)
+                .action(async (countArg: string) => {
+                        const count = Number.parseInt(countArg, 10);
+                        if (!Number.isFinite(count) || count <= 0) {
+                                log.error('Count must be a positive integer.');
+                                process.exit(1);
+                        }
+
+                        const { client } = await getAuthedClient();
+                        let service: DeviceIdentityService;
+                        try {
+                                service = await ensureDeviceService();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                        let identity: LinkedIdentity;
+                        try {
+                                identity = await service.requireIdentity();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+
+                        const spinner = ora(`Generating ${count} one-time prekeys…`).start();
+                        try {
+                                const prekeyBatch = await KeyService.createOneTimePrekeys(count);
+                                spinner.text = 'Uploading one-time prekeys…';
+                                await client.publishOneTimePrekeys(identity.deviceId, prekeyBatch);
+
+                                spinner.text = 'Reconciling local key cache…';
+                                const bundle = await client.getDevicePrekeys(identity.deviceId);
+                                await persistOneTimePrekeys(service, bundle);
+
+                                spinner.succeed('One-time prekeys topped up successfully.');
+                        } catch (error) {
+                                spinner.fail('Failed to top up one-time prekeys.');
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
+}

--- a/src/commands/device/status.ts
+++ b/src/commands/device/status.ts
@@ -1,0 +1,67 @@
+import { Command } from 'commander';
+import ora from 'ora';
+import { log } from '../../support/logger.js';
+import { DeviceIdentityService } from '../../services/DeviceIdentityService.js';
+import { ensureDeviceService, getAuthedClient } from './common.js';
+
+export function configureStatusCommand(device: Command) {
+        device
+                .command('status')
+                .description('Show local device identity details and remote status from Ghostable.')
+                .action(async () => {
+                        const { client } = await getAuthedClient();
+                        let service: DeviceIdentityService;
+                        try {
+                                service = await ensureDeviceService();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                        let identity: Awaited<ReturnType<DeviceIdentityService['loadIdentity']>>;
+                        try {
+                                identity = await service.requireIdentity();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+
+                        const spinner = ora('Fetching device status…').start();
+                        try {
+                                const deviceRecord = await client.getDevice(identity.deviceId);
+                                spinner.stop();
+
+                                log.info('Local device identity');
+                                log.info(`  ID: ${identity.deviceId}`);
+                                log.info(`  Name: ${identity.name ?? 'n/a'}`);
+                                log.info(`  Platform: ${identity.platform ?? 'n/a'}`);
+                                log.info(
+                                        `  Signing fingerprint: ${DeviceIdentityService.fingerprint(identity.signingKey.publicKey)}`,
+                                );
+                                log.info(
+                                        `  Encryption fingerprint: ${DeviceIdentityService.fingerprint(identity.encryptionKey.publicKey)}`,
+                                );
+
+                                log.info('Remote status');
+                                log.info(`  Platform: ${deviceRecord.platform}`);
+                                log.info(`  Status: ${deviceRecord.status}`);
+                                log.info(`  Created: ${deviceRecord.createdAt.toISOString()}`);
+                                log.info(`  Last seen: ${deviceRecord.lastSeenAt?.toISOString() ?? 'n/a'}`);
+                                log.info(`  Revoked at: ${deviceRecord.revokedAt?.toISOString() ?? 'n/a'}`);
+
+                                const signedPrekey = await service.loadSignedPrekey();
+                                if (signedPrekey) {
+                                        log.info('Signed prekey');
+                                        log.info(`  ID: ${signedPrekey.id}`);
+                                        log.info(`  Fingerprint: ${signedPrekey.fingerprint ?? 'n/a'}`);
+                                        log.info(`  Expires: ${signedPrekey.expiresAtIso ?? 'n/a'}`);
+                                }
+
+                                const oneTimePrekeys = await service.loadOneTimePrekeys();
+                                log.info(`One-time prekeys stored locally: ${oneTimePrekeys.length}`);
+                        } catch (error) {
+                                spinner.fail('Unable to fetch device status.');
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
+}

--- a/src/commands/device/unlink.ts
+++ b/src/commands/device/unlink.ts
@@ -1,0 +1,59 @@
+import { Command } from 'commander';
+import ora from 'ora';
+import { confirm } from '@inquirer/prompts';
+import { log } from '../../support/logger.js';
+import { DeviceIdentityService } from '../../services/DeviceIdentityService.js';
+import { ensureDeviceService, getAuthedClient, type LinkedIdentity } from './common.js';
+
+export function configureUnlinkCommand(device: Command) {
+        device
+                .command('unlink')
+                .description('Revoke the current device and wipe local key material.')
+                .action(async () => {
+                        const { client } = await getAuthedClient();
+                        let service: DeviceIdentityService;
+                        try {
+                                service = await ensureDeviceService();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                        let identity: LinkedIdentity;
+                        try {
+                                identity = await service.requireIdentity();
+                        } catch (error) {
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+
+                        const proceed = await confirm({
+                                message: 'This will revoke the device and delete local keys. Continue?',
+                                default: false,
+                        });
+                        if (!proceed) {
+                                log.warn('Device unlink aborted.');
+                                return;
+                        }
+
+                        const spinner = ora('Revoking device…').start();
+                        try {
+                                await client.revokeDevice(identity.deviceId);
+                                await service.clearIdentity(identity.deviceId);
+                                const currentSigned = await service.loadSignedPrekey();
+                                if (currentSigned) {
+                                        await service.clearSignedPrekey(currentSigned.id);
+                                }
+                                await service.clearSignedPrekey();
+                                const cachedPrekeys = await service.loadOneTimePrekeys();
+                                if (cachedPrekeys.length) {
+                                        await service.dropOneTimePrekeys(cachedPrekeys.map((p) => p.id));
+                                }
+                                await service.saveOneTimePrekeys([]);
+                                spinner.succeed('Device revoked and local keys cleared.');
+                        } catch (error) {
+                                spinner.fail('Failed to revoke device.');
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
+}

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -6,6 +6,7 @@ import { SessionService } from '../services/SessionService.js';
 import { GhostableClient } from '../services/GhostableClient.js';
 import { log } from '../support/logger.js';
 import { toErrorMessage } from '../support/errors.js';
+import { linkDeviceFlow } from './device/index.js';
 
 export function registerLoginCommand(program: Command) {
 	program
@@ -59,11 +60,21 @@ export function registerLoginCommand(program: Command) {
 					log.warn('No organizations found. Create one in the dashboard.');
 				}
 
-				await session.save({ accessToken: token, organizationId });
-				log.ok('✅ Session stored in OS keychain.');
-			} catch (error) {
-				spinner.fail(toErrorMessage(error) || 'Login failed');
-				process.exit(1);
+                                await session.save({ accessToken: token, organizationId });
+                                log.ok('✅ Session stored in OS keychain.');
+
+                                try {
+                                        await linkDeviceFlow(authed);
+                                } catch (deviceError) {
+                                        log.warn(
+                                                `⚠️ Device provisioning skipped: ${
+                                                        toErrorMessage(deviceError) ?? String(deviceError)
+                                                }`,
+                                        );
+                                }
+                        } catch (error) {
+                                spinner.fail(toErrorMessage(error) || 'Login failed');
+                                process.exit(1);
 			}
 		});
 }

--- a/src/services/DeviceIdentityService.ts
+++ b/src/services/DeviceIdentityService.ts
@@ -1,0 +1,222 @@
+import { sha256 } from '@noble/hashes/sha256';
+import { KeyService, KeytarKeyStore } from '@/crypto';
+import type { DeviceIdentity, OneTimePrekey, SignedPrekey } from '@/crypto';
+import { loadKeytar, type Keytar } from '../support/keyring.js';
+
+type StoredIdentity = Omit<DeviceIdentity, 'signingKey' | 'encryptionKey'> & {
+        signingKey: {
+                alg: 'Ed25519';
+                publicKey: string;
+        };
+        encryptionKey: {
+                alg: 'X25519';
+                publicKey: string;
+                derivedFromSigningKey?: boolean;
+        };
+};
+
+type StoredSignedPrekey = Omit<SignedPrekey, 'privateKey'>;
+type StoredOneTimePrekey = Omit<OneTimePrekey, 'privateKey'>;
+
+export class DeviceIdentityService {
+        private static readonly KEYCHAIN_SERVICE = 'ghostable-cli-device';
+        private static readonly ACCOUNT_IDENTITY = 'device:identity';
+        private static readonly ACCOUNT_SIGNED_PREKEY = 'device:signed-prekey';
+        private static readonly ACCOUNT_ONE_TIME_PREKEYS = 'device:one-time-prekeys';
+
+        private constructor(private readonly keytar: Keytar, private readonly keyStore: KeytarKeyStore) {}
+
+        static async create(): Promise<DeviceIdentityService> {
+                const keytar = await loadKeytar();
+                if (!keytar) {
+                        throw new Error(
+                                'OS keychain is unavailable. Device commands require access to the keychain.',
+                        );
+                }
+
+                const keyStore = new KeytarKeyStore(this.KEYCHAIN_SERVICE, keytar);
+                KeyService.initialize(keyStore);
+                return new DeviceIdentityService(keytar, keyStore);
+        }
+
+        static fingerprint(publicKeyB64: string): string {
+                const decoded = Buffer.from(publicKeyB64, 'base64');
+                return Buffer.from(sha256(decoded)).toString('hex');
+        }
+
+        async loadIdentity(): Promise<DeviceIdentity | null> {
+                const raw = await this.keytar.getPassword(
+                        DeviceIdentityService.KEYCHAIN_SERVICE,
+                        DeviceIdentityService.ACCOUNT_IDENTITY,
+                );
+                if (!raw) return null;
+
+                const parsed = JSON.parse(raw) as StoredIdentity;
+                const signing = await this.keyStore.getKey(`device:${parsed.deviceId}:signingKey`);
+                const encryption = await this.keyStore.getKey(`device:${parsed.deviceId}:encryptionKey`);
+                if (!signing || !encryption) {
+                        throw new Error('Device identity is corrupted. Private keys are missing.');
+                }
+
+                return {
+                        ...parsed,
+                        signingKey: {
+                                ...parsed.signingKey,
+                                privateKey: Buffer.from(signing).toString('base64'),
+                        },
+                        encryptionKey: {
+                                ...parsed.encryptionKey,
+                                privateKey: Buffer.from(encryption).toString('base64'),
+                        },
+                };
+        }
+
+        async requireIdentity(): Promise<DeviceIdentity> {
+                const identity = await this.loadIdentity();
+                if (!identity) {
+                        throw new Error('No device identity is linked on this machine.');
+                }
+                return identity;
+        }
+
+        async saveIdentity(identity: DeviceIdentity): Promise<void> {
+                const stored: StoredIdentity = {
+                        ...identity,
+                        signingKey: {
+                                alg: identity.signingKey.alg,
+                                publicKey: identity.signingKey.publicKey,
+                        },
+                        encryptionKey: {
+                                alg: identity.encryptionKey.alg,
+                                publicKey: identity.encryptionKey.publicKey,
+                                derivedFromSigningKey: identity.encryptionKey.derivedFromSigningKey,
+                        },
+                };
+
+                await this.keytar.setPassword(
+                        DeviceIdentityService.KEYCHAIN_SERVICE,
+                        DeviceIdentityService.ACCOUNT_IDENTITY,
+                        JSON.stringify(stored),
+                );
+        }
+
+        async renameDeviceKeys(oldId: string, nextId: string): Promise<void> {
+                if (!oldId || !nextId || oldId === nextId) return;
+
+                const signing = await this.keyStore.getKey(`device:${oldId}:signingKey`);
+                if (signing) {
+                        await this.keyStore.setKey(`device:${nextId}:signingKey`, signing);
+                        await this.keyStore.deleteKey(`device:${oldId}:signingKey`);
+                }
+
+                const encryption = await this.keyStore.getKey(`device:${oldId}:encryptionKey`);
+                if (encryption) {
+                        await this.keyStore.setKey(`device:${nextId}:encryptionKey`, encryption);
+                        await this.keyStore.deleteKey(`device:${oldId}:encryptionKey`);
+                }
+        }
+
+        async clearIdentity(deviceId?: string): Promise<void> {
+                const currentId =
+                        deviceId ?? (await this.loadIdentity())?.deviceId ?? undefined;
+
+                if (currentId) {
+                        await this.keyStore.deleteKey(`device:${currentId}:signingKey`);
+                        await this.keyStore.deleteKey(`device:${currentId}:encryptionKey`);
+                }
+
+                await this.keytar.deletePassword(
+                        DeviceIdentityService.KEYCHAIN_SERVICE,
+                        DeviceIdentityService.ACCOUNT_IDENTITY,
+                );
+        }
+
+        async loadSignedPrekey(): Promise<SignedPrekey | null> {
+                const raw = await this.keytar.getPassword(
+                        DeviceIdentityService.KEYCHAIN_SERVICE,
+                        DeviceIdentityService.ACCOUNT_SIGNED_PREKEY,
+                );
+                if (!raw) return null;
+                const parsed = JSON.parse(raw) as StoredSignedPrekey;
+                const priv = await this.keyStore.getKey(`signedPrekey:${parsed.id}`);
+                return {
+                        ...parsed,
+                        privateKey: priv ? Buffer.from(priv).toString('base64') : undefined,
+                };
+        }
+
+        async saveSignedPrekey(prekey: SignedPrekey): Promise<void> {
+                const stored: StoredSignedPrekey = { ...prekey };
+                delete (stored as unknown as { privateKey?: string }).privateKey;
+                await this.keytar.setPassword(
+                        DeviceIdentityService.KEYCHAIN_SERVICE,
+                        DeviceIdentityService.ACCOUNT_SIGNED_PREKEY,
+                        JSON.stringify(stored),
+                );
+        }
+
+        async clearSignedPrekey(prekeyId?: string): Promise<void> {
+                if (prekeyId) {
+                        await this.keyStore.deleteKey(`signedPrekey:${prekeyId}`);
+                        return;
+                }
+
+                await this.keytar.deletePassword(
+                        DeviceIdentityService.KEYCHAIN_SERVICE,
+                        DeviceIdentityService.ACCOUNT_SIGNED_PREKEY,
+                );
+        }
+
+        async loadOneTimePrekeys(): Promise<OneTimePrekey[]> {
+                const raw = await this.keytar.getPassword(
+                        DeviceIdentityService.KEYCHAIN_SERVICE,
+                        DeviceIdentityService.ACCOUNT_ONE_TIME_PREKEYS,
+                );
+                if (!raw) return [];
+
+                const parsed = JSON.parse(raw) as StoredOneTimePrekey[];
+                const enriched: OneTimePrekey[] = [];
+
+                for (const prekey of parsed) {
+                        const priv = await this.keyStore.getKey(`oneTimePrekey:${prekey.id}`);
+                        enriched.push({
+                                ...prekey,
+                                privateKey: priv ? Buffer.from(priv).toString('base64') : undefined,
+                        });
+                }
+
+                return enriched;
+        }
+
+        async saveOneTimePrekeys(prekeys: OneTimePrekey[]): Promise<void> {
+                const stored = prekeys
+                        .map((prekey) => {
+                                const clone: StoredOneTimePrekey = { ...prekey };
+                                delete (clone as unknown as { privateKey?: string }).privateKey;
+                                return clone;
+                        })
+                        .sort((a, b) => (a.createdAtIso ?? '').localeCompare(b.createdAtIso ?? ''));
+
+                await this.keytar.setPassword(
+                        DeviceIdentityService.KEYCHAIN_SERVICE,
+                        DeviceIdentityService.ACCOUNT_ONE_TIME_PREKEYS,
+                        JSON.stringify(stored),
+                );
+        }
+
+        async dropOneTimePrekeys(ids: string[]): Promise<void> {
+                if (!ids.length) return;
+                for (const id of ids) {
+                        await this.keyStore.deleteKey(`oneTimePrekey:${id}`);
+                }
+
+                const remaining = (await this.loadOneTimePrekeys()).filter(
+                        (prekey) => !ids.includes(prekey.id),
+                );
+                await this.saveOneTimePrekeys(remaining);
+        }
+
+        getKeyStore(): KeytarKeyStore {
+                return this.keyStore;
+        }
+}


### PR DESCRIPTION
## Summary
- split the device CLI into dedicated modules for link, status, prekeys, envelopes, and unlink flows
- extract shared device command helpers into a common utility module and keep the index focused on wiring

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd666b762c8333865a6431952122c6