### PR TITLE
fix: align deploy token client with api metadata

### DIFF
--- a/src/commands/deploy-token/create.ts
+++ b/src/commands/deploy-token/create.ts
@@ -69,22 +69,43 @@ export function configureCreateCommand(parent: Command) {
 					identity: deviceIdentity,
 				});
 
-				spinner.succeed('Deployment token created.');
-				log.ok(`✅ Token ID: ${created.token.id}`);
-				log.ok(`🌱 Environment: ${environment.name}`);
-				if (created.secret) {
-					log.ok(`🔐 Access token: ${created.secret}`);
-				}
+                                spinner.succeed('Deployment token created.');
+                                log.ok(`✅ Token ID: ${created.token.id}`);
+                                log.ok(`🌱 Environment: ${environment.name}`);
 
-				if (options.out) {
-					const resolved = path.resolve(options.out);
-					fs.mkdirSync(path.dirname(resolved), { recursive: true });
-					fs.writeFileSync(resolved, `${privateKeyB64}\n`, { mode: 0o600 });
-					log.ok(`🔑 Private key written to ${resolved}`);
-				} else {
-					log.info('🔑 Save this private key securely (Base64):');
-					console.log(privateKeyB64);
-				}
+                                const apiTokenPlainText = created.apiToken?.plainText ?? created.secret;
+                                if (apiTokenPlainText) {
+                                        log.line();
+                                        log.info('Add this one-time API token to your CI as GHOSTABLE_CI_TOKEN:');
+                                        log.text(apiTokenPlainText);
+                                        log.warn('⚠️ Store this token securely — it cannot be retrieved again.');
+
+                                        if (created.apiToken?.tokenSuffix) {
+                                                log.info(
+                                                        `🔐 Token suffix (for reference in the dashboard): ${created.apiToken.tokenSuffix}`,
+                                                );
+                                        }
+
+                                        if (created.apiToken?.expiresAt) {
+                                                log.info(
+                                                        `⏰ API token expires at ${created.apiToken.expiresAt.toISOString()}`,
+                                                );
+                                        }
+                                }
+
+                                log.line();
+                                if (options.out) {
+                                        const resolved = path.resolve(options.out);
+                                        fs.mkdirSync(path.dirname(resolved), { recursive: true });
+                                        fs.writeFileSync(resolved, `${privateKeyB64}\n`, { mode: 0o600 });
+                                        log.ok(`🔑 Private key written to ${resolved}`);
+                                        log.info(
+                                                'Set GHOSTABLE_MASTER_SEED in your CI to the contents of this private key file.',
+                                        );
+                                } else {
+                                        log.info('Set GHOSTABLE_MASTER_SEED in your CI to this private key (Base64):');
+                                        log.text(privateKeyB64);
+                                }
 			} catch (error) {
 				spinner.fail('Failed to create deployment token.');
 				log.error(toErrorMessage(error));

--- a/src/types/api/deploy-token.ts
+++ b/src/types/api/deploy-token.ts
@@ -42,15 +42,18 @@ export type RotateDeploymentTokenRequestJson = {
 	public_key: string;
 };
 
-export type DeployTokenSecretJson = {
-	token: string;
-};
-
 export type CreateDeploymentTokenResponseJson = {
-	data: DeploymentTokenJson;
-	meta?: {
-		secret?: DeployTokenSecretJson;
-	};
+        data: DeploymentTokenJson;
+        meta?: {
+                secret?: string;
+                api_token?: {
+                        plain_text: string;
+                        id: string;
+                        name: string;
+                        token_suffix: string;
+                        expires_at?: string | null;
+                };
+        };
 };
 
 export type RotateDeploymentTokenResponseJson = {
@@ -61,9 +64,18 @@ export type RevokeDeploymentTokenResponseJson = {
 	data: DeploymentTokenJson;
 };
 
+export type DeploymentApiTokenMeta = {
+        plainText: string;
+        id: string;
+        name: string;
+        tokenSuffix: string;
+        expiresAt: Date | null;
+};
+
 export type DeploymentTokenWithSecret = {
-	token: DeploymentToken;
-	secret?: string;
+        token: DeploymentToken;
+        secret?: string;
+        apiToken?: DeploymentApiTokenMeta;
 };
 
 export function deploymentTokenFromJSON(json: DeploymentTokenJson): DeploymentToken {


### PR DESCRIPTION
## Summary
- update deploy-token API types to reflect the meta.secret string and expanded Sanctum token details
- capture the one-time token metadata when creating deploy tokens and expose it to the CLI
- display the Sanctum token suffix and expiry (when present) alongside the GHOSTABLE_CI_TOKEN guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6905125e02488333b663f7d58e49c397