### PR TITLE
Ensure deployment tokens receive environment key shares

### DIFF
--- a/src/commands/deploy-token/create.ts
+++ b/src/commands/deploy-token/create.ts
@@ -62,12 +62,14 @@ export function configureCreateCommand(parent: Command) {
 
 				spinner.text = 'Updating environment key shares…';
 				const deviceIdentity = await requireDeviceIdentity();
-				await reshareEnvironmentKey({
-					client,
-					projectId,
-					envName: environment.name,
-					identity: deviceIdentity,
-				});
+                                await reshareEnvironmentKey({
+                                        client,
+                                        projectId,
+                                        envId: environment.id,
+                                        envName: environment.name,
+                                        identity: deviceIdentity,
+                                        extraDeployTokens: [created.token],
+                                });
 
                                 spinner.succeed('Deployment token created.');
                                 log.ok(`✅ Token ID: ${created.token.id}`);

--- a/src/commands/deploy-token/revoke.ts
+++ b/src/commands/deploy-token/revoke.ts
@@ -64,12 +64,13 @@ export function configureRevokeCommand(parent: Command) {
 				await client.revokeDeployToken(projectId, target.id);
 				spinner.text = 'Re-encrypting environment key for remaining identities…';
 				const deviceIdentity = await requireDeviceIdentity();
-				await reshareEnvironmentKey({
-					client,
-					projectId,
-					envName: environment.name,
-					identity: deviceIdentity,
-				});
+                                await reshareEnvironmentKey({
+                                        client,
+                                        projectId,
+                                        envId: environment.id,
+                                        envName: environment.name,
+                                        identity: deviceIdentity,
+                                });
 				spinner.succeed('Deployment token revoked.');
 				log.ok(`🛑 Revoked token ${target.id}`);
 			} catch (error) {

--- a/src/commands/deploy-token/rotate.ts
+++ b/src/commands/deploy-token/rotate.ts
@@ -77,12 +77,13 @@ export function configureRotateCommand(parent: Command) {
 
 				spinner.text = 'Updating environment key shares…';
 				const deviceIdentity = await requireDeviceIdentity();
-				await reshareEnvironmentKey({
-					client,
-					projectId,
-					envName: environment.name,
-					identity: deviceIdentity,
-				});
+                                await reshareEnvironmentKey({
+                                        client,
+                                        projectId,
+                                        envId: environment.id,
+                                        envName: environment.name,
+                                        identity: deviceIdentity,
+                                });
 
 				spinner.succeed('Deployment token rotated.');
 				if (options.out) {


### PR DESCRIPTION
## Summary
- propagate environment IDs and newly created tokens into the key re-share helper
- merge freshly created tokens with the API response before publishing environment key envelopes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6908be555cc08333a14957e99b0bda23