### PR TITLE
feat: add deployment token management commands

### DIFF
--- a/src/commands/deploy-token/common.ts
+++ b/src/commands/deploy-token/common.ts
@@ -1,0 +1,140 @@
+import { select } from '@inquirer/prompts';
+
+import { config } from '../../config/index.js';
+import { SessionService } from '../../services/SessionService.js';
+import { GhostableClient } from '../../services/GhostableClient.js';
+import { Manifest } from '../../support/Manifest.js';
+import { log } from '../../support/logger.js';
+import { toErrorMessage } from '../../support/errors.js';
+import { DeviceIdentityService } from '../../services/DeviceIdentityService.js';
+import { EnvironmentKeyService } from '../../services/EnvironmentKeyService.js';
+
+import type { DeviceIdentity } from '@/crypto';
+import type { Environment } from '@/domain';
+
+export type ProjectContext = {
+	projectId: string;
+	projectName: string;
+};
+
+export async function requireProjectContext(): Promise<ProjectContext> {
+	try {
+		return {
+			projectId: Manifest.id(),
+			projectName: Manifest.name(),
+		};
+	} catch (error) {
+		log.error(toErrorMessage(error));
+		process.exit(1);
+	}
+}
+
+export async function requireAuthedClient(): Promise<GhostableClient> {
+	const session = await new SessionService().load();
+	if (!session?.accessToken) {
+		log.error('❌ Not authenticated. Run `ghostable login`.');
+		process.exit(1);
+	}
+
+	return GhostableClient.unauthenticated(config.apiBase).withToken(session.accessToken);
+}
+
+export async function selectEnvironment(
+	client: GhostableClient,
+	projectId: string,
+	requested?: string,
+): Promise<Environment> {
+	let environments: Environment[] = [];
+	try {
+		environments = await client.getEnvironments(projectId);
+	} catch (error) {
+		log.error(`❌ Failed to load environments: ${toErrorMessage(error)}`);
+		process.exit(1);
+	}
+
+	if (!environments.length) {
+		log.error('❌ No environments found for this project.');
+		process.exit(1);
+	}
+
+	if (requested) {
+		const normalized = requested.trim().toLowerCase();
+		const match = environments.find(
+			(env) => env.name.toLowerCase() === normalized || env.id === requested,
+		);
+		if (!match) {
+			log.error(`❌ Environment '${requested}' not found.`);
+			process.exit(1);
+		}
+		return match;
+	}
+
+	const choice = await select<string>({
+		message: 'Which environment should the deployment token target?',
+		choices: environments
+			.slice()
+			.sort((a, b) => a.name.localeCompare(b.name))
+			.map((env) => ({ name: `${env.name} (${env.type})`, value: env.id })),
+	});
+	const selected = environments.find((env) => env.id === choice);
+	if (!selected) {
+		log.error('❌ Invalid environment selection.');
+		process.exit(1);
+	}
+	return selected;
+}
+
+export async function requireDeviceIdentity(): Promise<DeviceIdentity> {
+	let service: DeviceIdentityService;
+	try {
+		service = await DeviceIdentityService.create();
+	} catch (error) {
+		log.error(`❌ Failed to access device identity: ${toErrorMessage(error)}`);
+		process.exit(1);
+	}
+
+	try {
+		return await service.requireIdentity();
+	} catch (error) {
+		log.error(`❌ ${toErrorMessage(error)}`);
+		process.exit(1);
+	}
+}
+
+export async function reshareEnvironmentKey(opts: {
+	client: GhostableClient;
+	projectId: string;
+	envName: string;
+	identity: DeviceIdentity;
+}): Promise<void> {
+	const { client, projectId, envName, identity } = opts;
+
+	let keyService: EnvironmentKeyService;
+	try {
+		keyService = await EnvironmentKeyService.create();
+	} catch (error) {
+		log.error(`❌ Failed to access environment keys: ${toErrorMessage(error)}`);
+		process.exit(1);
+	}
+
+	try {
+		const keyInfo = await keyService.ensureEnvironmentKey({
+			client,
+			projectId,
+			envName,
+			identity,
+		});
+		await keyService.publishKeyEnvelopes({
+			client,
+			projectId,
+			envName,
+			identity,
+			key: keyInfo.key,
+			version: keyInfo.version,
+			fingerprint: keyInfo.fingerprint,
+		});
+	} catch (error) {
+		log.error(`❌ Failed to share environment key: ${toErrorMessage(error)}`);
+		process.exit(1);
+	}
+}

--- a/src/commands/deploy-token/create.ts
+++ b/src/commands/deploy-token/create.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+import { input } from '@inquirer/prompts';
+import ora from 'ora';
+
+import { log } from '../../support/logger.js';
+import { toErrorMessage } from '../../support/errors.js';
+import {
+	requireAuthedClient,
+	requireDeviceIdentity,
+	requireProjectContext,
+	reshareEnvironmentKey,
+	selectEnvironment,
+} from './common.js';
+
+import { KeyService, MemoryKeyStore } from '@/crypto';
+
+export function configureCreateCommand(parent: Command) {
+	parent
+		.command('create')
+		.description('Create a new deployment token and X25519 keypair.')
+		.option('--env <ENV>', 'Environment name or ID to target')
+		.option('--name <NAME>', 'Token display name')
+		.option('--out <FILE>', 'Write the private key to a file instead of stdout')
+		.action(async (options: { env?: string; name?: string; out?: string }) => {
+			const { projectId } = await requireProjectContext();
+			const client = await requireAuthedClient();
+			const environment = await selectEnvironment(client, projectId, options.env);
+
+			const tokenName =
+				options.name?.trim() ||
+				(
+					await input({
+						message: 'Token name (shown in Ghostable dashboard)',
+						default: `${environment.name}-ci`,
+					})
+				).trim();
+
+			if (!tokenName) {
+				log.error('❌ Token name is required.');
+				process.exit(1);
+			}
+
+			KeyService.initialize(new MemoryKeyStore());
+
+			const spinner = ora('Minting deployment keypair…').start();
+			let privateKeyB64 = '';
+			try {
+				const identity = await KeyService.createDeviceIdentity(
+					tokenName,
+					'deployment-token',
+				);
+				privateKeyB64 = identity.encryptionKey.privateKey;
+
+				spinner.text = 'Registering deployment token…';
+				const created = await client.createDeployToken(projectId, {
+					environmentId: environment.id,
+					name: tokenName,
+					publicKey: identity.encryptionKey.publicKey,
+				});
+
+				spinner.text = 'Updating environment key shares…';
+				const deviceIdentity = await requireDeviceIdentity();
+				await reshareEnvironmentKey({
+					client,
+					projectId,
+					envName: environment.name,
+					identity: deviceIdentity,
+				});
+
+				spinner.succeed('Deployment token created.');
+				log.ok(`✅ Token ID: ${created.token.id}`);
+				log.ok(`🌱 Environment: ${environment.name}`);
+				if (created.secret) {
+					log.ok(`🔐 Access token: ${created.secret}`);
+				}
+
+				if (options.out) {
+					const resolved = path.resolve(options.out);
+					fs.mkdirSync(path.dirname(resolved), { recursive: true });
+					fs.writeFileSync(resolved, `${privateKeyB64}\n`, { mode: 0o600 });
+					log.ok(`🔑 Private key written to ${resolved}`);
+				} else {
+					log.info('🔑 Save this private key securely (Base64):');
+					console.log(privateKeyB64);
+				}
+			} catch (error) {
+				spinner.fail('Failed to create deployment token.');
+				log.error(toErrorMessage(error));
+				process.exit(1);
+			}
+		});
+}

--- a/src/commands/deploy-token/index.ts
+++ b/src/commands/deploy-token/index.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+
+import { configureCreateCommand } from './create.js';
+import { configureListCommand } from './list.js';
+import { configureRevokeCommand } from './revoke.js';
+import { configureRotateCommand } from './rotate.js';
+
+export function registerDeployTokenCommands(program: Command) {
+	const deploy = program
+		.command('deploy-token')
+		.description('Manage deployment tokens used for CI/CD deployments.');
+
+	configureListCommand(deploy);
+	configureCreateCommand(deploy);
+	configureRotateCommand(deploy);
+	configureRevokeCommand(deploy);
+}

--- a/src/commands/deploy-token/list.ts
+++ b/src/commands/deploy-token/list.ts
@@ -1,0 +1,42 @@
+import { Command } from 'commander';
+
+import { log } from '../../support/logger.js';
+import { toErrorMessage } from '../../support/errors.js';
+import { requireAuthedClient, requireProjectContext, selectEnvironment } from './common.js';
+
+export function configureListCommand(parent: Command) {
+	parent
+		.command('list')
+		.description('List deployment tokens for a project environment.')
+		.option('--env <ENV>', 'Environment name or ID to filter by')
+		.action(async (options: { env?: string }) => {
+			const { projectId } = await requireProjectContext();
+			const client = await requireAuthedClient();
+			const environment = await selectEnvironment(client, projectId, options.env);
+
+			let tokens;
+			try {
+				tokens = await client.listDeployTokens(projectId, environment.id);
+			} catch (error) {
+				log.error(`❌ Failed to load deployment tokens: ${toErrorMessage(error)}`);
+				process.exit(1);
+			}
+
+			if (!tokens.length) {
+				log.warn(`No deployment tokens found for ${environment.name}.`);
+				return;
+			}
+
+			const rows = tokens.map((token) => ({
+				ID: token.id,
+				Name: token.name,
+				Environment: token.environmentName,
+				Status: token.status,
+				Fingerprint: token.fingerprint ?? '—',
+				'Last used': token.lastUsedAt ? token.lastUsedAt.toISOString() : 'never',
+				Created: token.createdAt.toISOString(),
+			}));
+
+			console.table(rows);
+		});
+}

--- a/src/commands/deploy-token/revoke.ts
+++ b/src/commands/deploy-token/revoke.ts
@@ -1,0 +1,81 @@
+import { Command } from 'commander';
+import { select } from '@inquirer/prompts';
+import ora from 'ora';
+
+import { log } from '../../support/logger.js';
+import { toErrorMessage } from '../../support/errors.js';
+import {
+	requireAuthedClient,
+	requireDeviceIdentity,
+	requireProjectContext,
+	reshareEnvironmentKey,
+	selectEnvironment,
+} from './common.js';
+
+import { formatDeploymentTokenLabel, isDeploymentTokenActive } from '@/domain';
+
+export function configureRevokeCommand(parent: Command) {
+	parent
+		.command('revoke')
+		.description('Revoke an existing deployment token and reshare KEKs.')
+		.option('--env <ENV>', 'Environment name or ID that owns the token')
+		.option('--token <ID>', 'Deployment token ID to revoke')
+		.action(async (options: { env?: string; token?: string }) => {
+			const { projectId } = await requireProjectContext();
+			const client = await requireAuthedClient();
+			const environment = await selectEnvironment(client, projectId, options.env);
+
+			let tokens;
+			try {
+				tokens = await client.listDeployTokens(projectId, environment.id);
+			} catch (error) {
+				log.error(`❌ Failed to load deployment tokens: ${toErrorMessage(error)}`);
+				process.exit(1);
+			}
+
+			const active = tokens.filter(isDeploymentTokenActive);
+			if (!active.length) {
+				log.error(`❌ No active deployment tokens for ${environment.name}.`);
+				process.exit(1);
+			}
+
+			let target = options.token
+				? active.find((token) => token.id === options.token)
+				: undefined;
+
+			if (!target) {
+				const choice = await select<string>({
+					message: 'Select a deployment token to revoke',
+					choices: active.map((token) => ({
+						name: formatDeploymentTokenLabel(token),
+						value: token.id,
+					})),
+				});
+				target = active.find((token) => token.id === choice);
+			}
+
+			if (!target) {
+				log.error('❌ Deployment token not found.');
+				process.exit(1);
+			}
+
+			const spinner = ora('Revoking deployment token…').start();
+			try {
+				await client.revokeDeployToken(projectId, target.id);
+				spinner.text = 'Re-encrypting environment key for remaining identities…';
+				const deviceIdentity = await requireDeviceIdentity();
+				await reshareEnvironmentKey({
+					client,
+					projectId,
+					envName: environment.name,
+					identity: deviceIdentity,
+				});
+				spinner.succeed('Deployment token revoked.');
+				log.ok(`🛑 Revoked token ${target.id}`);
+			} catch (error) {
+				spinner.fail('Failed to revoke deployment token.');
+				log.error(toErrorMessage(error));
+				process.exit(1);
+			}
+		});
+}

--- a/src/commands/deploy-token/rotate.ts
+++ b/src/commands/deploy-token/rotate.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+import { select } from '@inquirer/prompts';
+import ora from 'ora';
+
+import { log } from '../../support/logger.js';
+import { toErrorMessage } from '../../support/errors.js';
+import {
+	requireAuthedClient,
+	requireDeviceIdentity,
+	requireProjectContext,
+	reshareEnvironmentKey,
+	selectEnvironment,
+} from './common.js';
+
+import { KeyService, MemoryKeyStore } from '@/crypto';
+import { formatDeploymentTokenLabel } from '@/domain';
+
+export function configureRotateCommand(parent: Command) {
+	parent
+		.command('rotate')
+		.description('Rotate the X25519 keypair for an existing deployment token.')
+		.option('--env <ENV>', 'Environment name or ID that owns the token')
+		.option('--token <ID>', 'Deployment token ID to rotate')
+		.option('--out <FILE>', 'Write the new private key to a file instead of stdout')
+		.action(async (options: { env?: string; token?: string; out?: string }) => {
+			const { projectId } = await requireProjectContext();
+			const client = await requireAuthedClient();
+			const environment = await selectEnvironment(client, projectId, options.env);
+
+			let tokens;
+			try {
+				tokens = await client.listDeployTokens(projectId, environment.id);
+			} catch (error) {
+				log.error(`❌ Failed to load deployment tokens: ${toErrorMessage(error)}`);
+				process.exit(1);
+			}
+
+			if (!tokens.length) {
+				log.error(`❌ No deployment tokens available for ${environment.name}.`);
+				process.exit(1);
+			}
+
+			let target = options.token
+				? tokens.find((token) => token.id === options.token)
+				: undefined;
+
+			if (!target) {
+				const choice = await select<string>({
+					message: 'Select a deployment token to rotate',
+					choices: tokens.map((token) => ({
+						name: formatDeploymentTokenLabel(token),
+						value: token.id,
+					})),
+				});
+				target = tokens.find((token) => token.id === choice);
+			}
+
+			if (!target) {
+				log.error('❌ Deployment token not found.');
+				process.exit(1);
+			}
+
+			KeyService.initialize(new MemoryKeyStore());
+			const spinner = ora('Minting replacement keypair…').start();
+			try {
+				const identity = await KeyService.createDeviceIdentity(
+					target.name,
+					'deployment-token',
+				);
+
+				spinner.text = 'Updating token on Ghostable…';
+				await client.rotateDeployToken(projectId, target.id, {
+					publicKey: identity.encryptionKey.publicKey,
+				});
+
+				spinner.text = 'Updating environment key shares…';
+				const deviceIdentity = await requireDeviceIdentity();
+				await reshareEnvironmentKey({
+					client,
+					projectId,
+					envName: environment.name,
+					identity: deviceIdentity,
+				});
+
+				spinner.succeed('Deployment token rotated.');
+				if (options.out) {
+					const resolved = path.resolve(options.out);
+					fs.mkdirSync(path.dirname(resolved), { recursive: true });
+					fs.writeFileSync(resolved, `${identity.encryptionKey.privateKey}\n`, {
+						mode: 0o600,
+					});
+					log.ok(`🔑 New private key written to ${resolved}`);
+				} else {
+					log.info('🔑 New private key (Base64):');
+					console.log(identity.encryptionKey.privateKey);
+				}
+			} catch (error) {
+				spinner.fail('Failed to rotate deployment token.');
+				log.error(toErrorMessage(error));
+				process.exit(1);
+			}
+		});
+}

--- a/src/domain/DeploymentToken.ts
+++ b/src/domain/DeploymentToken.ts
@@ -1,0 +1,24 @@
+export type DeploymentTokenStatus = 'active' | 'revoked';
+
+export type DeploymentToken = {
+	id: string;
+	name: string;
+	status: DeploymentTokenStatus;
+	publicKey: string;
+	fingerprint: string | null;
+	lastUsedAt: Date | null;
+	createdAt: Date;
+	updatedAt: Date | null;
+	revokedAt: Date | null;
+	environmentId: string;
+	environmentName: string;
+};
+
+export function isDeploymentTokenActive(token: DeploymentToken): boolean {
+	return token.status === 'active' && !token.revokedAt;
+}
+
+export function formatDeploymentTokenLabel(token: DeploymentToken): string {
+	const envPart = token.environmentName ? ` (${token.environmentName})` : '';
+	return `${token.name}${envPart}`;
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -7,3 +7,4 @@ export * from './Organization.js';
 export * from './Project.js';
 export * from './Device.js';
 export * from './DeviceEnvelope.js';
+export * from './DeploymentToken.js';

--- a/src/types/api/deploy-token.ts
+++ b/src/types/api/deploy-token.ts
@@ -1,0 +1,75 @@
+import type { DeploymentToken } from '@/domain';
+
+export type DeploymentTokenStatusJson = 'active' | 'revoked';
+
+export type DeploymentTokenEnvironmentJson = {
+	id: string;
+	name: string;
+};
+
+export type DeploymentTokenJson = {
+	id: string;
+	name: string;
+	status: DeploymentTokenStatusJson;
+	public_key: string;
+	fingerprint?: string | null;
+	last_used_at?: string | null;
+	created_at: string;
+	updated_at?: string | null;
+	revoked_at?: string | null;
+	environment: DeploymentTokenEnvironmentJson;
+};
+
+export type DeploymentTokenListResponseJson = {
+	data?: DeploymentTokenJson[];
+};
+
+export type CreateDeploymentTokenRequestJson = {
+	name: string;
+	environment_id: string;
+	public_key: string;
+};
+
+export type RotateDeploymentTokenRequestJson = {
+	public_key: string;
+};
+
+export type DeployTokenSecretJson = {
+	token: string;
+};
+
+export type CreateDeploymentTokenResponseJson = {
+	data: DeploymentTokenJson;
+	meta?: {
+		secret?: DeployTokenSecretJson;
+	};
+};
+
+export type RotateDeploymentTokenResponseJson = {
+	data: DeploymentTokenJson;
+};
+
+export type RevokeDeploymentTokenResponseJson = {
+	data: DeploymentTokenJson;
+};
+
+export type DeploymentTokenWithSecret = {
+	token: DeploymentToken;
+	secret?: string;
+};
+
+export function deploymentTokenFromJSON(json: DeploymentTokenJson): DeploymentToken {
+	return {
+		id: json.id,
+		name: json.name,
+		status: json.status,
+		publicKey: json.public_key,
+		fingerprint: json.fingerprint ?? null,
+		lastUsedAt: json.last_used_at ? new Date(json.last_used_at) : null,
+		createdAt: new Date(json.created_at),
+		updatedAt: json.updated_at ? new Date(json.updated_at) : null,
+		revokedAt: json.revoked_at ? new Date(json.revoked_at) : null,
+		environmentId: json.environment.id,
+		environmentName: json.environment.name,
+	};
+}

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -3,3 +3,4 @@ export * from './project.js';
 export * from './environment.js';
 export * from './crypto.js';
 export * from './device.js';
+export * from './deploy-token.js';


### PR DESCRIPTION
## Summary
- add a deploy-token command group with list/create/rotate/revoke flows, environment selection, and private key export support
- extend the Ghostable client plus domain/types for deployment token API endpoints and ensure KEK sharing re-encrypts for deployments
- include deployment tokens when publishing environment key envelopes so new identities stay in sync

## Testing
- npm run pretty
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69041f64539c8333ac25ed38d8cb6fc4