### PR TITLE
Fix browser registration flow to open registration URL

### DIFF
--- a/src/commands/auth/browser-flow.ts
+++ b/src/commands/auth/browser-flow.ts
@@ -59,20 +59,28 @@ export async function runBrowserAuthFlow(options: BrowserFlowOptions): Promise<s
 		throw error;
 	}
 
-	log.info(copy.intro);
-	await input({ message: 'Press ENTER to continue...', default: '' });
-	log.info(copy.open);
-	try {
-		await open(session.loginUrl, { wait: false });
-	} catch (error) {
-		const message = toErrorMessage(error);
-		if (message) {
-			log.warn(`⚠️ Unable to automatically open the browser: ${message}`);
-		} else {
-			log.warn('⚠️ Unable to automatically open the browser.');
-		}
-	}
-	log.info(`${copy.manual}\n${session.loginUrl}`);
+        log.info(copy.intro);
+        await input({ message: 'Press ENTER to continue...', default: '' });
+        log.info(copy.open);
+        try {
+                const browserUrl = session.browserUrl ?? session.loginUrl;
+                if (!browserUrl) {
+                        throw new Error('Browser authentication is not available.');
+                }
+                await open(browserUrl, { wait: false });
+        } catch (error) {
+                const message = toErrorMessage(error);
+                if (message) {
+                        log.warn(`⚠️ Unable to automatically open the browser: ${message}`);
+                } else {
+                        log.warn('⚠️ Unable to automatically open the browser.');
+                }
+        }
+        const manualUrl = session.browserUrl ?? session.loginUrl;
+        if (!manualUrl) {
+                throw new Error('Browser authentication is not available.');
+        }
+        log.info(`${copy.manual}\n${manualUrl}`);
 
 	const spinner = ora(copy.waiting).start();
 	const pollIntervalMs = Math.max(

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -63,11 +63,12 @@ type BrowserLoginPollResponse = {
 };
 
 export type BrowserLoginSession = {
-	ticket: string;
-	loginUrl: string;
-	pollIntervalSeconds?: number;
-	pollUrl?: string;
-	expiresAt?: string;
+        ticket: string;
+        browserUrl: string;
+        loginUrl?: string;
+        pollIntervalSeconds?: number;
+        pollUrl?: string;
+        expiresAt?: string;
 };
 
 export type BrowserLoginStatus = {
@@ -97,19 +98,20 @@ export class GhostableClient {
 		return res.token;
 	}
 
-	async startBrowserLogin(): Promise<BrowserLoginSession> {
-		const res = await this.http.post<BrowserLoginStartResponse>('/cli/login/start', {});
-		if (!res.ticket || !res.login_url) {
-			throw new Error('Browser login is not available.');
-		}
-		return {
-			ticket: res.ticket,
-			loginUrl: res.login_url,
-			pollIntervalSeconds: res.poll_interval,
-			pollUrl: res.poll_url,
-			expiresAt: res.expires_at,
-		};
-	}
+        async startBrowserLogin(): Promise<BrowserLoginSession> {
+                const res = await this.http.post<BrowserLoginStartResponse>('/cli/login/start', {});
+                if (!res.ticket || !res.login_url) {
+                        throw new Error('Browser login is not available.');
+                }
+                return {
+                        ticket: res.ticket,
+                        browserUrl: res.login_url,
+                        loginUrl: res.login_url,
+                        pollIntervalSeconds: res.poll_interval,
+                        pollUrl: res.poll_url,
+                        expiresAt: res.expires_at,
+                };
+        }
 
 	async pollBrowserLogin(ticket: string): Promise<BrowserLoginStatus> {
 		const res = await this.http.post<BrowserLoginPollResponse>('/cli/login/poll', { ticket });
@@ -127,7 +129,8 @@ export class GhostableClient {
                 }
                 return {
                         ticket: res.ticket,
-                        loginUrl: registrationUrl,
+                        browserUrl: registrationUrl,
+                        loginUrl: res.login_url ?? registrationUrl,
                         pollIntervalSeconds: res.poll_interval,
                         pollUrl: res.poll_url,
                         expiresAt: res.expires_at,

--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -49,11 +49,13 @@ import {
 
 type LoginResponse = { token?: string; two_factor?: boolean };
 type BrowserLoginStartResponse = {
-	ticket?: string;
-	login_url?: string;
-	poll_interval?: number;
-	poll_url?: string;
-	expires_at?: string;
+        ticket?: string;
+        login_url?: string;
+        register_url?: string;
+        registration_url?: string;
+        poll_interval?: number;
+        poll_url?: string;
+        expires_at?: string;
 };
 type BrowserLoginPollResponse = {
 	token?: string;
@@ -117,19 +119,20 @@ export class GhostableClient {
 		};
 	}
 
-	async startBrowserRegistration(): Promise<BrowserLoginSession> {
-		const res = await this.http.post<BrowserLoginStartResponse>('/cli/register/start', {});
-		if (!res.ticket || !res.login_url) {
-			throw new Error('Browser registration is not available.');
-		}
-		return {
-			ticket: res.ticket,
-			loginUrl: res.login_url,
-			pollIntervalSeconds: res.poll_interval,
-			pollUrl: res.poll_url,
-			expiresAt: res.expires_at,
-		};
-	}
+        async startBrowserRegistration(): Promise<BrowserLoginSession> {
+                const res = await this.http.post<BrowserLoginStartResponse>('/cli/register/start', {});
+                const registrationUrl = res.register_url ?? res.registration_url ?? res.login_url;
+                if (!res.ticket || !registrationUrl) {
+                        throw new Error('Browser registration is not available.');
+                }
+                return {
+                        ticket: res.ticket,
+                        loginUrl: registrationUrl,
+                        pollIntervalSeconds: res.poll_interval,
+                        pollUrl: res.poll_url,
+                        expiresAt: res.expires_at,
+                };
+        }
 
 	async pollBrowserRegistration(ticket: string): Promise<BrowserLoginStatus> {
 		const res = await this.http.post<BrowserLoginPollResponse>('/cli/register/poll', {

--- a/test/services/GhostableClient.test.ts
+++ b/test/services/GhostableClient.test.ts
@@ -70,3 +70,39 @@ describe('GhostableClient.sendEnvelope', () => {
 		});
 	});
 });
+
+describe('GhostableClient.startBrowserRegistration', () => {
+        it('uses register_url when provided', async () => {
+                const post = vi.fn(async () => ({
+                        ticket: 'ticket-1',
+                        register_url: 'https://ghostable.example/register',
+                        poll_interval: 4,
+                        poll_url: 'https://ghostable.example/poll',
+                        expires_at: '2024-01-01T00:00:00.000Z',
+                }));
+                const client = new GhostableClient({ post } as unknown as HttpClient);
+
+                const session = await client.startBrowserRegistration();
+
+                expect(post).toHaveBeenCalledWith('/cli/register/start', {});
+                expect(session).toEqual({
+                        ticket: 'ticket-1',
+                        loginUrl: 'https://ghostable.example/register',
+                        pollIntervalSeconds: 4,
+                        pollUrl: 'https://ghostable.example/poll',
+                        expiresAt: '2024-01-01T00:00:00.000Z',
+                });
+        });
+
+        it('falls back to login_url for backward compatibility', async () => {
+                const post = vi.fn(async () => ({
+                        ticket: 'ticket-2',
+                        login_url: 'https://ghostable.example/login',
+                }));
+                const client = new GhostableClient({ post } as unknown as HttpClient);
+
+                const session = await client.startBrowserRegistration();
+
+                expect(session.loginUrl).toBe('https://ghostable.example/login');
+        });
+});

--- a/test/services/GhostableClient.test.ts
+++ b/test/services/GhostableClient.test.ts
@@ -87,6 +87,7 @@ describe('GhostableClient.startBrowserRegistration', () => {
                 expect(post).toHaveBeenCalledWith('/cli/register/start', {});
                 expect(session).toEqual({
                         ticket: 'ticket-1',
+                        browserUrl: 'https://ghostable.example/register',
                         loginUrl: 'https://ghostable.example/register',
                         pollIntervalSeconds: 4,
                         pollUrl: 'https://ghostable.example/poll',
@@ -103,6 +104,7 @@ describe('GhostableClient.startBrowserRegistration', () => {
 
                 const session = await client.startBrowserRegistration();
 
+                expect(session.browserUrl).toBe('https://ghostable.example/login');
                 expect(session.loginUrl).toBe('https://ghostable.example/login');
         });
 });


### PR DESCRIPTION
## Summary
- ensure the browser registration flow uses register-specific URLs when returned by the API
- add unit tests covering register_url handling and fallback to login_url

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69039583d084833382d7747be27b8928