### PR TITLE
Use environment KEKs when pushing env variables

### DIFF
--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -8,16 +8,16 @@ import { config } from '../config/index.js';
 import { SessionService } from '../services/SessionService.js';
 import { GhostableClient } from '../services/GhostableClient.js';
 import { DeviceIdentityService } from '../services/DeviceIdentityService.js';
-import { EnvelopeService } from '../services/EnvelopeService.js';
+import { EnvironmentKeyService } from '../services/EnvironmentKeyService.js';
 import { Manifest } from '../support/Manifest.js';
 import { log } from '../support/logger.js';
 import { toErrorMessage } from '../support/errors.js';
 import { getIgnoredKeys, filterIgnoredKeys } from '../support/ignore.js';
-import {
-	EnvVarSnapshot,
-	resolveEnvFile,
-	readEnvFileSafeWithMetadata,
-} from '../support/env-files.js';
+import { resolveEnvFile, readEnvFileSafeWithMetadata } from '../support/env-files.js';
+import { initSodium } from '../crypto.js';
+import { loadOrCreateKeys } from '../keys.js';
+import { buildSecretPayload } from '../support/secret-payload.js';
+import type { SignedEnvironmentSecretUploadRequest } from '@/types';
 
 export type PushOptions = {
 	api?: string;
@@ -29,25 +29,6 @@ export type PushOptions = {
 	replace?: boolean;
 	pruneServer?: boolean;
 };
-
-function serializeEnv(
-	vars: Record<string, string>,
-	snapshots: Record<string, EnvVarSnapshot>,
-): string {
-	return (
-		Object.keys(vars)
-			.sort((a, b) => a.localeCompare(b))
-			.map((key) => {
-				const value = vars[key] ?? '';
-				const snapshot = snapshots[key];
-				if (snapshot && snapshot.value === value) {
-					return `${key}=${snapshot.rawValue}`;
-				}
-				return `${key}=${value}`;
-			})
-			.join('\n') + '\n'
-	);
-}
 
 export function registerEnvPushCommand(program: Command) {
 	program
@@ -108,7 +89,7 @@ export async function runEnvPush(opts: PushOptions): Promise<void> {
 	}
 
 	// 5) Read variables + apply ignore list
-	const { vars: envMap, snapshots } = readEnvFileSafeWithMetadata(filePath);
+        const { vars: envMap } = readEnvFileSafeWithMetadata(filePath);
 	const ignored = getIgnoredKeys(envName);
 	const filteredVars = filterIgnoredKeys(envMap, ignored);
 	const entryCount = Object.keys(filteredVars).length;
@@ -125,15 +106,7 @@ export async function runEnvPush(opts: PushOptions): Promise<void> {
 		);
 	}
 
-	const serialized = serializeEnv(filteredVars, snapshots);
-	const plaintext = Buffer.from(serialized, 'utf8');
-
-	if (!plaintext.length) {
-		log.warn('⚠️  No variables found in the .env file.');
-		return;
-	}
-
-	const client = GhostableClient.unauthenticated(config.apiBase).withToken(token);
+        const client = GhostableClient.unauthenticated(config.apiBase).withToken(token);
 
 	let identityService: DeviceIdentityService;
 	try {
@@ -153,33 +126,67 @@ export async function runEnvPush(opts: PushOptions): Promise<void> {
 		return;
 	}
 
-	const spinner = ora('Encrypting environment…').start();
-	try {
-		spinner.text = 'Encrypting environment variables locally…';
-		const envelope = await EnvelopeService.encrypt({
-			sender: identity,
-			recipientPublicKey: identity.encryptionKey.publicKey,
-			plaintext,
-			meta: {
-				project_id: projectId,
-				environment: envName!,
-				org_id: orgId ?? '',
-				file_path: filePath,
-			},
-		});
+        const spinner = ora('Encrypting environment…').start();
+        try {
+                spinner.text = 'Ensuring environment key…';
+                const envKeyService = await EnvironmentKeyService.create();
+                const keyInfo = await envKeyService.ensureEnvironmentKey({
+                        client,
+                        projectId,
+                        envName: envName!,
+                        identity,
+                });
 
-		spinner.text = 'Uploading encrypted envelope to Ghostable…';
-		const result = await client.sendEnvelope(identity.deviceId, envelope);
+                if (keyInfo.created) {
+                        spinner.text = 'Sharing environment key with team devices…';
+                        await envKeyService.publishKeyEnvelopes({
+                                client,
+                                projectId,
+                                envName: envName!,
+                                identity,
+                                key: keyInfo.key,
+                                version: keyInfo.version,
+                                fingerprint: keyInfo.fingerprint,
+                        });
+                }
 
-		spinner.succeed('Environment pushed securely.');
-		const ciphertextBytes = Buffer.from(envelope.ciphertextB64, 'base64').byteLength;
-		log.ok(
-			`✅ Envelope ${result.id} uploaded (${ciphertextBytes} encrypted bytes for ${projectId}:${envName}).`,
-		);
-	} catch (error) {
-		console.log(error);
-		spinner.fail('env:push failed.');
-		log.error(toErrorMessage(error));
-		process.exit(1);
-	}
+                spinner.text = 'Encrypting environment variables locally…';
+                await initSodium();
+                const keyBundle = await loadOrCreateKeys();
+                const edPriv = Buffer.from(
+                        keyBundle.ed25519PrivB64.replace(/^b64:/, ''),
+                        'base64',
+                );
+
+                const secrets = [] as SignedEnvironmentSecretUploadRequest[];
+                const sortedKeys = Object.keys(filteredVars).sort((a, b) => a.localeCompare(b));
+                for (const name of sortedKeys) {
+                        const value = filteredVars[name] ?? '';
+                        const payload = await buildSecretPayload({
+                                org: orgId ?? '',
+                                project: projectId,
+                                env: envName!,
+                                name,
+                                plaintext: value,
+                                keyMaterial: keyInfo.key,
+                                edPriv,
+                                envKekVersion: keyInfo.version,
+                                envKekFingerprint: keyInfo.fingerprint,
+                        });
+                        secrets.push(payload);
+                }
+
+                spinner.text = 'Uploading encrypted secrets to Ghostable…';
+                const sync = Boolean(opts.sync || opts.replace || opts.pruneServer);
+                await client.push(projectId, envName!, { secrets }, { sync });
+
+                spinner.succeed('Environment pushed securely.');
+                log.ok(
+                        `✅ Pushed ${secrets.length} variables to ${projectId}:${envName}.`,
+                );
+        } catch (error) {
+                spinner.fail('env:push failed.');
+                log.error(toErrorMessage(error));
+                process.exit(1);
+        }
 }

--- a/src/commands/var-push.ts
+++ b/src/commands/var-push.ts
@@ -164,16 +164,16 @@ export function registerVarPushCommand(program: Command) {
 			}
 
 			try {
-                                const payload = await buildSecretPayload({
-                                        name: target.name,
-                                        env: envName!,
-                                        org: orgId,
-                                        project: projectId,
-                                        plaintext: target.plaintext,
-                                        keyMaterial: masterSeed,
-                                        edPriv,
-                                        validators,
-                                });
+				const payload = await buildSecretPayload({
+					name: target.name,
+					env: envName!,
+					org: orgId,
+					project: projectId,
+					plaintext: target.plaintext,
+					keyMaterial: masterSeed,
+					edPriv,
+					validators,
+				});
 
 				await client.uploadSecret(projectId, envName, payload);
 				log.ok(

--- a/src/commands/var-push.ts
+++ b/src/commands/var-push.ts
@@ -164,16 +164,16 @@ export function registerVarPushCommand(program: Command) {
 			}
 
 			try {
-				const payload = await buildSecretPayload({
-					name: target.name,
-					env: envName!,
-					org: orgId,
-					project: projectId,
-					plaintext: target.plaintext,
-					masterSeed,
-					edPriv,
-					validators,
-				});
+                                const payload = await buildSecretPayload({
+                                        name: target.name,
+                                        env: envName!,
+                                        org: orgId,
+                                        project: projectId,
+                                        plaintext: target.plaintext,
+                                        keyMaterial: masterSeed,
+                                        edPriv,
+                                        validators,
+                                });
 
 				await client.uploadSecret(projectId, envName, payload);
 				log.ok(

--- a/src/domain/EnvironmentSecret.ts
+++ b/src/domain/EnvironmentSecret.ts
@@ -7,19 +7,19 @@ export class EnvironmentSecret {
 	constructor(
 		public readonly env: string,
 		public readonly name: string,
-        public readonly ciphertext: string,
-        public readonly nonce: string,
-        public readonly alg: CipherAlg,
-        public readonly aad: AAD,
-        public readonly claims?: Claims,
-        public readonly version?: number,
-        public readonly envKekVersion?: number,
-        public readonly envKekFingerprint?: string | null,
-        public readonly meta?: {
-                line_bytes?: number;
-                is_vapor_secret?: boolean;
-                is_commented?: boolean;
-                is_override?: boolean;
+		public readonly ciphertext: string,
+		public readonly nonce: string,
+		public readonly alg: CipherAlg,
+		public readonly aad: AAD,
+		public readonly claims?: Claims,
+		public readonly version?: number,
+		public readonly envKekVersion?: number,
+		public readonly envKekFingerprint?: string | null,
+		public readonly meta?: {
+			line_bytes?: number;
+			is_vapor_secret?: boolean;
+			is_commented?: boolean;
+			is_override?: boolean;
 		},
 	) {}
 
@@ -27,15 +27,15 @@ export class EnvironmentSecret {
 		return new EnvironmentSecret(
 			json.env,
 			json.name,
-                        json.ciphertext,
-                        json.nonce,
-                        json.alg,
-                        json.aad,
-                        json.claims,
-                        json.version,
-                        json.env_kek_version ?? undefined,
-                        json.env_kek_fingerprint ?? null,
-                        json.meta,
-                );
-        }
+			json.ciphertext,
+			json.nonce,
+			json.alg,
+			json.aad,
+			json.claims,
+			json.version,
+			json.env_kek_version ?? undefined,
+			json.env_kek_fingerprint ?? null,
+			json.meta,
+		);
+	}
 }

--- a/src/domain/EnvironmentSecret.ts
+++ b/src/domain/EnvironmentSecret.ts
@@ -7,17 +7,19 @@ export class EnvironmentSecret {
 	constructor(
 		public readonly env: string,
 		public readonly name: string,
-		public readonly ciphertext: string,
-		public readonly nonce: string,
-		public readonly alg: CipherAlg,
-		public readonly aad: AAD,
-		public readonly claims?: Claims,
-		public readonly version?: number,
-		public readonly meta?: {
-			line_bytes?: number;
-			is_vapor_secret?: boolean;
-			is_commented?: boolean;
-			is_override?: boolean;
+        public readonly ciphertext: string,
+        public readonly nonce: string,
+        public readonly alg: CipherAlg,
+        public readonly aad: AAD,
+        public readonly claims?: Claims,
+        public readonly version?: number,
+        public readonly envKekVersion?: number,
+        public readonly envKekFingerprint?: string | null,
+        public readonly meta?: {
+                line_bytes?: number;
+                is_vapor_secret?: boolean;
+                is_commented?: boolean;
+                is_override?: boolean;
 		},
 	) {}
 
@@ -25,13 +27,15 @@ export class EnvironmentSecret {
 		return new EnvironmentSecret(
 			json.env,
 			json.name,
-			json.ciphertext,
-			json.nonce,
-			json.alg,
-			json.aad,
-			json.claims,
-			json.version,
-			json.meta,
-		);
-	}
+                        json.ciphertext,
+                        json.nonce,
+                        json.alg,
+                        json.aad,
+                        json.claims,
+                        json.version,
+                        json.env_kek_version ?? undefined,
+                        json.env_kek_fingerprint ?? null,
+                        json.meta,
+                );
+        }
 }

--- a/src/services/EnvironmentKeyService.ts
+++ b/src/services/EnvironmentKeyService.ts
@@ -9,168 +9,174 @@ import { KeyService, type DeviceIdentity } from '@/crypto';
 import type { PublishEnvironmentKeyRequest } from '@/types';
 
 function toHex(bytes: Uint8Array): string {
-        return Buffer.from(bytes).toString('hex');
+	return Buffer.from(bytes).toString('hex');
 }
 
 function encodeKey(key: Uint8Array): string {
-        return Buffer.from(key).toString('base64');
+	return Buffer.from(key).toString('base64');
 }
 
 function decodeKey(keyB64: string): Uint8Array {
-        return new Uint8Array(Buffer.from(keyB64, 'base64'));
+	return new Uint8Array(Buffer.from(keyB64, 'base64'));
 }
 
 type StoredEnvironmentKey = {
-        keyB64: string;
-        version: number;
-        fingerprint: string;
+	keyB64: string;
+	version: number;
+	fingerprint: string;
 };
 
 export type EnsureEnvironmentKeyResult = {
-        key: Uint8Array;
-        version: number;
-        fingerprint: string;
-        created: boolean;
+	key: Uint8Array;
+	version: number;
+	fingerprint: string;
+	created: boolean;
 };
 
 export class EnvironmentKeyService {
-        private static readonly KEYCHAIN_SERVICE = 'ghostable-cli-env';
+	private static readonly KEYCHAIN_SERVICE = 'ghostable-cli-env';
 
-        private constructor(private readonly keytar: Keytar) {}
+	private constructor(private readonly keytar: Keytar) {}
 
-        static async create(): Promise<EnvironmentKeyService> {
-                const keytar = await loadKeytar();
-                if (!keytar) {
-                        throw new Error(
-                                'OS keychain is unavailable. Environment key management requires keychain access.',
-                        );
-                }
+	static async create(): Promise<EnvironmentKeyService> {
+		const keytar = await loadKeytar();
+		if (!keytar) {
+			throw new Error(
+				'OS keychain is unavailable. Environment key management requires keychain access.',
+			);
+		}
 
-                return new EnvironmentKeyService(keytar);
-        }
+		return new EnvironmentKeyService(keytar);
+	}
 
-        private static account(projectId: string, envName: string): string {
-                return `${projectId}:${envName}`;
-        }
+	private static account(projectId: string, envName: string): string {
+		return `${projectId}:${envName}`;
+	}
 
-        private static fingerprintOf(key: Uint8Array): string {
-                return toHex(sha256(key));
-        }
+	private static fingerprintOf(key: Uint8Array): string {
+		return toHex(sha256(key));
+	}
 
-        private static normalizeFingerprint(value?: string | null): string {
-                return value ?? '';
-        }
+	private static normalizeFingerprint(value?: string | null): string {
+		return value ?? '';
+	}
 
-        private async loadLocal(projectId: string, envName: string): Promise<StoredEnvironmentKey | null> {
-                const raw = await this.keytar.getPassword(
-                        EnvironmentKeyService.KEYCHAIN_SERVICE,
-                        EnvironmentKeyService.account(projectId, envName),
-                );
-                if (!raw) return null;
-                try {
-                        const parsed = JSON.parse(raw) as StoredEnvironmentKey;
-                        if (!parsed?.keyB64) return null;
-                        return parsed;
-                } catch {
-                        return null;
-                }
-        }
+	private async loadLocal(
+		projectId: string,
+		envName: string,
+	): Promise<StoredEnvironmentKey | null> {
+		const raw = await this.keytar.getPassword(
+			EnvironmentKeyService.KEYCHAIN_SERVICE,
+			EnvironmentKeyService.account(projectId, envName),
+		);
+		if (!raw) return null;
+		try {
+			const parsed = JSON.parse(raw) as StoredEnvironmentKey;
+			if (!parsed?.keyB64) return null;
+			return parsed;
+		} catch {
+			return null;
+		}
+	}
 
-        private async saveLocal(
-                projectId: string,
-                envName: string,
-                value: StoredEnvironmentKey,
-        ): Promise<void> {
-                await this.keytar.setPassword(
-                        EnvironmentKeyService.KEYCHAIN_SERVICE,
-                        EnvironmentKeyService.account(projectId, envName),
-                        JSON.stringify(value),
-                );
-        }
+	private async saveLocal(
+		projectId: string,
+		envName: string,
+		value: StoredEnvironmentKey,
+	): Promise<void> {
+		await this.keytar.setPassword(
+			EnvironmentKeyService.KEYCHAIN_SERVICE,
+			EnvironmentKeyService.account(projectId, envName),
+			JSON.stringify(value),
+		);
+	}
 
-        async ensureEnvironmentKey(opts: {
-                client: GhostableClient;
-                projectId: string;
-                envName: string;
-                identity: DeviceIdentity;
-        }): Promise<EnsureEnvironmentKeyResult> {
-                const { client, projectId, envName, identity } = opts;
+	async ensureEnvironmentKey(opts: {
+		client: GhostableClient;
+		projectId: string;
+		envName: string;
+		identity: DeviceIdentity;
+	}): Promise<EnsureEnvironmentKeyResult> {
+		const { client, projectId, envName, identity } = opts;
 
-                const cached = await this.loadLocal(projectId, envName);
-                if (cached) {
-                        return {
-                                key: decodeKey(cached.keyB64),
-                                version: cached.version,
-                                fingerprint: EnvironmentKeyService.normalizeFingerprint(cached.fingerprint),
-                                created: false,
-                        };
-                }
+		const cached = await this.loadLocal(projectId, envName);
+		if (cached) {
+			return {
+				key: decodeKey(cached.keyB64),
+				version: cached.version,
+				fingerprint: EnvironmentKeyService.normalizeFingerprint(cached.fingerprint),
+				created: false,
+			};
+		}
 
-                const remote = await client.getEnvironmentKey(projectId, envName, identity.deviceId);
+		const remote = await client.getEnvironmentKey(projectId, envName, identity.deviceId);
 
-                if (remote) {
-                        const plaintext = await KeyService.decryptOnThisDevice(remote.envelope, identity.deviceId);
-                        const fingerprint = EnvironmentKeyService.normalizeFingerprint(remote.fingerprint);
-                        await this.saveLocal(projectId, envName, {
-                                keyB64: encodeKey(plaintext),
-                                version: remote.version,
-                                fingerprint,
-                        });
-                        return { key: plaintext, version: remote.version, fingerprint, created: false };
-                }
+		if (remote) {
+			const plaintext = await KeyService.decryptOnThisDevice(
+				remote.envelope,
+				identity.deviceId,
+			);
+			const fingerprint = EnvironmentKeyService.normalizeFingerprint(remote.fingerprint);
+			await this.saveLocal(projectId, envName, {
+				keyB64: encodeKey(plaintext),
+				version: remote.version,
+				fingerprint,
+			});
+			return { key: plaintext, version: remote.version, fingerprint, created: false };
+		}
 
-                const key = randomBytes(32);
-                const fingerprint = EnvironmentKeyService.fingerprintOf(key);
-                const version = 1;
-                await this.saveLocal(projectId, envName, {
-                        keyB64: encodeKey(key),
-                        version,
-                        fingerprint,
-                });
+		const key = randomBytes(32);
+		const fingerprint = EnvironmentKeyService.fingerprintOf(key);
+		const version = 1;
+		await this.saveLocal(projectId, envName, {
+			keyB64: encodeKey(key),
+			version,
+			fingerprint,
+		});
 
-                return { key, version, fingerprint, created: true };
-        }
+		return { key, version, fingerprint, created: true };
+	}
 
-        async publishKeyEnvelopes(opts: {
-                client: GhostableClient;
-                projectId: string;
-                envName: string;
-                identity: DeviceIdentity;
-                key: Uint8Array;
-                version: number;
-                fingerprint: string;
-        }): Promise<void> {
-                const { client, projectId, envName, identity, key, version, fingerprint } = opts;
+	async publishKeyEnvelopes(opts: {
+		client: GhostableClient;
+		projectId: string;
+		envName: string;
+		identity: DeviceIdentity;
+		key: Uint8Array;
+		version: number;
+		fingerprint: string;
+	}): Promise<void> {
+		const { client, projectId, envName, identity, key, version, fingerprint } = opts;
 
-                const devices = await client.listDevices();
-                if (!devices.length) return;
+		const devices = await client.listDevices();
+		if (!devices.length) return;
 
-                const envelopes: PublishEnvironmentKeyRequest['envelopes'] = [];
-                for (const device of devices) {
-                        if (!device.publicKey) continue;
-                        const envelope = await EnvelopeService.encrypt({
-                                sender: identity,
-                                recipientPublicKey: device.publicKey,
-                                plaintext: key,
-                                meta: {
-                                        project_id: projectId,
-                                        environment: envName,
-                                        key_fingerprint: fingerprint,
-                                },
-                        });
+		const envelopes: PublishEnvironmentKeyRequest['envelopes'] = [];
+		for (const device of devices) {
+			if (!device.publicKey) continue;
+			const envelope = await EnvelopeService.encrypt({
+				sender: identity,
+				recipientPublicKey: device.publicKey,
+				plaintext: key,
+				meta: {
+					project_id: projectId,
+					environment: envName,
+					key_fingerprint: fingerprint,
+				},
+			});
 
-                        envelopes.push({
-                                deviceId: device.id,
-                                envelope,
-                        });
-                }
+			envelopes.push({
+				deviceId: device.id,
+				envelope,
+			});
+		}
 
-                if (!envelopes.length) return;
+		if (!envelopes.length) return;
 
-                await client.publishEnvironmentKeyEnvelopes(projectId, envName, {
-                        version,
-                        fingerprint,
-                        envelopes,
-                });
-        }
+		await client.publishEnvironmentKeyEnvelopes(projectId, envName, {
+			version,
+			fingerprint,
+			envelopes,
+		});
+	}
 }

--- a/src/services/EnvironmentKeyService.ts
+++ b/src/services/EnvironmentKeyService.ts
@@ -1,0 +1,176 @@
+import { sha256 } from '@noble/hashes/sha256';
+
+import { randomBytes } from '../crypto.js';
+import { loadKeytar, type Keytar } from '../support/keyring.js';
+import { EnvelopeService } from './EnvelopeService.js';
+import type { GhostableClient } from './GhostableClient.js';
+
+import { KeyService, type DeviceIdentity } from '@/crypto';
+import type { PublishEnvironmentKeyRequest } from '@/types';
+
+function toHex(bytes: Uint8Array): string {
+        return Buffer.from(bytes).toString('hex');
+}
+
+function encodeKey(key: Uint8Array): string {
+        return Buffer.from(key).toString('base64');
+}
+
+function decodeKey(keyB64: string): Uint8Array {
+        return new Uint8Array(Buffer.from(keyB64, 'base64'));
+}
+
+type StoredEnvironmentKey = {
+        keyB64: string;
+        version: number;
+        fingerprint: string;
+};
+
+export type EnsureEnvironmentKeyResult = {
+        key: Uint8Array;
+        version: number;
+        fingerprint: string;
+        created: boolean;
+};
+
+export class EnvironmentKeyService {
+        private static readonly KEYCHAIN_SERVICE = 'ghostable-cli-env';
+
+        private constructor(private readonly keytar: Keytar) {}
+
+        static async create(): Promise<EnvironmentKeyService> {
+                const keytar = await loadKeytar();
+                if (!keytar) {
+                        throw new Error(
+                                'OS keychain is unavailable. Environment key management requires keychain access.',
+                        );
+                }
+
+                return new EnvironmentKeyService(keytar);
+        }
+
+        private static account(projectId: string, envName: string): string {
+                return `${projectId}:${envName}`;
+        }
+
+        private static fingerprintOf(key: Uint8Array): string {
+                return toHex(sha256(key));
+        }
+
+        private static normalizeFingerprint(value?: string | null): string {
+                return value ?? '';
+        }
+
+        private async loadLocal(projectId: string, envName: string): Promise<StoredEnvironmentKey | null> {
+                const raw = await this.keytar.getPassword(
+                        EnvironmentKeyService.KEYCHAIN_SERVICE,
+                        EnvironmentKeyService.account(projectId, envName),
+                );
+                if (!raw) return null;
+                try {
+                        const parsed = JSON.parse(raw) as StoredEnvironmentKey;
+                        if (!parsed?.keyB64) return null;
+                        return parsed;
+                } catch {
+                        return null;
+                }
+        }
+
+        private async saveLocal(
+                projectId: string,
+                envName: string,
+                value: StoredEnvironmentKey,
+        ): Promise<void> {
+                await this.keytar.setPassword(
+                        EnvironmentKeyService.KEYCHAIN_SERVICE,
+                        EnvironmentKeyService.account(projectId, envName),
+                        JSON.stringify(value),
+                );
+        }
+
+        async ensureEnvironmentKey(opts: {
+                client: GhostableClient;
+                projectId: string;
+                envName: string;
+                identity: DeviceIdentity;
+        }): Promise<EnsureEnvironmentKeyResult> {
+                const { client, projectId, envName, identity } = opts;
+
+                const cached = await this.loadLocal(projectId, envName);
+                if (cached) {
+                        return {
+                                key: decodeKey(cached.keyB64),
+                                version: cached.version,
+                                fingerprint: EnvironmentKeyService.normalizeFingerprint(cached.fingerprint),
+                                created: false,
+                        };
+                }
+
+                const remote = await client.getEnvironmentKey(projectId, envName, identity.deviceId);
+
+                if (remote) {
+                        const plaintext = await KeyService.decryptOnThisDevice(remote.envelope, identity.deviceId);
+                        const fingerprint = EnvironmentKeyService.normalizeFingerprint(remote.fingerprint);
+                        await this.saveLocal(projectId, envName, {
+                                keyB64: encodeKey(plaintext),
+                                version: remote.version,
+                                fingerprint,
+                        });
+                        return { key: plaintext, version: remote.version, fingerprint, created: false };
+                }
+
+                const key = randomBytes(32);
+                const fingerprint = EnvironmentKeyService.fingerprintOf(key);
+                const version = 1;
+                await this.saveLocal(projectId, envName, {
+                        keyB64: encodeKey(key),
+                        version,
+                        fingerprint,
+                });
+
+                return { key, version, fingerprint, created: true };
+        }
+
+        async publishKeyEnvelopes(opts: {
+                client: GhostableClient;
+                projectId: string;
+                envName: string;
+                identity: DeviceIdentity;
+                key: Uint8Array;
+                version: number;
+                fingerprint: string;
+        }): Promise<void> {
+                const { client, projectId, envName, identity, key, version, fingerprint } = opts;
+
+                const devices = await client.listDevices();
+                if (!devices.length) return;
+
+                const envelopes: PublishEnvironmentKeyRequest['envelopes'] = [];
+                for (const device of devices) {
+                        if (!device.publicKey) continue;
+                        const envelope = await EnvelopeService.encrypt({
+                                sender: identity,
+                                recipientPublicKey: device.publicKey,
+                                plaintext: key,
+                                meta: {
+                                        project_id: projectId,
+                                        environment: envName,
+                                        key_fingerprint: fingerprint,
+                                },
+                        });
+
+                        envelopes.push({
+                                deviceId: device.id,
+                                envelope,
+                        });
+                }
+
+                if (!envelopes.length) return;
+
+                await client.publishEnvironmentKeyEnvelopes(projectId, envName, {
+                        version,
+                        fingerprint,
+                        envelopes,
+                });
+        }
+}

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -15,37 +15,37 @@ import type { DeviceStatus } from '@/domain';
 import type { EncryptedEnvelope, OneTimePrekey, SignedPrekey } from '@/crypto';
 
 import type {
-        ConsumeEnvelopeResponseJson,
-        DeviceDeleteResponseJson,
-        DeviceDocumentJson,
-        DeviceEnvelopeJson,
-        DeviceResourceJson,
-        DevicePrekeyBundle,
-        DevicePrekeyBundleJson,
-        EnvironmentJson,
-        EnvironmentKeyEnvelope,
-        EnvironmentKeyEnvelopeJson,
-        EnvironmentKeysResponse,
-        EnvironmentKeysResponseJson,
-        EnvironmentSecretBundleJson,
-        EnvironmentSuggestedNameJson,
-        EnvironmentTypeJson,
-        OrganizationJson,
-        PublishEnvironmentKeyRequest,
-        PublishEnvironmentKeyRequestJson,
-        PublishOneTimePrekeysResponseJson,
-        PublishSignedPrekeyResponseJson,
-        ProjectJson,
-        QueueEnvelopeResponseJson,
-        SignedEnvironmentSecretBatchUploadRequest,
-        SignedEnvironmentSecretUploadRequest,
+	ConsumeEnvelopeResponseJson,
+	DeviceDeleteResponseJson,
+	DeviceDocumentJson,
+	DeviceEnvelopeJson,
+	DeviceResourceJson,
+	DevicePrekeyBundle,
+	DevicePrekeyBundleJson,
+	EnvironmentJson,
+	EnvironmentKeyEnvelope,
+	EnvironmentKeyEnvelopeJson,
+	EnvironmentKeysResponse,
+	EnvironmentKeysResponseJson,
+	EnvironmentSecretBundleJson,
+	EnvironmentSuggestedNameJson,
+	EnvironmentTypeJson,
+	OrganizationJson,
+	PublishEnvironmentKeyRequest,
+	PublishEnvironmentKeyRequestJson,
+	PublishOneTimePrekeysResponseJson,
+	PublishSignedPrekeyResponseJson,
+	ProjectJson,
+	QueueEnvelopeResponseJson,
+	SignedEnvironmentSecretBatchUploadRequest,
+	SignedEnvironmentSecretUploadRequest,
 } from '@/types';
 import {
-        devicePrekeyBundleFromJSON,
-        encryptedEnvelopeToJSON,
-        environmentKeyEnvelopeFromJSON,
-        environmentKeysFromJSON,
-        publishEnvironmentKeyRequestToJSON,
+	devicePrekeyBundleFromJSON,
+	encryptedEnvelopeToJSON,
+	environmentKeyEnvelopeFromJSON,
+	environmentKeysFromJSON,
+	publishEnvironmentKeyRequestToJSON,
 } from '@/types';
 
 type LoginResponse = { token?: string; two_factor?: boolean };
@@ -77,23 +77,23 @@ export class GhostableClient {
 		return (res.data ?? []).map(Organization.fromJSON);
 	}
 
-        async projects(organizationId: string): Promise<Project[]> {
-                const res = await this.http.get<ListResp<ProjectJson>>(
-                        `/organizations/${organizationId}/projects`,
-                );
-                return (res.data ?? []).map(Project.fromJSON);
-        }
+	async projects(organizationId: string): Promise<Project[]> {
+		const res = await this.http.get<ListResp<ProjectJson>>(
+			`/organizations/${organizationId}/projects`,
+		);
+		return (res.data ?? []).map(Project.fromJSON);
+	}
 
-        async listDevices(): Promise<Device[]> {
-                const res = await this.http.get<{ data?: DeviceResourceJson[] }>('/devices');
-                return (res.data ?? []).map(Device.fromResource);
-        }
+	async listDevices(): Promise<Device[]> {
+		const res = await this.http.get<{ data?: DeviceResourceJson[] }>('/devices');
+		return (res.data ?? []).map(Device.fromResource);
+	}
 
-        async createProject(input: { organizationId: string; name: string }): Promise<Project> {
-                const res = await this.http.post<ProjectJson>(
-                        `/organizations/${input.organizationId}/projects`,
-                        { name: input.name },
-                );
+	async createProject(input: { organizationId: string; name: string }): Promise<Project> {
+		const res = await this.http.post<ProjectJson>(
+			`/organizations/${input.organizationId}/projects`,
+			{ name: input.name },
+		);
 		return Project.fromJSON(res);
 	}
 
@@ -187,57 +187,57 @@ export class GhostableClient {
 		return EnvironmentSecretBundle.fromJSON(json);
 	}
 
-        async getEnvironmentKeys(projectId: string, envName: string): Promise<EnvironmentKeysResponse> {
-                const p = encodeURIComponent(projectId);
-                const e = encodeURIComponent(envName);
+	async getEnvironmentKeys(projectId: string, envName: string): Promise<EnvironmentKeysResponse> {
+		const p = encodeURIComponent(projectId);
+		const e = encodeURIComponent(envName);
 
-                const json = await this.http.get<EnvironmentKeysResponseJson>(
-                        `/projects/${p}/environments/${e}/keys`,
-                );
+		const json = await this.http.get<EnvironmentKeysResponseJson>(
+			`/projects/${p}/environments/${e}/keys`,
+		);
 
-                return environmentKeysFromJSON(json);
-        }
+		return environmentKeysFromJSON(json);
+	}
 
-        async getEnvironmentKey(
-                projectId: string,
-                envName: string,
-                deviceId: string,
-        ): Promise<EnvironmentKeyEnvelope | null> {
-                const p = encodeURIComponent(projectId);
-                const e = encodeURIComponent(envName);
-                const d = encodeURIComponent(deviceId);
+	async getEnvironmentKey(
+		projectId: string,
+		envName: string,
+		deviceId: string,
+	): Promise<EnvironmentKeyEnvelope | null> {
+		const p = encodeURIComponent(projectId);
+		const e = encodeURIComponent(envName);
+		const d = encodeURIComponent(deviceId);
 
-                try {
-                        const json = await this.http.get<EnvironmentKeyEnvelopeJson>(
-                                `/projects/${p}/environments/${e}/keys/${d}`,
-                        );
-                        return environmentKeyEnvelopeFromJSON(json);
-                } catch (error) {
-                        if (error instanceof HttpError && error.status === 404) {
-                                return null;
-                        }
-                        throw error;
-                }
-        }
+		try {
+			const json = await this.http.get<EnvironmentKeyEnvelopeJson>(
+				`/projects/${p}/environments/${e}/keys/${d}`,
+			);
+			return environmentKeyEnvelopeFromJSON(json);
+		} catch (error) {
+			if (error instanceof HttpError && error.status === 404) {
+				return null;
+			}
+			throw error;
+		}
+	}
 
-        async publishEnvironmentKeyEnvelopes(
-                projectId: string,
-                envName: string,
-                request: PublishEnvironmentKeyRequest,
-        ): Promise<void> {
-                const p = encodeURIComponent(projectId);
-                const e = encodeURIComponent(envName);
-                await this.http.post<PublishEnvironmentKeyRequestJson>(
-                        `/projects/${p}/environments/${e}/keys`,
-                        publishEnvironmentKeyRequestToJSON(request),
-                );
-        }
+	async publishEnvironmentKeyEnvelopes(
+		projectId: string,
+		envName: string,
+		request: PublishEnvironmentKeyRequest,
+	): Promise<void> {
+		const p = encodeURIComponent(projectId);
+		const e = encodeURIComponent(envName);
+		await this.http.post<PublishEnvironmentKeyRequestJson>(
+			`/projects/${p}/environments/${e}/keys`,
+			publishEnvironmentKeyRequestToJSON(request),
+		);
+	}
 
-        async deploy(opts?: {
-                only?: string[];
-                includeMeta?: boolean;
-                includeVersions?: boolean;
-        }): Promise<EnvironmentSecretBundle> {
+	async deploy(opts?: {
+		only?: string[];
+		includeMeta?: boolean;
+		includeVersions?: boolean;
+	}): Promise<EnvironmentSecretBundle> {
 		const qs = new URLSearchParams();
 		if (opts?.includeMeta) qs.set('include_meta', '1');
 		if (opts?.includeVersions) qs.set('include_versions', '1');
@@ -321,20 +321,20 @@ export class GhostableClient {
 		return devicePrekeyBundleFromJSON(json);
 	}
 
-        async sendEnvelope(
-                deviceId: string,
-                envelope: EncryptedEnvelope,
-                senderDeviceId?: string,
-        ): Promise<{ id: string }> {
-                const json = await this.http.post<{ id: string }>(
-                        `${this.devicePath(deviceId)}/envelopes`,
-                        {
-                                envelope: encryptedEnvelopeToJSON(envelope),
-                                sender_device_id: senderDeviceId ?? deviceId,
-                        },
-                );
-                return { id: json.id };
-        }
+	async sendEnvelope(
+		deviceId: string,
+		envelope: EncryptedEnvelope,
+		senderDeviceId?: string,
+	): Promise<{ id: string }> {
+		const json = await this.http.post<{ id: string }>(
+			`${this.devicePath(deviceId)}/envelopes`,
+			{
+				envelope: encryptedEnvelopeToJSON(envelope),
+				sender_device_id: senderDeviceId ?? deviceId,
+			},
+		);
+		return { id: json.id };
+	}
 
 	async queueEnvelope(
 		deviceId: string,

--- a/src/support/secret-payload.ts
+++ b/src/support/secret-payload.ts
@@ -1,25 +1,39 @@
 import { aeadEncrypt, b64, deriveKeys, edSign, hmacSHA256 } from '../crypto.js';
 import type {
-	AAD,
-	Claims,
-	SecretUploadValidators,
-	SignedEnvironmentSecretUploadRequest,
+        AAD,
+        Claims,
+        SecretUploadValidators,
+        SignedEnvironmentSecretUploadRequest,
 } from '@/types';
 
 export async function buildSecretPayload(opts: {
-	org: string;
-	project: string;
-	env: string;
-	name: string;
-	plaintext: string;
-	masterSeed: Uint8Array;
-	edPriv: Uint8Array;
-	validators?: SecretUploadValidators;
-	ifVersion?: number;
+        org: string;
+        project: string;
+        env: string;
+        name: string;
+        plaintext: string;
+        keyMaterial: Uint8Array;
+        edPriv: Uint8Array;
+        validators?: SecretUploadValidators;
+        ifVersion?: number;
+        envKekVersion?: number;
+        envKekFingerprint?: string;
 }): Promise<SignedEnvironmentSecretUploadRequest> {
-	const { org, project, env, name, plaintext, masterSeed, edPriv, validators, ifVersion } = opts;
+        const {
+                org,
+                project,
+                env,
+                name,
+                plaintext,
+                keyMaterial,
+                edPriv,
+                validators,
+                ifVersion,
+                envKekVersion,
+                envKekFingerprint,
+        } = opts;
 
-	const { encKey, hmacKey } = deriveKeys(masterSeed, `${org}/${project}/${env}`);
+        const { encKey, hmacKey } = deriveKeys(keyMaterial, `${org}/${project}/${env}`);
 
 	const aad: AAD = { org, project, env, name };
 	const pt = new TextEncoder().encode(plaintext);
@@ -31,16 +45,18 @@ export async function buildSecretPayload(opts: {
 		validators: { non_empty: plaintext.length > 0, ...(validators ?? {}) },
 	};
 
-	const body = {
-		name,
-		env,
-		ciphertext: bundle.ciphertext,
-		nonce: bundle.nonce,
-		alg: bundle.alg,
-		aad: bundle.aad,
-		claims,
-		...(ifVersion !== undefined ? { if_version: ifVersion } : {}),
-	};
+        const body = {
+                name,
+                env,
+                ciphertext: bundle.ciphertext,
+                nonce: bundle.nonce,
+                alg: bundle.alg,
+                aad: bundle.aad,
+                claims,
+                ...(ifVersion !== undefined ? { if_version: ifVersion } : {}),
+                ...(envKekVersion !== undefined ? { env_kek_version: envKekVersion } : {}),
+                ...(envKekFingerprint ? { env_kek_fingerprint: envKekFingerprint } : {}),
+        };
 
 	const bytes = new TextEncoder().encode(JSON.stringify(body));
 	const sig = await edSign(edPriv, bytes);

--- a/src/support/secret-payload.ts
+++ b/src/support/secret-payload.ts
@@ -1,39 +1,39 @@
 import { aeadEncrypt, b64, deriveKeys, edSign, hmacSHA256 } from '../crypto.js';
 import type {
-        AAD,
-        Claims,
-        SecretUploadValidators,
-        SignedEnvironmentSecretUploadRequest,
+	AAD,
+	Claims,
+	SecretUploadValidators,
+	SignedEnvironmentSecretUploadRequest,
 } from '@/types';
 
 export async function buildSecretPayload(opts: {
-        org: string;
-        project: string;
-        env: string;
-        name: string;
-        plaintext: string;
-        keyMaterial: Uint8Array;
-        edPriv: Uint8Array;
-        validators?: SecretUploadValidators;
-        ifVersion?: number;
-        envKekVersion?: number;
-        envKekFingerprint?: string;
+	org: string;
+	project: string;
+	env: string;
+	name: string;
+	plaintext: string;
+	keyMaterial: Uint8Array;
+	edPriv: Uint8Array;
+	validators?: SecretUploadValidators;
+	ifVersion?: number;
+	envKekVersion?: number;
+	envKekFingerprint?: string;
 }): Promise<SignedEnvironmentSecretUploadRequest> {
-        const {
-                org,
-                project,
-                env,
-                name,
-                plaintext,
-                keyMaterial,
-                edPriv,
-                validators,
-                ifVersion,
-                envKekVersion,
-                envKekFingerprint,
-        } = opts;
+	const {
+		org,
+		project,
+		env,
+		name,
+		plaintext,
+		keyMaterial,
+		edPriv,
+		validators,
+		ifVersion,
+		envKekVersion,
+		envKekFingerprint,
+	} = opts;
 
-        const { encKey, hmacKey } = deriveKeys(keyMaterial, `${org}/${project}/${env}`);
+	const { encKey, hmacKey } = deriveKeys(keyMaterial, `${org}/${project}/${env}`);
 
 	const aad: AAD = { org, project, env, name };
 	const pt = new TextEncoder().encode(plaintext);
@@ -45,18 +45,18 @@ export async function buildSecretPayload(opts: {
 		validators: { non_empty: plaintext.length > 0, ...(validators ?? {}) },
 	};
 
-        const body = {
-                name,
-                env,
-                ciphertext: bundle.ciphertext,
-                nonce: bundle.nonce,
-                alg: bundle.alg,
-                aad: bundle.aad,
-                claims,
-                ...(ifVersion !== undefined ? { if_version: ifVersion } : {}),
-                ...(envKekVersion !== undefined ? { env_kek_version: envKekVersion } : {}),
-                ...(envKekFingerprint ? { env_kek_fingerprint: envKekFingerprint } : {}),
-        };
+	const body = {
+		name,
+		env,
+		ciphertext: bundle.ciphertext,
+		nonce: bundle.nonce,
+		alg: bundle.alg,
+		aad: bundle.aad,
+		claims,
+		...(ifVersion !== undefined ? { if_version: ifVersion } : {}),
+		...(envKekVersion !== undefined ? { env_kek_version: envKekVersion } : {}),
+		...(envKekFingerprint ? { env_kek_fingerprint: envKekFingerprint } : {}),
+	};
 
 	const bytes = new TextEncoder().encode(JSON.stringify(body));
 	const sig = await edSign(edPriv, bytes);

--- a/src/types/api/environment.ts
+++ b/src/types/api/environment.ts
@@ -1,4 +1,5 @@
-import type { AAD, CipherAlg, Claims, EncryptedEnvelope } from '@/types';
+import type { AAD, CipherAlg, Claims } from '@/types';
+import type { EncryptedEnvelope } from '@/crypto';
 import type { EncryptedEnvelopeJson } from '@/types';
 import { encryptedEnvelopeFromJSON, encryptedEnvelopeToJSON } from '@/types';
 
@@ -46,32 +47,32 @@ export type EnvironmentSuggestedNameJson = {
  * Common fields for environment secrets (shared by upload and response).
  */
 export type EnvironmentSecretCommon = {
-        /** Environment layer this secret came from (e.g., "production"). */
-        env: string;
+	/** Environment layer this secret came from (e.g., "production"). */
+	env: string;
 
-        /** Variable key, e.g., "APP_KEY". */
-        name: string;
+	/** Variable key, e.g., "APP_KEY". */
+	name: string;
 
-        /** Base64-encoded ciphertext of the variable value. */
-        ciphertext: string;
+	/** Base64-encoded ciphertext of the variable value. */
+	ciphertext: string;
 
-        /** Base64-encoded nonce used for encryption. */
-        nonce: string;
+	/** Base64-encoded nonce used for encryption. */
+	nonce: string;
 
-        /** Encryption algorithm used. */
-        alg: CipherAlg;
+	/** Encryption algorithm used. */
+	alg: CipherAlg;
 
-        /** Authenticated associated data (org/project/env/name). */
-        aad: AAD;
+	/** Authenticated associated data (org/project/env/name). */
+	aad: AAD;
 
-        /** Optional claims (HMAC, validators, etc.) attached by the client. */
-        claims?: Claims;
+	/** Optional claims (HMAC, validators, etc.) attached by the client. */
+	claims?: Claims;
 
-        /** Version of the environment KEK used during encryption (optional). */
-        env_kek_version?: number;
+	/** Version of the environment KEK used during encryption (optional). */
+	env_kek_version?: number;
 
-        /** Fingerprint of the environment KEK used during encryption (optional). */
-        env_kek_fingerprint?: string | null;
+	/** Fingerprint of the environment KEK used during encryption (optional). */
+	env_kek_fingerprint?: string | null;
 };
 
 /**
@@ -148,96 +149,96 @@ export type EnvironmentKeySummary = {
 };
 
 export type EnvironmentKeysResponse = {
-        projectId: string;
-        environment: string;
-        count: number;
-        data: EnvironmentKeySummary[];
+	projectId: string;
+	environment: string;
+	count: number;
+	data: EnvironmentKeySummary[];
 };
 
 /** JSON → TS mappers */
 export function environmentKeysFromJSON(
-        json: EnvironmentKeysResponseJson,
+	json: EnvironmentKeysResponseJson,
 ): EnvironmentKeysResponse {
-        return {
-                projectId: json.project_id,
-                environment: json.environment,
-                count: json.count,
-                data: json.data.map(environmentKeySummaryFromJSON),
-        };
+	return {
+		projectId: json.project_id,
+		environment: json.environment,
+		count: json.count,
+		data: json.data.map(environmentKeySummaryFromJSON),
+	};
 }
 
 export function environmentKeySummaryFromJSON(
-        item: EnvironmentKeySummaryJson,
+	item: EnvironmentKeySummaryJson,
 ): EnvironmentKeySummary {
-        return {
-                name: item.name,
-                version: item.version ?? null,
-                updatedAt: item.updated_at ?? null,
-                updatedByEmail: item.updated_by_email ?? null,
-        };
+	return {
+		name: item.name,
+		version: item.version ?? null,
+		updatedAt: item.updated_at ?? null,
+		updatedByEmail: item.updated_by_email ?? null,
+	};
 }
 
 export type EnvironmentKeyEnvelopeJson = {
-        version: number;
-        fingerprint?: string | null;
-        envelope: EncryptedEnvelopeJson;
+	version: number;
+	fingerprint?: string | null;
+	envelope: EncryptedEnvelopeJson;
 };
 
 export type EnvironmentKeyEnvelope = {
-        version: number;
-        fingerprint: string;
-        envelope: EncryptedEnvelope;
+	version: number;
+	fingerprint: string;
+	envelope: EncryptedEnvelope;
 };
 
 export type EnvironmentKeyEnvelopeUploadJson = {
-        device_id: string;
-        envelope: EncryptedEnvelopeJson;
+	device_id: string;
+	envelope: EncryptedEnvelopeJson;
 };
 
 export type EnvironmentKeyEnvelopeUpload = {
-        deviceId: string;
-        envelope: EncryptedEnvelope;
+	deviceId: string;
+	envelope: EncryptedEnvelope;
 };
 
 export type PublishEnvironmentKeyRequestJson = {
-        version: number;
-        fingerprint: string;
-        envelopes: EnvironmentKeyEnvelopeUploadJson[];
+	version: number;
+	fingerprint: string;
+	envelopes: EnvironmentKeyEnvelopeUploadJson[];
 };
 
 export type PublishEnvironmentKeyRequest = {
-        version: number;
-        fingerprint: string;
-        envelopes: EnvironmentKeyEnvelopeUpload[];
+	version: number;
+	fingerprint: string;
+	envelopes: EnvironmentKeyEnvelopeUpload[];
 };
 
 export function environmentKeyEnvelopeFromJSON(
-        json: EnvironmentKeyEnvelopeJson,
+	json: EnvironmentKeyEnvelopeJson,
 ): EnvironmentKeyEnvelope {
-        return {
-                version: json.version,
-                fingerprint: json.fingerprint ?? '',
-                envelope: encryptedEnvelopeFromJSON(json.envelope),
-        };
+	return {
+		version: json.version,
+		fingerprint: json.fingerprint ?? '',
+		envelope: encryptedEnvelopeFromJSON(json.envelope),
+	};
 }
 
 export function environmentKeyEnvelopeUploadToJSON(
-        upload: EnvironmentKeyEnvelopeUpload,
+	upload: EnvironmentKeyEnvelopeUpload,
 ): EnvironmentKeyEnvelopeUploadJson {
-        return {
-                device_id: upload.deviceId,
-                envelope: encryptedEnvelopeToJSON(upload.envelope),
-        };
+	return {
+		device_id: upload.deviceId,
+		envelope: encryptedEnvelopeToJSON(upload.envelope),
+	};
 }
 
 export function publishEnvironmentKeyRequestToJSON(
-        request: PublishEnvironmentKeyRequest,
+	request: PublishEnvironmentKeyRequest,
 ): PublishEnvironmentKeyRequestJson {
-        return {
-                version: request.version,
-                fingerprint: request.fingerprint,
-                envelopes: request.envelopes.map(environmentKeyEnvelopeUploadToJSON),
-        };
+	return {
+		version: request.version,
+		fingerprint: request.fingerprint,
+		envelopes: request.envelopes.map(environmentKeyEnvelopeUploadToJSON),
+	};
 }
 
 /**

--- a/src/types/api/environment.ts
+++ b/src/types/api/environment.ts
@@ -1,4 +1,6 @@
-import type { AAD, CipherAlg, Claims } from '@/types';
+import type { AAD, CipherAlg, Claims, EncryptedEnvelope } from '@/types';
+import type { EncryptedEnvelopeJson } from '@/types';
+import { encryptedEnvelopeFromJSON, encryptedEnvelopeToJSON } from '@/types';
 
 /**
  * Environment shape returned by Ghostable’s API.
@@ -44,26 +46,32 @@ export type EnvironmentSuggestedNameJson = {
  * Common fields for environment secrets (shared by upload and response).
  */
 export type EnvironmentSecretCommon = {
-	/** Environment layer this secret came from (e.g., "production"). */
-	env: string;
+        /** Environment layer this secret came from (e.g., "production"). */
+        env: string;
 
-	/** Variable key, e.g., "APP_KEY". */
-	name: string;
+        /** Variable key, e.g., "APP_KEY". */
+        name: string;
 
-	/** Base64-encoded ciphertext of the variable value. */
-	ciphertext: string;
+        /** Base64-encoded ciphertext of the variable value. */
+        ciphertext: string;
 
-	/** Base64-encoded nonce used for encryption. */
-	nonce: string;
+        /** Base64-encoded nonce used for encryption. */
+        nonce: string;
 
-	/** Encryption algorithm used. */
-	alg: CipherAlg;
+        /** Encryption algorithm used. */
+        alg: CipherAlg;
 
-	/** Authenticated associated data (org/project/env/name). */
-	aad: AAD;
+        /** Authenticated associated data (org/project/env/name). */
+        aad: AAD;
 
-	/** Optional claims (HMAC, validators, etc.) attached by the client. */
-	claims?: Claims;
+        /** Optional claims (HMAC, validators, etc.) attached by the client. */
+        claims?: Claims;
+
+        /** Version of the environment KEK used during encryption (optional). */
+        env_kek_version?: number;
+
+        /** Fingerprint of the environment KEK used during encryption (optional). */
+        env_kek_fingerprint?: string | null;
 };
 
 /**
@@ -140,33 +148,96 @@ export type EnvironmentKeySummary = {
 };
 
 export type EnvironmentKeysResponse = {
-	projectId: string;
-	environment: string;
-	count: number;
-	data: EnvironmentKeySummary[];
+        projectId: string;
+        environment: string;
+        count: number;
+        data: EnvironmentKeySummary[];
 };
 
 /** JSON → TS mappers */
 export function environmentKeysFromJSON(
-	json: EnvironmentKeysResponseJson,
+        json: EnvironmentKeysResponseJson,
 ): EnvironmentKeysResponse {
-	return {
-		projectId: json.project_id,
-		environment: json.environment,
-		count: json.count,
-		data: json.data.map(environmentKeySummaryFromJSON),
-	};
+        return {
+                projectId: json.project_id,
+                environment: json.environment,
+                count: json.count,
+                data: json.data.map(environmentKeySummaryFromJSON),
+        };
 }
 
 export function environmentKeySummaryFromJSON(
-	item: EnvironmentKeySummaryJson,
+        item: EnvironmentKeySummaryJson,
 ): EnvironmentKeySummary {
-	return {
-		name: item.name,
-		version: item.version ?? null,
-		updatedAt: item.updated_at ?? null,
-		updatedByEmail: item.updated_by_email ?? null,
-	};
+        return {
+                name: item.name,
+                version: item.version ?? null,
+                updatedAt: item.updated_at ?? null,
+                updatedByEmail: item.updated_by_email ?? null,
+        };
+}
+
+export type EnvironmentKeyEnvelopeJson = {
+        version: number;
+        fingerprint?: string | null;
+        envelope: EncryptedEnvelopeJson;
+};
+
+export type EnvironmentKeyEnvelope = {
+        version: number;
+        fingerprint: string;
+        envelope: EncryptedEnvelope;
+};
+
+export type EnvironmentKeyEnvelopeUploadJson = {
+        device_id: string;
+        envelope: EncryptedEnvelopeJson;
+};
+
+export type EnvironmentKeyEnvelopeUpload = {
+        deviceId: string;
+        envelope: EncryptedEnvelope;
+};
+
+export type PublishEnvironmentKeyRequestJson = {
+        version: number;
+        fingerprint: string;
+        envelopes: EnvironmentKeyEnvelopeUploadJson[];
+};
+
+export type PublishEnvironmentKeyRequest = {
+        version: number;
+        fingerprint: string;
+        envelopes: EnvironmentKeyEnvelopeUpload[];
+};
+
+export function environmentKeyEnvelopeFromJSON(
+        json: EnvironmentKeyEnvelopeJson,
+): EnvironmentKeyEnvelope {
+        return {
+                version: json.version,
+                fingerprint: json.fingerprint ?? '',
+                envelope: encryptedEnvelopeFromJSON(json.envelope),
+        };
+}
+
+export function environmentKeyEnvelopeUploadToJSON(
+        upload: EnvironmentKeyEnvelopeUpload,
+): EnvironmentKeyEnvelopeUploadJson {
+        return {
+                device_id: upload.deviceId,
+                envelope: encryptedEnvelopeToJSON(upload.envelope),
+        };
+}
+
+export function publishEnvironmentKeyRequestToJSON(
+        request: PublishEnvironmentKeyRequest,
+): PublishEnvironmentKeyRequestJson {
+        return {
+                version: request.version,
+                fingerprint: request.fingerprint,
+                envelopes: request.envelopes.map(environmentKeyEnvelopeUploadToJSON),
+        };
 }
 
 /**

--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -16,10 +16,9 @@ let localEnvVars: Record<string, string> = {};
 let snapshots: Record<string, { rawValue: string }> = {};
 let remoteBundle: any = { chain: ['prod'], secrets: [] };
 let decryptedSecrets: Array<{
-	entry: { name: string; meta?: { is_commented?: boolean } };
-	value: string;
+        entry: { name: string; meta?: { is_commented?: boolean } };
+        value: string;
 }> = [];
-const sendEnvelopeCalls: Array<{ deviceId: string; envelope: any }> = [];
 const writeFileCalls: Array<{ path: string; content: string }> = [];
 const copyFileCalls: Array<{ src: string; dest: string }> = [];
 
@@ -29,26 +28,23 @@ const identity = {
 	encryptionKey: { alg: 'X25519', publicKey: 'enc-pub', privateKey: 'enc-priv' },
 };
 
-const encryptedEnvelope = {
-	id: 'envelope-1',
-	version: 'v1',
-	alg: 'XChaCha20-Poly1305+HKDF-SHA256',
-	toDevicePublicKey: identity.encryptionKey.publicKey,
-	fromEphemeralPublicKey: 'ephemeral-pub',
-	nonceB64: Buffer.from('nonce').toString('base64'),
-	ciphertextB64: Buffer.from('ciphertext').toString('base64'),
-	createdAtIso: new Date('2024-01-01T00:00:00.000Z').toISOString(),
-	meta: {},
-};
+const buildSecretPayloadCalls: Array<Record<string, unknown>> = [];
 
-const encryptCalls: Array<{ plaintext: Uint8Array; meta?: Record<string, string> }> = [];
-
-const envelopeEncryptMock = vi.fn(
-	async (input: { plaintext: Uint8Array; meta?: Record<string, string> }) => {
-		encryptCalls.push(input);
-		return encryptedEnvelope;
-	},
-);
+const buildSecretPayloadMock = vi.fn(async (input: Record<string, unknown>) => {
+        buildSecretPayloadCalls.push(input);
+        return {
+                name: input.name,
+                env: input.env,
+                ciphertext: `cipher-${input.name as string}`,
+                nonce: 'nonce',
+                alg: 'alg',
+                aad: { org: input.org, project: input.project, env: input.env, name: input.name },
+                claims: { hmac: 'hmac', validators: {} },
+                client_sig: 'sig',
+                env_kek_version: input.envKekVersion,
+                env_kek_fingerprint: input.envKekFingerprint,
+        };
+});
 
 const requireIdentityMock = vi.fn(async () => identity);
 const createDeviceServiceMock = vi.fn(async () => ({ requireIdentity: requireIdentityMock }));
@@ -92,13 +88,12 @@ vi.mock('../src/services/SessionService.js', () => ({
 }));
 
 const client = {
-	pull: vi.fn(async () => remoteBundle),
-	uploadSecret: vi.fn(),
-	push: vi.fn(),
-	sendEnvelope: vi.fn(async (deviceId: string, envelope: any) => {
-		sendEnvelopeCalls.push({ deviceId, envelope });
-		return { id: 'envelope-1' };
-	}),
+        pull: vi.fn(async () => remoteBundle),
+        uploadSecret: vi.fn(),
+        push: vi.fn(),
+        getEnvironmentKey: vi.fn(async () => null),
+        publishEnvironmentKeyEnvelopes: vi.fn(),
+        listDevices: vi.fn(async () => []),
 };
 
 vi.mock('../src/services/GhostableClient.js', () => ({
@@ -110,7 +105,7 @@ vi.mock('../src/services/GhostableClient.js', () => ({
 }));
 
 vi.mock('../src/support/deploy-helpers.js', () => ({
-	decryptBundle: vi.fn(async () => ({ secrets: decryptedSecrets, warnings: [] })),
+        decryptBundle: vi.fn(async () => ({ secrets: decryptedSecrets, warnings: [] })),
 }));
 
 vi.mock('../src/support/env-files.js', () => ({
@@ -124,28 +119,28 @@ vi.mock('../src/support/workdir.js', () => ({
 }));
 
 vi.mock('../src/crypto.js', () => ({
-	initSodium: vi.fn(async () => {}),
-	deriveKeys: vi.fn(() => ({ encKey: new Uint8Array(), hmacKey: new Uint8Array() })),
-	aeadDecrypt: vi.fn((_encKey: Uint8Array, params: { ciphertext: string }) =>
-		new TextEncoder().encode(params.ciphertext),
-	),
-	scopeFromAAD: vi.fn(() => 'scope'),
-	aeadEncrypt: vi.fn(() => ({
-		ciphertext: 'ciphertext',
-		nonce: 'nonce',
-		alg: 'alg',
-		aad: { org: 'org', project: 'project', env: 'env', name: 'name' },
-	})),
-	edSign: vi.fn(async () => new Uint8Array()),
-	hmacSHA256: vi.fn(() => 'hmac'),
-	b64: vi.fn(() => 'encoded'),
+        initSodium: vi.fn(async () => {}),
+        deriveKeys: vi.fn(() => ({ encKey: new Uint8Array(), hmacKey: new Uint8Array() })),
+        aeadDecrypt: vi.fn((_encKey: Uint8Array, params: { ciphertext: string }) =>
+                new TextEncoder().encode(params.ciphertext),
+        ),
+        scopeFromAAD: vi.fn(() => 'scope'),
+        aeadEncrypt: vi.fn(() => ({
+                ciphertext: 'ciphertext',
+                nonce: 'nonce',
+                alg: 'alg',
+                aad: { org: 'org', project: 'project', env: 'env', name: 'name' },
+        })),
+        edSign: vi.fn(async () => new Uint8Array()),
+        hmacSHA256: vi.fn(() => 'hmac'),
+        b64: vi.fn(() => 'encoded'),
 }));
 
 vi.mock('../src/keys.js', () => ({
-	loadOrCreateKeys: vi.fn(async () => ({
-		masterSeedB64: 'b64:master',
-		ed25519PrivB64: 'b64:priv',
-	})),
+        loadOrCreateKeys: vi.fn(async () => ({
+                masterSeedB64: `b64:${Buffer.from('0123456789abcdef0123456789abcdef', 'utf8').toString('base64')}`,
+                ed25519PrivB64: `b64:${Buffer.from('abcdef0123456789abcdef0123456789', 'utf8').toString('base64')}`,
+        })),
 }));
 
 vi.mock('@inquirer/prompts', () => ({
@@ -153,15 +148,31 @@ vi.mock('@inquirer/prompts', () => ({
 }));
 
 vi.mock('../src/services/DeviceIdentityService.js', () => ({
-	DeviceIdentityService: {
-		create: createDeviceServiceMock,
-	},
+        DeviceIdentityService: {
+                create: createDeviceServiceMock,
+        },
 }));
 
-vi.mock('../src/services/EnvelopeService.js', () => ({
-	EnvelopeService: {
-		encrypt: envelopeEncryptMock,
-	},
+const ensureEnvironmentKeyMock = vi.fn(async () => ({
+        key: new Uint8Array([1, 2, 3, 4]),
+        version: 1,
+        fingerprint: 'fingerprint-1',
+        created: false,
+}));
+const publishKeyEnvelopesMock = vi.fn(async () => {});
+const createEnvironmentKeyServiceMock = vi.fn(async () => ({
+        ensureEnvironmentKey: ensureEnvironmentKeyMock,
+        publishKeyEnvelopes: publishKeyEnvelopesMock,
+}));
+
+vi.mock('../src/services/EnvironmentKeyService.js', () => ({
+        EnvironmentKeyService: {
+                create: createEnvironmentKeyServiceMock,
+        },
+}));
+
+vi.mock('../src/support/secret-payload.js', () => ({
+        buildSecretPayload: buildSecretPayloadMock,
 }));
 
 vi.mock('ora', () => ({
@@ -224,18 +235,22 @@ beforeEach(() => {
 	logOutputs.warn.length = 0;
 	logOutputs.error.length = 0;
 	logOutputs.ok.length = 0;
-	client.pull.mockClear();
-	client.uploadSecret.mockClear();
-	client.push.mockClear();
-	client.sendEnvelope.mockClear();
-	sendEnvelopeCalls.splice(0, sendEnvelopeCalls.length);
-	encryptCalls.splice(0, encryptCalls.length);
-	envelopeEncryptMock.mockClear();
-	createDeviceServiceMock.mockClear();
-	requireIdentityMock.mockClear();
-	spinner.start.mockClear();
-	spinner.succeed.mockClear();
-	spinner.fail.mockClear();
+        client.pull.mockClear();
+        client.uploadSecret.mockClear();
+        client.push.mockClear();
+        client.getEnvironmentKey.mockClear();
+        client.publishEnvironmentKeyEnvelopes.mockClear();
+        client.listDevices.mockClear();
+        buildSecretPayloadCalls.splice(0, buildSecretPayloadCalls.length);
+        buildSecretPayloadMock.mockClear();
+        ensureEnvironmentKeyMock.mockClear();
+        publishKeyEnvelopesMock.mockClear();
+        createEnvironmentKeyServiceMock.mockClear();
+        createDeviceServiceMock.mockClear();
+        requireIdentityMock.mockClear();
+        spinner.start.mockClear();
+        spinner.succeed.mockClear();
+        spinner.fail.mockClear();
 	spinner.text = '';
 	oraMock.mockClear();
 	existsSyncMock.mockClear();
@@ -353,11 +368,11 @@ describe('env:diff ignore behaviour', () => {
 });
 
 describe('env:push ignore behaviour', () => {
-	it('skips ignored keys when uploading', async () => {
-		localEnvVars = {
-			FOO: 'value',
-			GHOSTABLE_MASTER_SEED: 'true',
-			CUSTOM_TOKEN: 'custom',
+        it('skips ignored keys when uploading', async () => {
+                localEnvVars = {
+                        FOO: 'value',
+                        GHOSTABLE_MASTER_SEED: 'true',
+                        CUSTOM_TOKEN: 'custom',
 		};
 		snapshots = {
 			FOO: { rawValue: 'value' },
@@ -365,30 +380,39 @@ describe('env:push ignore behaviour', () => {
 			CUSTOM_TOKEN: { rawValue: 'custom' },
 		};
 
-		const program = new Command();
-		registerEnvPushCommand(program);
-		await program.parseAsync(['node', 'test', 'env:push', '--env', 'prod', '--assume-yes']);
+                const program = new Command();
+                registerEnvPushCommand(program);
+                await program.parseAsync(['node', 'test', 'env:push', '--env', 'prod', '--assume-yes']);
 
-		expect(envelopeEncryptMock).toHaveBeenCalledTimes(1);
-		const [[input]] = envelopeEncryptMock.mock.calls as Array<
-			[{ plaintext: Uint8Array; meta?: Record<string, string> }]
-		>;
-		expect(input).toBeDefined();
-		const plaintext = Buffer.from(input.plaintext).toString('utf8');
-		expect(plaintext).toBe('FOO=value\n');
-		expect(input.meta).toMatchObject({
-			project_id: 'project-id',
-			environment: 'prod',
-			org_id: 'org-1',
-			file_path: envFilePath,
-		});
+                expect(ensureEnvironmentKeyMock).toHaveBeenCalledTimes(1);
+                expect(publishKeyEnvelopesMock).not.toHaveBeenCalled();
+                expect(buildSecretPayloadMock).toHaveBeenCalledTimes(1);
 
-		expect(sendEnvelopeCalls).toHaveLength(1);
-		expect(sendEnvelopeCalls[0]).toEqual({
-			deviceId: identity.deviceId,
-			envelope: encryptedEnvelope,
-		});
-	});
+                const [call] = buildSecretPayloadMock.mock.calls;
+                expect(call[0]).toMatchObject({
+                        name: 'FOO',
+                        plaintext: 'value',
+                        envKekVersion: 1,
+                        envKekFingerprint: 'fingerprint-1',
+                });
+
+                expect(client.push).toHaveBeenCalledTimes(1);
+                const [args] = client.push.mock.calls;
+                expect(args[0]).toBe('project-id');
+                expect(args[1]).toBe('prod');
+                expect(args[2]).toEqual({
+                        secrets: [
+                                expect.objectContaining({
+                                        name: 'FOO',
+                                        env: 'prod',
+                                        ciphertext: 'cipher-FOO',
+                                        env_kek_version: 1,
+                                        env_kek_fingerprint: 'fingerprint-1',
+                                }),
+                        ],
+                });
+                expect(args[3]).toEqual({ sync: false });
+        });
 
 	it('passes sync flag to upload when requested', async () => {
 		localEnvVars = {
@@ -400,19 +424,21 @@ describe('env:push ignore behaviour', () => {
 
 		const program = new Command();
 		registerEnvPushCommand(program);
-		await program.parseAsync([
-			'node',
-			'test',
-			'env:push',
-			'--env',
-			'prod',
-			'--assume-yes',
-			'--sync',
-		]);
+                await program.parseAsync([
+                        'node',
+                        'test',
+                        'env:push',
+                        '--env',
+                        'prod',
+                        '--assume-yes',
+                        '--sync',
+                ]);
 
-		expect(envelopeEncryptMock).toHaveBeenCalledTimes(1);
-		expect(sendEnvelopeCalls).toHaveLength(1);
-	});
+                expect(buildSecretPayloadMock).toHaveBeenCalledTimes(1);
+                expect(client.push).toHaveBeenCalledTimes(1);
+                const [args] = client.push.mock.calls;
+                expect(args[3]).toEqual({ sync: true });
+        });
 });
 
 describe('env:pull ignore behaviour', () => {

--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -16,8 +16,8 @@ let localEnvVars: Record<string, string> = {};
 let snapshots: Record<string, { rawValue: string }> = {};
 let remoteBundle: any = { chain: ['prod'], secrets: [] };
 let decryptedSecrets: Array<{
-        entry: { name: string; meta?: { is_commented?: boolean } };
-        value: string;
+	entry: { name: string; meta?: { is_commented?: boolean } };
+	value: string;
 }> = [];
 const writeFileCalls: Array<{ path: string; content: string }> = [];
 const copyFileCalls: Array<{ src: string; dest: string }> = [];
@@ -31,19 +31,19 @@ const identity = {
 const buildSecretPayloadCalls: Array<Record<string, unknown>> = [];
 
 const buildSecretPayloadMock = vi.fn(async (input: Record<string, unknown>) => {
-        buildSecretPayloadCalls.push(input);
-        return {
-                name: input.name,
-                env: input.env,
-                ciphertext: `cipher-${input.name as string}`,
-                nonce: 'nonce',
-                alg: 'alg',
-                aad: { org: input.org, project: input.project, env: input.env, name: input.name },
-                claims: { hmac: 'hmac', validators: {} },
-                client_sig: 'sig',
-                env_kek_version: input.envKekVersion,
-                env_kek_fingerprint: input.envKekFingerprint,
-        };
+	buildSecretPayloadCalls.push(input);
+	return {
+		name: input.name,
+		env: input.env,
+		ciphertext: `cipher-${input.name as string}`,
+		nonce: 'nonce',
+		alg: 'alg',
+		aad: { org: input.org, project: input.project, env: input.env, name: input.name },
+		claims: { hmac: 'hmac', validators: {} },
+		client_sig: 'sig',
+		env_kek_version: input.envKekVersion,
+		env_kek_fingerprint: input.envKekFingerprint,
+	};
 });
 
 const requireIdentityMock = vi.fn(async () => identity);
@@ -88,12 +88,12 @@ vi.mock('../src/services/SessionService.js', () => ({
 }));
 
 const client = {
-        pull: vi.fn(async () => remoteBundle),
-        uploadSecret: vi.fn(),
-        push: vi.fn(),
-        getEnvironmentKey: vi.fn(async () => null),
-        publishEnvironmentKeyEnvelopes: vi.fn(),
-        listDevices: vi.fn(async () => []),
+	pull: vi.fn(async () => remoteBundle),
+	uploadSecret: vi.fn(),
+	push: vi.fn(),
+	getEnvironmentKey: vi.fn(async () => null),
+	publishEnvironmentKeyEnvelopes: vi.fn(),
+	listDevices: vi.fn(async () => []),
 };
 
 vi.mock('../src/services/GhostableClient.js', () => ({
@@ -105,7 +105,7 @@ vi.mock('../src/services/GhostableClient.js', () => ({
 }));
 
 vi.mock('../src/support/deploy-helpers.js', () => ({
-        decryptBundle: vi.fn(async () => ({ secrets: decryptedSecrets, warnings: [] })),
+	decryptBundle: vi.fn(async () => ({ secrets: decryptedSecrets, warnings: [] })),
 }));
 
 vi.mock('../src/support/env-files.js', () => ({
@@ -119,28 +119,28 @@ vi.mock('../src/support/workdir.js', () => ({
 }));
 
 vi.mock('../src/crypto.js', () => ({
-        initSodium: vi.fn(async () => {}),
-        deriveKeys: vi.fn(() => ({ encKey: new Uint8Array(), hmacKey: new Uint8Array() })),
-        aeadDecrypt: vi.fn((_encKey: Uint8Array, params: { ciphertext: string }) =>
-                new TextEncoder().encode(params.ciphertext),
-        ),
-        scopeFromAAD: vi.fn(() => 'scope'),
-        aeadEncrypt: vi.fn(() => ({
-                ciphertext: 'ciphertext',
-                nonce: 'nonce',
-                alg: 'alg',
-                aad: { org: 'org', project: 'project', env: 'env', name: 'name' },
-        })),
-        edSign: vi.fn(async () => new Uint8Array()),
-        hmacSHA256: vi.fn(() => 'hmac'),
-        b64: vi.fn(() => 'encoded'),
+	initSodium: vi.fn(async () => {}),
+	deriveKeys: vi.fn(() => ({ encKey: new Uint8Array(), hmacKey: new Uint8Array() })),
+	aeadDecrypt: vi.fn((_encKey: Uint8Array, params: { ciphertext: string }) =>
+		new TextEncoder().encode(params.ciphertext),
+	),
+	scopeFromAAD: vi.fn(() => 'scope'),
+	aeadEncrypt: vi.fn(() => ({
+		ciphertext: 'ciphertext',
+		nonce: 'nonce',
+		alg: 'alg',
+		aad: { org: 'org', project: 'project', env: 'env', name: 'name' },
+	})),
+	edSign: vi.fn(async () => new Uint8Array()),
+	hmacSHA256: vi.fn(() => 'hmac'),
+	b64: vi.fn(() => 'encoded'),
 }));
 
 vi.mock('../src/keys.js', () => ({
-        loadOrCreateKeys: vi.fn(async () => ({
-                masterSeedB64: `b64:${Buffer.from('0123456789abcdef0123456789abcdef', 'utf8').toString('base64')}`,
-                ed25519PrivB64: `b64:${Buffer.from('abcdef0123456789abcdef0123456789', 'utf8').toString('base64')}`,
-        })),
+	loadOrCreateKeys: vi.fn(async () => ({
+		masterSeedB64: `b64:${Buffer.from('0123456789abcdef0123456789abcdef', 'utf8').toString('base64')}`,
+		ed25519PrivB64: `b64:${Buffer.from('abcdef0123456789abcdef0123456789', 'utf8').toString('base64')}`,
+	})),
 }));
 
 vi.mock('@inquirer/prompts', () => ({
@@ -148,31 +148,31 @@ vi.mock('@inquirer/prompts', () => ({
 }));
 
 vi.mock('../src/services/DeviceIdentityService.js', () => ({
-        DeviceIdentityService: {
-                create: createDeviceServiceMock,
-        },
+	DeviceIdentityService: {
+		create: createDeviceServiceMock,
+	},
 }));
 
 const ensureEnvironmentKeyMock = vi.fn(async () => ({
-        key: new Uint8Array([1, 2, 3, 4]),
-        version: 1,
-        fingerprint: 'fingerprint-1',
-        created: false,
+	key: new Uint8Array([1, 2, 3, 4]),
+	version: 1,
+	fingerprint: 'fingerprint-1',
+	created: false,
 }));
 const publishKeyEnvelopesMock = vi.fn(async () => {});
 const createEnvironmentKeyServiceMock = vi.fn(async () => ({
-        ensureEnvironmentKey: ensureEnvironmentKeyMock,
-        publishKeyEnvelopes: publishKeyEnvelopesMock,
+	ensureEnvironmentKey: ensureEnvironmentKeyMock,
+	publishKeyEnvelopes: publishKeyEnvelopesMock,
 }));
 
 vi.mock('../src/services/EnvironmentKeyService.js', () => ({
-        EnvironmentKeyService: {
-                create: createEnvironmentKeyServiceMock,
-        },
+	EnvironmentKeyService: {
+		create: createEnvironmentKeyServiceMock,
+	},
 }));
 
 vi.mock('../src/support/secret-payload.js', () => ({
-        buildSecretPayload: buildSecretPayloadMock,
+	buildSecretPayload: buildSecretPayloadMock,
 }));
 
 vi.mock('ora', () => ({
@@ -235,22 +235,22 @@ beforeEach(() => {
 	logOutputs.warn.length = 0;
 	logOutputs.error.length = 0;
 	logOutputs.ok.length = 0;
-        client.pull.mockClear();
-        client.uploadSecret.mockClear();
-        client.push.mockClear();
-        client.getEnvironmentKey.mockClear();
-        client.publishEnvironmentKeyEnvelopes.mockClear();
-        client.listDevices.mockClear();
-        buildSecretPayloadCalls.splice(0, buildSecretPayloadCalls.length);
-        buildSecretPayloadMock.mockClear();
-        ensureEnvironmentKeyMock.mockClear();
-        publishKeyEnvelopesMock.mockClear();
-        createEnvironmentKeyServiceMock.mockClear();
-        createDeviceServiceMock.mockClear();
-        requireIdentityMock.mockClear();
-        spinner.start.mockClear();
-        spinner.succeed.mockClear();
-        spinner.fail.mockClear();
+	client.pull.mockClear();
+	client.uploadSecret.mockClear();
+	client.push.mockClear();
+	client.getEnvironmentKey.mockClear();
+	client.publishEnvironmentKeyEnvelopes.mockClear();
+	client.listDevices.mockClear();
+	buildSecretPayloadCalls.splice(0, buildSecretPayloadCalls.length);
+	buildSecretPayloadMock.mockClear();
+	ensureEnvironmentKeyMock.mockClear();
+	publishKeyEnvelopesMock.mockClear();
+	createEnvironmentKeyServiceMock.mockClear();
+	createDeviceServiceMock.mockClear();
+	requireIdentityMock.mockClear();
+	spinner.start.mockClear();
+	spinner.succeed.mockClear();
+	spinner.fail.mockClear();
 	spinner.text = '';
 	oraMock.mockClear();
 	existsSyncMock.mockClear();
@@ -368,11 +368,11 @@ describe('env:diff ignore behaviour', () => {
 });
 
 describe('env:push ignore behaviour', () => {
-        it('skips ignored keys when uploading', async () => {
-                localEnvVars = {
-                        FOO: 'value',
-                        GHOSTABLE_MASTER_SEED: 'true',
-                        CUSTOM_TOKEN: 'custom',
+	it('skips ignored keys when uploading', async () => {
+		localEnvVars = {
+			FOO: 'value',
+			GHOSTABLE_MASTER_SEED: 'true',
+			CUSTOM_TOKEN: 'custom',
 		};
 		snapshots = {
 			FOO: { rawValue: 'value' },
@@ -380,39 +380,39 @@ describe('env:push ignore behaviour', () => {
 			CUSTOM_TOKEN: { rawValue: 'custom' },
 		};
 
-                const program = new Command();
-                registerEnvPushCommand(program);
-                await program.parseAsync(['node', 'test', 'env:push', '--env', 'prod', '--assume-yes']);
+		const program = new Command();
+		registerEnvPushCommand(program);
+		await program.parseAsync(['node', 'test', 'env:push', '--env', 'prod', '--assume-yes']);
 
-                expect(ensureEnvironmentKeyMock).toHaveBeenCalledTimes(1);
-                expect(publishKeyEnvelopesMock).not.toHaveBeenCalled();
-                expect(buildSecretPayloadMock).toHaveBeenCalledTimes(1);
+		expect(ensureEnvironmentKeyMock).toHaveBeenCalledTimes(1);
+		expect(publishKeyEnvelopesMock).not.toHaveBeenCalled();
+		expect(buildSecretPayloadMock).toHaveBeenCalledTimes(1);
 
-                const [call] = buildSecretPayloadMock.mock.calls;
-                expect(call[0]).toMatchObject({
-                        name: 'FOO',
-                        plaintext: 'value',
-                        envKekVersion: 1,
-                        envKekFingerprint: 'fingerprint-1',
-                });
+		const [call] = buildSecretPayloadMock.mock.calls;
+		expect(call[0]).toMatchObject({
+			name: 'FOO',
+			plaintext: 'value',
+			envKekVersion: 1,
+			envKekFingerprint: 'fingerprint-1',
+		});
 
-                expect(client.push).toHaveBeenCalledTimes(1);
-                const [args] = client.push.mock.calls;
-                expect(args[0]).toBe('project-id');
-                expect(args[1]).toBe('prod');
-                expect(args[2]).toEqual({
-                        secrets: [
-                                expect.objectContaining({
-                                        name: 'FOO',
-                                        env: 'prod',
-                                        ciphertext: 'cipher-FOO',
-                                        env_kek_version: 1,
-                                        env_kek_fingerprint: 'fingerprint-1',
-                                }),
-                        ],
-                });
-                expect(args[3]).toEqual({ sync: false });
-        });
+		expect(client.push).toHaveBeenCalledTimes(1);
+		const [args] = client.push.mock.calls;
+		expect(args[0]).toBe('project-id');
+		expect(args[1]).toBe('prod');
+		expect(args[2]).toEqual({
+			secrets: [
+				expect.objectContaining({
+					name: 'FOO',
+					env: 'prod',
+					ciphertext: 'cipher-FOO',
+					env_kek_version: 1,
+					env_kek_fingerprint: 'fingerprint-1',
+				}),
+			],
+		});
+		expect(args[3]).toEqual({ sync: false });
+	});
 
 	it('passes sync flag to upload when requested', async () => {
 		localEnvVars = {
@@ -424,21 +424,21 @@ describe('env:push ignore behaviour', () => {
 
 		const program = new Command();
 		registerEnvPushCommand(program);
-                await program.parseAsync([
-                        'node',
-                        'test',
-                        'env:push',
-                        '--env',
-                        'prod',
-                        '--assume-yes',
-                        '--sync',
-                ]);
+		await program.parseAsync([
+			'node',
+			'test',
+			'env:push',
+			'--env',
+			'prod',
+			'--assume-yes',
+			'--sync',
+		]);
 
-                expect(buildSecretPayloadMock).toHaveBeenCalledTimes(1);
-                expect(client.push).toHaveBeenCalledTimes(1);
-                const [args] = client.push.mock.calls;
-                expect(args[3]).toEqual({ sync: true });
-        });
+		expect(buildSecretPayloadMock).toHaveBeenCalledTimes(1);
+		expect(client.push).toHaveBeenCalledTimes(1);
+		const [args] = client.push.mock.calls;
+		expect(args[3]).toEqual({ sync: true });
+	});
 });
 
 describe('env:pull ignore behaviour', () => {

--- a/test/services/GhostableClient.test.ts
+++ b/test/services/GhostableClient.test.ts
@@ -4,64 +4,69 @@ import type { HttpClient } from '../../src/http/HttpClient.js';
 import type { EncryptedEnvelope } from '../../src/crypto/index.js';
 import { encryptedEnvelopeToJSON } from '../../src/types/index.js';
 
-vi.mock('@/domain', () => ({
-        Device: { fromResource: vi.fn(), fromJSON: vi.fn() },
-        Environment: { fromJSON: vi.fn() },
-        EnvironmentSecretBundle: { fromJSON: vi.fn() },
-        EnvironmentSuggestedName: { fromJSON: vi.fn() },
-        EnvironmentType: { fromJSON: vi.fn() },
-        Organization: { fromJSON: vi.fn() },
-        Project: { fromJSON: vi.fn() },
-}), { virtual: true });
+vi.mock(
+	'@/domain',
+	() => ({
+		Device: { fromResource: vi.fn(), fromJSON: vi.fn() },
+		Environment: { fromJSON: vi.fn() },
+		EnvironmentSecretBundle: { fromJSON: vi.fn() },
+		EnvironmentSuggestedName: { fromJSON: vi.fn() },
+		EnvironmentType: { fromJSON: vi.fn() },
+		Organization: { fromJSON: vi.fn() },
+		Project: { fromJSON: vi.fn() },
+	}),
+	{ virtual: true },
+);
 
 vi.mock('@/types', async () => {
-        const actual = await vi.importActual<typeof import('../../src/types/index.js')>(
-                '../../src/types/index.js',
-        );
-        return actual;
+	const actual = await vi.importActual<typeof import('../../src/types/index.js')>(
+		'../../src/types/index.js',
+	);
+	return actual;
 });
 
-type GhostableClientCtor = (typeof import('../../src/services/GhostableClient.js'))['GhostableClient'];
+type GhostableClientCtor =
+	(typeof import('../../src/services/GhostableClient.js'))['GhostableClient'];
 
 let GhostableClient: GhostableClientCtor;
 
 beforeAll(async () => {
-        ({ GhostableClient } = await import('../../src/services/GhostableClient.js'));
+	({ GhostableClient } = await import('../../src/services/GhostableClient.js'));
 });
 
 describe('GhostableClient.sendEnvelope', () => {
-        const envelope: EncryptedEnvelope = {
-                id: 'env-1',
-                version: 'v1',
-                alg: 'XChaCha20-Poly1305+HKDF-SHA256',
-                toDevicePublicKey: 'recipient-key',
-                fromEphemeralPublicKey: 'ephemeral-key',
-                nonceB64: 'nonce',
-                ciphertextB64: 'ciphertext',
-                createdAtIso: '2024-01-01T00:00:00.000Z',
-        };
+	const envelope: EncryptedEnvelope = {
+		id: 'env-1',
+		version: 'v1',
+		alg: 'XChaCha20-Poly1305+HKDF-SHA256',
+		toDevicePublicKey: 'recipient-key',
+		fromEphemeralPublicKey: 'ephemeral-key',
+		nonceB64: 'nonce',
+		ciphertextB64: 'ciphertext',
+		createdAtIso: '2024-01-01T00:00:00.000Z',
+	};
 
-        it('includes sender_device_id when explicitly provided', async () => {
-                const post = vi.fn(async () => ({ id: '123' }));
-                const client = new GhostableClient({ post } as unknown as HttpClient);
+	it('includes sender_device_id when explicitly provided', async () => {
+		const post = vi.fn(async () => ({ id: '123' }));
+		const client = new GhostableClient({ post } as unknown as HttpClient);
 
-                await client.sendEnvelope('device-42', envelope, 'sender-99');
+		await client.sendEnvelope('device-42', envelope, 'sender-99');
 
-                expect(post).toHaveBeenCalledWith('/devices/device-42/envelopes', {
-                        envelope: encryptedEnvelopeToJSON(envelope),
-                        sender_device_id: 'sender-99',
-                });
-        });
+		expect(post).toHaveBeenCalledWith('/devices/device-42/envelopes', {
+			envelope: encryptedEnvelopeToJSON(envelope),
+			sender_device_id: 'sender-99',
+		});
+	});
 
-        it('defaults sender_device_id to the device path identifier when omitted', async () => {
-                const post = vi.fn(async () => ({ id: '456' }));
-                const client = new GhostableClient({ post } as unknown as HttpClient);
+	it('defaults sender_device_id to the device path identifier when omitted', async () => {
+		const post = vi.fn(async () => ({ id: '456' }));
+		const client = new GhostableClient({ post } as unknown as HttpClient);
 
-                await client.sendEnvelope('device-7', envelope);
+		await client.sendEnvelope('device-7', envelope);
 
-                expect(post).toHaveBeenCalledWith('/devices/device-7/envelopes', {
-                        envelope: encryptedEnvelopeToJSON(envelope),
-                        sender_device_id: 'device-7',
-                });
-        });
+		expect(post).toHaveBeenCalledWith('/devices/device-7/envelopes', {
+			envelope: encryptedEnvelopeToJSON(envelope),
+			sender_device_id: 'device-7',
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- ensure `env:push` loads an environment KEK via the keychain, shares new keys with teammates, and encrypts variables locally before upload
- update `buildSecretPayload`, Ghostable client types, and domain models to carry KEK metadata in requests
- adjust `var:push` and the env ignore tests for the new encryption flow and add an EnvironmentKeyService helper

## Testing
- npm test -- env-ignore

------
https://chatgpt.com/codex/tasks/task_e_68fe7e09a8288333a8bde1e94bc2c706