### PR TITLE
Handle email verification requirement in registration flow

### DIFF
--- a/src/services/GhostableClient.ts
+++ b/src/services/GhostableClient.ts
@@ -57,7 +57,7 @@ type BrowserLoginStartResponse = {
 };
 type BrowserLoginPollResponse = {
 	token?: string;
-	status?: 'pending' | 'approved' | 'expired' | 'cancelled';
+	status?: 'pending' | 'approved' | 'expired' | 'cancelled' | 'verification_required';
 };
 
 export type BrowserLoginSession = {
@@ -70,7 +70,7 @@ export type BrowserLoginSession = {
 
 export type BrowserLoginStatus = {
 	token?: string;
-	status?: 'pending' | 'approved' | 'expired' | 'cancelled';
+	status?: 'pending' | 'approved' | 'expired' | 'cancelled' | 'verification_required';
 };
 type ListResp<T> = { data?: T[] };
 


### PR DESCRIPTION
## Summary
- extend the browser auth flow to surface verification_required responses and return structured results
- update CLI registration to instruct users to verify email and bail when required, while keeping login fallback behavior unchanged
- recognize the verification status in the Ghostable client response types

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6903ae6920188333be266e8fa3d3db06