### PR TITLE
Ensure environment ID is provided when publishing keys

### DIFF
--- a/test/env-ignore.test.ts
+++ b/test/env-ignore.test.ts
@@ -88,12 +88,15 @@ vi.mock('../src/services/SessionService.js', () => ({
 }));
 
 const client = {
-	pull: vi.fn(async () => remoteBundle),
-	uploadSecret: vi.fn(),
-	push: vi.fn(),
-	getEnvironmentKey: vi.fn(async () => null),
-	createEnvironmentKey: vi.fn(),
-	listDevices: vi.fn(async () => []),
+        pull: vi.fn(async () => remoteBundle),
+        uploadSecret: vi.fn(),
+        push: vi.fn(),
+        getEnvironmentKey: vi.fn(async () => null),
+        createEnvironmentKey: vi.fn(),
+        listDevices: vi.fn(async () => []),
+        getEnvironments: vi.fn(async () => [
+                { id: 'env-prod', name: 'prod', type: 'production' },
+        ]),
 };
 
 vi.mock('../src/services/GhostableClient.js', () => ({
@@ -238,9 +241,10 @@ beforeEach(() => {
 	client.pull.mockClear();
 	client.uploadSecret.mockClear();
 	client.push.mockClear();
-	client.getEnvironmentKey.mockClear();
-	client.createEnvironmentKey.mockClear();
-	client.listDevices.mockClear();
+        client.getEnvironmentKey.mockClear();
+        client.createEnvironmentKey.mockClear();
+        client.listDevices.mockClear();
+        client.getEnvironments.mockClear();
 	buildSecretPayloadCalls.splice(0, buildSecretPayloadCalls.length);
 	buildSecretPayloadMock.mockClear();
 	ensureEnvironmentKeyMock.mockClear();


### PR DESCRIPTION
## Summary
- resolve the environment ID before publishing key envelopes in `env:push` and `var:push`
- pass the resolved ID to `EnvironmentKeyService.publishKeyEnvelopes`
- extend the env command tests to mock `getEnvironments`

## Testing
- npm test -- env-ignore

------
https://chatgpt.com/codex/tasks/task_e_6908c55bee9c8333926d8d39ae8cbce1