### PR TITLE
Handle JSON:API deployment token responses

### DIFF
--- a/src/types/api/deploy-token.ts
+++ b/src/types/api/deploy-token.ts
@@ -7,18 +7,26 @@ export type DeploymentTokenEnvironmentJson = {
 	name: string;
 };
 
-export type DeploymentTokenJson = {
-	id: string;
-	name: string;
-	status: DeploymentTokenStatusJson;
-	public_key: string;
+type DeploymentTokenAttributesJson = {
+	name?: string;
+	status?: DeploymentTokenStatusJson;
+	public_key?: string;
 	fingerprint?: string | null;
 	last_used_at?: string | null;
-	created_at: string;
+	created_at?: string;
 	updated_at?: string | null;
 	revoked_at?: string | null;
-	environment: DeploymentTokenEnvironmentJson;
+	environment?: DeploymentTokenEnvironmentJson | null;
+	environment_id?: string | null;
+	environment_name?: string | null;
 };
+
+export type DeploymentTokenJson =
+	| {
+			id: string;
+			attributes: DeploymentTokenAttributesJson;
+	  }
+	| ({ id: string } & DeploymentTokenAttributesJson);
 
 export type DeploymentTokenListResponseJson = {
 	data?: DeploymentTokenJson[];
@@ -59,17 +67,47 @@ export type DeploymentTokenWithSecret = {
 };
 
 export function deploymentTokenFromJSON(json: DeploymentTokenJson): DeploymentToken {
+	const attrs: DeploymentTokenAttributesJson = 'attributes' in json ? json.attributes : json;
+
+	const name = attrs.name ?? null;
+	const status = attrs.status ?? null;
+	const publicKey = attrs.public_key ?? null;
+	const createdAtIso = attrs.created_at ?? null;
+
+	if (!name) {
+		throw new Error('Deployment token is missing name');
+	}
+
+	if (!status) {
+		throw new Error('Deployment token is missing status');
+	}
+
+	if (!publicKey) {
+		throw new Error('Deployment token is missing public_key');
+	}
+
+	if (!createdAtIso) {
+		throw new Error('Deployment token is missing created_at');
+	}
+
+	const environmentId = attrs.environment?.id ?? attrs.environment_id ?? '';
+	if (!environmentId) {
+		throw new Error('Deployment token is missing environment identifier');
+	}
+
+	const environmentName = attrs.environment?.name ?? attrs.environment_name ?? environmentId;
+
 	return {
 		id: json.id,
-		name: json.name,
-		status: json.status,
-		publicKey: json.public_key,
-		fingerprint: json.fingerprint ?? null,
-		lastUsedAt: json.last_used_at ? new Date(json.last_used_at) : null,
-		createdAt: new Date(json.created_at),
-		updatedAt: json.updated_at ? new Date(json.updated_at) : null,
-		revokedAt: json.revoked_at ? new Date(json.revoked_at) : null,
-		environmentId: json.environment.id,
-		environmentName: json.environment.name,
+		name,
+		status,
+		publicKey,
+		fingerprint: attrs.fingerprint ?? null,
+		lastUsedAt: attrs.last_used_at ? new Date(attrs.last_used_at) : null,
+		createdAt: new Date(createdAtIso),
+		updatedAt: attrs.updated_at ? new Date(attrs.updated_at) : null,
+		revokedAt: attrs.revoked_at ? new Date(attrs.revoked_at) : null,
+		environmentId,
+		environmentName,
 	};
 }


### PR DESCRIPTION
## Summary
- support deployment token responses where fields are nested under an `attributes` object
- add validation and fallbacks for missing environment metadata when transforming deployment tokens

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_6904dd930b24833397e26a01df6f9410