### PR TITLE
Handle missing remote device during unlink

### DIFF
--- a/src/commands/device/unlink.ts
+++ b/src/commands/device/unlink.ts
@@ -4,6 +4,26 @@ import { confirm } from '@inquirer/prompts';
 import { log } from '../../support/logger.js';
 import { DeviceIdentityService } from '../../services/DeviceIdentityService.js';
 import { ensureDeviceService, getAuthedClient, type LinkedIdentity } from './common.js';
+import { HttpError } from '../../http/errors.js';
+
+async function clearLocalDeviceState(
+        service: DeviceIdentityService,
+        identity: LinkedIdentity,
+): Promise<void> {
+        await service.clearIdentity(identity.deviceId);
+
+        const currentSigned = await service.loadSignedPrekey();
+        if (currentSigned) {
+                await service.clearSignedPrekey(currentSigned.id);
+        }
+        await service.clearSignedPrekey();
+
+        const cachedPrekeys = await service.loadOneTimePrekeys();
+        if (cachedPrekeys.length) {
+                await service.dropOneTimePrekeys(cachedPrekeys.map((p) => p.id));
+        }
+        await service.saveOneTimePrekeys([]);
+}
 
 export function configureUnlinkCommand(device: Command) {
 	device
@@ -35,25 +55,43 @@ export function configureUnlinkCommand(device: Command) {
 				return;
 			}
 
-			const spinner = ora('Revoking device…').start();
-			try {
-				await client.revokeDevice(identity.deviceId);
-				await service.clearIdentity(identity.deviceId);
-				const currentSigned = await service.loadSignedPrekey();
-				if (currentSigned) {
-					await service.clearSignedPrekey(currentSigned.id);
-				}
-				await service.clearSignedPrekey();
-				const cachedPrekeys = await service.loadOneTimePrekeys();
-				if (cachedPrekeys.length) {
-					await service.dropOneTimePrekeys(cachedPrekeys.map((p) => p.id));
-				}
-				await service.saveOneTimePrekeys([]);
-				spinner.succeed('Device revoked and local keys cleared.');
-			} catch (error) {
-				spinner.fail('Failed to revoke device.');
-				log.error(error instanceof Error ? error.message : String(error));
-				process.exit(1);
-			}
-		});
+                        const revokeSpinner = ora('Revoking device…').start();
+                        let revokedRemotely = false;
+                        try {
+                                await client.revokeDevice(identity.deviceId);
+                                revokedRemotely = true;
+                                revokeSpinner.succeed('Device revoked.');
+                        } catch (error) {
+                                if (error instanceof HttpError && error.status === 404) {
+                                        revokeSpinner.warn('Device not found on Ghostable.');
+                                        const clearLocally = await confirm({
+                                                message:
+                                                        'The device no longer exists on Ghostable. Clear it locally and delete local keys?',
+                                                default: true,
+                                        });
+                                        if (!clearLocally) {
+                                                log.warn('Device unlink aborted.');
+                                                return;
+                                        }
+                                } else {
+                                        revokeSpinner.fail('Failed to revoke device.');
+                                        log.error(error instanceof Error ? error.message : String(error));
+                                        process.exit(1);
+                                }
+                        }
+
+                        const clearSpinner = ora('Clearing local keys…').start();
+                        try {
+                                await clearLocalDeviceState(service, identity);
+                                clearSpinner.succeed(
+                                        revokedRemotely
+                                                ? 'Device revoked and local keys cleared.'
+                                                : 'Local device keys cleared.',
+                                );
+                        } catch (error) {
+                                clearSpinner.fail('Failed to clear local keys.');
+                                log.error(error instanceof Error ? error.message : String(error));
+                                process.exit(1);
+                        }
+                });
 }


### PR DESCRIPTION
## Summary
- handle missing remote device errors when unlinking by prompting to clear keys locally
- refactor device unlink command to reuse local cleanup logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd82f2cbb8833391600497dbfad70f