### PR TITLE
Add browser login confirmation prompt

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -36,6 +36,8 @@ async function attemptBrowserLogin(client: GhostableClient): Promise<string | nu
 		throw error;
 	}
 
+	log.info('We need to open your browser to complete login.');
+	await input({ message: 'Press ENTER to continue...', default: '' });
 	log.info('🌐 Opening Ghostable in your browser to authenticate…');
 	try {
 		await open(session.loginUrl, { wait: false });


### PR DESCRIPTION
## Summary
- prompt the user before opening the browser for the login flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903840b9fa08333a03f44e654181cf6