### PR TITLE
Fix environment key generation when remote key is missing

### DIFF
--- a/src/services/EnvironmentKeyService.ts
+++ b/src/services/EnvironmentKeyService.ts
@@ -147,6 +147,11 @@ export class EnvironmentKeyService {
 			};
 		}
 
+		const keyBytes = cached ? decodeKey(cached.keyB64) : randomBytes(32);
+		const version = cached?.version ?? 1;
+		const fingerprint =
+			cachedFingerprint || EnvironmentKeyService.fingerprintOf(keyBytes);
+
 		await this.saveLocal(projectId, envName, {
 			keyB64: encodeKey(keyBytes),
 			version,


### PR DESCRIPTION
## Summary
- generate or reuse local environment keys when the remote key is absent
- persist a normalized fingerprint alongside the cached key material

## Testing
- npm test -- EnvironmentKeyService

------
https://chatgpt.com/codex/tasks/task_e_690118cf9b548333bda7961a17e941c9