### PR TITLE
Add browser-based registration command

### DIFF
--- a/src/commands/auth/browser-flow.ts
+++ b/src/commands/auth/browser-flow.ts
@@ -1,0 +1,112 @@
+import { input } from '@inquirer/prompts';
+import ora from 'ora';
+import open from 'open';
+import { log } from '../../support/logger.js';
+import { toErrorMessage } from '../../support/errors.js';
+import { HttpError } from '../../http/errors.js';
+import type {
+        BrowserLoginSession,
+        BrowserLoginStatus,
+} from '../../services/GhostableClient.js';
+
+const BROWSER_UNAVAILABLE_STATUSES = [404, 405, 409, 410, 422, 501];
+const MIN_BROWSER_POLL_INTERVAL_MS = 1_000;
+
+function parseExpiry(value?: string): number | null {
+        if (!value) return null;
+        const timestamp = Date.parse(value);
+        return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+async function delay(ms: number): Promise<void> {
+        await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type BrowserFlowHandlers = {
+        start: () => Promise<BrowserLoginSession>;
+        poll: (ticket: string) => Promise<BrowserLoginStatus>;
+};
+
+export type BrowserFlowCopy = {
+        intro: string;
+        open: string;
+        manual: string;
+        waiting: string;
+        expired: string;
+        cancelled: string;
+        success: string;
+};
+
+export type BrowserFlowOptions = {
+        handlers: BrowserFlowHandlers;
+        copy: BrowserFlowCopy;
+        unsupportedMessageSubstrings?: string[];
+};
+
+export async function runBrowserAuthFlow(options: BrowserFlowOptions): Promise<string | null> {
+        const { handlers, copy, unsupportedMessageSubstrings = [] } = options;
+
+        let session: BrowserLoginSession;
+        try {
+                session = await handlers.start();
+        } catch (error) {
+                if (error instanceof HttpError && BROWSER_UNAVAILABLE_STATUSES.includes(error.status)) {
+                        return null;
+                }
+                if (
+                        error instanceof Error &&
+                        unsupportedMessageSubstrings.some((text) => error.message.includes(text))
+                ) {
+                        return null;
+                }
+                throw error;
+        }
+
+        log.info(copy.intro);
+        await input({ message: 'Press ENTER to continue...', default: '' });
+        log.info(copy.open);
+        try {
+                await open(session.loginUrl, { wait: false });
+        } catch (error) {
+                const message = toErrorMessage(error);
+                if (message) {
+                        log.warn(`⚠️ Unable to automatically open the browser: ${message}`);
+                } else {
+                        log.warn('⚠️ Unable to automatically open the browser.');
+                }
+        }
+        log.info(`${copy.manual}\n${session.loginUrl}`);
+
+        const spinner = ora(copy.waiting).start();
+        const pollIntervalMs = Math.max(
+                MIN_BROWSER_POLL_INTERVAL_MS,
+                Math.round((session.pollIntervalSeconds ?? 2) * 1_000),
+        );
+        const expiresAt = parseExpiry(session.expiresAt);
+
+        while (true) {
+                if (expiresAt && Date.now() >= expiresAt) {
+                        spinner.fail(copy.expired);
+                        return null;
+                }
+
+                await delay(pollIntervalMs);
+
+                try {
+                        const status = await handlers.poll(session.ticket);
+                        if (status.token) {
+                                spinner.succeed(copy.success);
+                                return status.token;
+                        }
+                        if (status.status && status.status !== 'pending') {
+                                const message =
+                                        status.status === 'expired' ? copy.expired : copy.cancelled;
+                                spinner.fail(message);
+                                return null;
+                        }
+                } catch (error) {
+                        spinner.fail(toErrorMessage(error) || 'Authentication failed');
+                        throw error;
+                }
+        }
+}

--- a/src/commands/auth/shared.ts
+++ b/src/commands/auth/shared.ts
@@ -1,0 +1,41 @@
+import { select } from '@inquirer/prompts';
+import type { GhostableClient } from '../../services/GhostableClient.js';
+import type { SessionService } from '../../services/SessionService.js';
+import { log } from '../../support/logger.js';
+import { toErrorMessage } from '../../support/errors.js';
+import { linkDeviceFlow } from '../device/index.js';
+
+export async function finalizeAuthentication(
+        token: string,
+        client: GhostableClient,
+        session: SessionService,
+): Promise<void> {
+        const authed = client.withToken(token);
+        const orgs = await authed.organizations();
+
+        let organizationId: string | undefined;
+        if (orgs.length === 1) {
+                organizationId = orgs[0].id;
+                log.ok(`✅ Using organization: ${orgs[0].label()}`);
+        } else if (orgs.length > 1) {
+                organizationId = await select({
+                        message: 'Choose your organization',
+                        choices: orgs.map((o) => ({
+                                name: o.label(),
+                                value: o.id,
+                        })),
+                });
+                log.ok(`✅ Using organization: ${orgs.find((o) => o.id === organizationId)?.label()}`);
+        } else {
+                log.warn('No organizations found. Create one in the dashboard.');
+        }
+
+        await session.save({ accessToken: token, organizationId });
+        log.ok('✅ Session stored in OS keychain.');
+
+        try {
+                await linkDeviceFlow(authed);
+        } catch (deviceError) {
+                log.warn(`⚠️ Device provisioning skipped: ${toErrorMessage(deviceError) ?? String(deviceError)}`);
+        }
+}

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -1,0 +1,61 @@
+import { Command } from 'commander';
+import { config } from '../config/index.js';
+import { SessionService } from '../services/SessionService.js';
+import { GhostableClient } from '../services/GhostableClient.js';
+import { log } from '../support/logger.js';
+import { toErrorMessage } from '../support/errors.js';
+import { finalizeAuthentication } from './auth/shared.js';
+import { runBrowserAuthFlow } from './auth/browser-flow.js';
+
+export function registerRegisterCommand(program: Command) {
+        program
+                .command('register')
+                .description('Create a new Ghostable account')
+                .action(async () => {
+                        const apiBase = config.apiBase;
+                        const session = new SessionService();
+                        const client = GhostableClient.unauthenticated(apiBase);
+
+                        let token: string | null = null;
+                        try {
+                                token = await runBrowserAuthFlow({
+                                        handlers: {
+                                                start: () => client.startBrowserRegistration(),
+                                                poll: (ticket) => client.pollBrowserRegistration(ticket),
+                                        },
+                                        copy: {
+                                                intro: 'We need to open your browser to create your Ghostable account.',
+                                                open: '🌐 Opening Ghostable in your browser to continue…',
+                                                manual: 'If the browser does not open automatically, visit:',
+                                                waiting: 'Waiting for you to finish registration…',
+                                                expired: 'Registration link expired. Please try again.',
+                                                cancelled: 'Registration was cancelled.',
+                                                success: 'Account created. Completing setup…',
+                                        },
+                                        unsupportedMessageSubstrings: ['Browser registration'],
+                                });
+                        } catch (error) {
+                                const message = toErrorMessage(error);
+                                if (message) {
+                                        log.error(message);
+                                } else {
+                                        log.error('Registration failed.');
+                                }
+                                process.exit(1);
+                        }
+
+                        if (!token) {
+                                log.error(
+                                        'Browser registration is not available. Visit the Ghostable dashboard to create an account.',
+                                );
+                                process.exit(1);
+                        }
+
+                        try {
+                                await finalizeAuthentication(token, client, session);
+                        } catch (error) {
+                                log.error(toErrorMessage(error) || 'Registration failed');
+                                process.exit(1);
+                        }
+                });
+}

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -95,11 +95,11 @@ export class GhostableClient {
 		return res.token;
 	}
 
-	async startBrowserLogin(): Promise<BrowserLoginSession> {
-		const res = await this.http.post<BrowserLoginStartResponse>('/cli/login/start', {});
-		if (!res.ticket || !res.login_url) {
-			throw new Error('Browser login is not available.');
-		}
+        async startBrowserLogin(): Promise<BrowserLoginSession> {
+                const res = await this.http.post<BrowserLoginStartResponse>('/cli/login/start', {});
+                if (!res.ticket || !res.login_url) {
+                        throw new Error('Browser login is not available.');
+                }
 		return {
 			ticket: res.ticket,
 			loginUrl: res.login_url,
@@ -109,13 +109,35 @@ export class GhostableClient {
 		};
 	}
 
-	async pollBrowserLogin(ticket: string): Promise<BrowserLoginStatus> {
-		const res = await this.http.post<BrowserLoginPollResponse>('/cli/login/poll', { ticket });
-		return {
-			token: res.token,
-			status: res.status,
-		};
-	}
+        async pollBrowserLogin(ticket: string): Promise<BrowserLoginStatus> {
+                const res = await this.http.post<BrowserLoginPollResponse>('/cli/login/poll', { ticket });
+                return {
+                        token: res.token,
+                        status: res.status,
+                };
+        }
+
+        async startBrowserRegistration(): Promise<BrowserLoginSession> {
+                const res = await this.http.post<BrowserLoginStartResponse>('/cli/register/start', {});
+                if (!res.ticket || !res.login_url) {
+                        throw new Error('Browser registration is not available.');
+                }
+                return {
+                        ticket: res.ticket,
+                        loginUrl: res.login_url,
+                        pollIntervalSeconds: res.poll_interval,
+                        pollUrl: res.poll_url,
+                        expiresAt: res.expires_at,
+                };
+        }
+
+        async pollBrowserRegistration(ticket: string): Promise<BrowserLoginStatus> {
+                const res = await this.http.post<BrowserLoginPollResponse>('/cli/register/poll', { ticket });
+                return {
+                        token: res.token,
+                        status: res.status,
+                };
+        }
 
 	async organizations(): Promise<Organization[]> {
 		const res = await this.http.get<{ data?: OrganizationJson[] }>('/organizations');


### PR DESCRIPTION
## Summary
- factor shared authentication helpers used by login browser flow
- extend the client with browser-based registration endpoints
- add a `ghostable register` command that reuses the browser authentication flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69038887e2a48333bbeef2f045d28c1c