### PR TITLE
Use environment KEK for env sync and variable commands

### DIFF
--- a/src/commands/env-sync.ts
+++ b/src/commands/env-sync.ts
@@ -11,7 +11,7 @@ export function registerEnvSyncCommand(program: Command) {
 		.option('--file <PATH>', 'Path to .env file (default: .env.<env> or .env)')
 		.option('--env <ENV>', 'Environment name (if omitted, select from manifest)')
 		.option('-y, --assume-yes', 'Skip confirmation prompts', false)
-		.action(async (opts: PushOptions) => {
-			await runEnvPush({ ...opts, replace: true });
-		});
+                .action(async (opts: PushOptions) => {
+                        await runEnvPush({ ...opts, replace: true, sync: true, pruneServer: true });
+                });
 }

--- a/src/commands/var-pull.ts
+++ b/src/commands/var-pull.ts
@@ -8,10 +8,11 @@ import { config } from '../config/index.js';
 import { SessionService } from '../services/SessionService.js';
 import { GhostableClient } from '../services/GhostableClient.js';
 import { initSodium, deriveKeys, aeadDecrypt, scopeFromAAD } from '../crypto.js';
-import { loadOrCreateKeys } from '../keys.js';
 import { log } from '../support/logger.js';
 import { toErrorMessage } from '../support/errors.js';
 import { resolveWorkDir } from '../support/workdir.js';
+import { DeviceIdentityService } from '../services/DeviceIdentityService.js';
+import { EnvironmentKeyService } from '../services/EnvironmentKeyService.js';
 
 import type { EnvironmentSecret } from '@/domain';
 
@@ -158,9 +159,61 @@ export function registerVarPullCommand(program: Command) {
 				return;
 			}
 
-			await initSodium();
-			const keyBundle = await loadOrCreateKeys();
-			const masterSeed = Buffer.from(keyBundle.masterSeedB64.replace(/^b64:/, ''), 'base64');
+                        await initSodium();
+
+                        let identityService: DeviceIdentityService;
+                        try {
+                                identityService = await DeviceIdentityService.create();
+                        } catch (error) {
+                                log.error(`❌ Failed to access device identity: ${toErrorMessage(error)}`);
+                                process.exit(1);
+                                return;
+                        }
+
+                        let identity;
+                        try {
+                                identity = await identityService.requireIdentity();
+                        } catch (error) {
+                                log.error(`❌ Failed to load device identity: ${toErrorMessage(error)}`);
+                                process.exit(1);
+                                return;
+                        }
+
+                        let envKeyService: EnvironmentKeyService;
+                        try {
+                                envKeyService = await EnvironmentKeyService.create();
+                        } catch (error) {
+                                log.error(`❌ Failed to access environment keys: ${toErrorMessage(error)}`);
+                                process.exit(1);
+                                return;
+                        }
+
+                        const envKeys = new Map<string, Uint8Array>();
+                        const envs = new Set<string>();
+                        for (const layer of bundle.chain) {
+                                envs.add(layer);
+                        }
+                        for (const entry of bundle.secrets) {
+                                envs.add(entry.env);
+                        }
+
+                        for (const env of envs) {
+                                try {
+                                        const { key } = await envKeyService.ensureEnvironmentKey({
+                                                client,
+                                                projectId,
+                                                envName: env,
+                                                identity,
+                                        });
+                                        envKeys.set(env, key);
+                                } catch (error) {
+                                        log.error(
+                                                `❌ Failed to load environment key for ${env}: ${toErrorMessage(error)}`,
+                                        );
+                                        process.exit(1);
+                                        return;
+                                }
+                        }
 
 			const chainOrder: readonly string[] = bundle.chain;
 			const byEnv = new Map<string, EnvironmentSecret[]>();
@@ -175,8 +228,15 @@ export function registerVarPullCommand(program: Command) {
 			for (const layer of chainOrder) {
 				const entries: EnvironmentSecret[] = byEnv.get(layer) || [];
 				for (const entry of entries) {
-					const scope = scopeFromAAD(entry.aad);
-					const { encKey } = deriveKeys(masterSeed, scope);
+                                        const scope = scopeFromAAD(entry.aad);
+                                        const keyMaterial = envKeys.get(entry.env);
+                                        if (!keyMaterial) {
+                                                log.warn(
+                                                        `⚠️ Missing decryption key for ${entry.env}; skipping ${entry.name}`,
+                                                );
+                                                continue;
+                                        }
+                                        const { encKey } = deriveKeys(keyMaterial, scope);
 
 					try {
 						const plaintext = aeadDecrypt(encKey, {


### PR DESCRIPTION
## Summary
- ensure env:sync forwards sync-related flags when invoking env:push
- update var:push to derive encryption payloads from the environment KEK and publish new keys when created
- update var:pull to load environment KEKs for every layer before decrypting values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69011afe2e30833392bea5ef85c73413