### PR TITLE
Add deploy token envelope decryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "@inquirer/prompts": "^7.8.6",
+                "@noble/ciphers": "^2.0.1",
+                "@noble/curves": "^2.0.1",
                 "@noble/ed25519": "^2.3.0",
                 "@noble/hashes": "^1.8.0",
                 "@stablelib/random": "^2.0.1",
@@ -1085,6 +1087,45 @@
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@noble/ciphers": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.0.1.tgz",
+            "integrity": "sha512-xHK3XHPUW8DTAobU+G0XT+/w+JLM7/8k1UFdB5xg/zTFPnFCobhftzw8wl4Lw2aq/Rvir5pxfZV5fEazmeCJ2g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/curves": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+            "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "2.0.1"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/curves/node_modules/@noble/hashes": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+            "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
         },
         "node_modules/@noble/ed25519": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     },
     "dependencies": {
         "@inquirer/prompts": "^7.8.6",
+        "@noble/ciphers": "^2.0.1",
+        "@noble/curves": "^2.0.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/hashes": "^1.8.0",
         "@stablelib/random": "^2.0.1",

--- a/src/domain/EnvironmentSecretBundle.ts
+++ b/src/domain/EnvironmentSecretBundle.ts
@@ -1,20 +1,41 @@
-import type { EnvironmentSecretBundleJson } from '@/types';
+import type { EnvironmentSecretBundleJson, EnvironmentKey, EnvironmentKeyResourceJson } from '@/types';
+import { environmentKeyFromJSON } from '@/types';
 import { EnvironmentSecret } from './EnvironmentSecret.js';
 
 /**
  * Domain model for a bundle of encrypted secrets merged across inheritance.
  */
 export class EnvironmentSecretBundle {
-	constructor(
-		public readonly env: string,
-		public readonly chain: readonly string[],
-		public readonly secrets: readonly EnvironmentSecret[],
-	) {}
+        constructor(
+                public readonly env: string,
+                public readonly chain: readonly string[],
+                public readonly secrets: readonly EnvironmentSecret[],
+                public readonly environmentKey: EnvironmentKey | null = null,
+        ) {}
 
-	static fromJSON(json: EnvironmentSecretBundleJson): EnvironmentSecretBundle {
-		const secrets = (json.secrets ?? []).map(EnvironmentSecret.fromJSON);
-		return new EnvironmentSecretBundle(json.env, json.chain, secrets);
-	}
+        static fromJSON(json: EnvironmentSecretBundleJson): EnvironmentSecretBundle {
+                const secrets = (json.secrets ?? []).map(EnvironmentSecret.fromJSON);
+                const rawEnvironmentKey =
+                        (json.environmentKey as EnvironmentKey | { data?: EnvironmentKeyResourceJson | null } | null) ??
+                        (json.environment_key as EnvironmentKeyResourceJson | { data?: EnvironmentKeyResourceJson | null } | null) ??
+                        null;
+
+                let environmentKey: EnvironmentKey | null = null;
+                const resourceLike =
+                        rawEnvironmentKey && typeof rawEnvironmentKey === 'object' && 'data' in rawEnvironmentKey
+                                ? (rawEnvironmentKey as { data?: EnvironmentKeyResourceJson | null }).data
+                                : rawEnvironmentKey;
+
+                if (resourceLike) {
+                        if (typeof resourceLike === 'object' && 'attributes' in resourceLike) {
+                                environmentKey = environmentKeyFromJSON(resourceLike as EnvironmentKeyResourceJson);
+                        } else if (typeof resourceLike === 'object') {
+                                environmentKey = resourceLike as EnvironmentKey;
+                        }
+                }
+
+                return new EnvironmentSecretBundle(json.env, json.chain, secrets, environmentKey);
+        }
 
 	/** Returns the latest value version for a given key, if present. */
 	secretByName(name: string): EnvironmentSecret | undefined {

--- a/src/support/deploy-helpers.ts
+++ b/src/support/deploy-helpers.ts
@@ -7,8 +7,8 @@ import { config } from '../config/index.js';
 
 import { sha256 } from '@noble/hashes/sha256';
 import { hkdf } from '@noble/hashes/hkdf';
-import { x25519 } from '@noble/curves/ed25519';
-import { xchacha20poly1305 } from '@noble/ciphers/chacha';
+import { x25519 } from '@noble/curves/ed25519.js';
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
 
 import { initSodium, deriveKeys, aeadDecrypt, scopeFromAAD, hmacSHA256 } from '../crypto.js';
 import { deriveEnvKEK, deriveOrgKEK, deriveProjKEK } from '@/crypto';
@@ -235,10 +235,10 @@ export async function decryptBundle(
 
                 const nonce = decodeBase64(payload.nonce_b64);
                 const ciphertext = decodeBase64(payload.ciphertext_b64);
-                const aad = payload.aad_b64 ? decodeBase64(payload.aad_b64) : undefined;
+                const aadBytes = payload.aad_b64 ? decodeBase64(payload.aad_b64) : undefined;
 
                 try {
-                        const cipher = xchacha20poly1305(edekKey, nonce, aad);
+                        const cipher = xchacha20poly1305(edekKey, nonce, aadBytes);
                         const plaintext = cipher.decrypt(ciphertext);
                         const fingerprint = fingerprintOf(plaintext);
                         const cached = { key: plaintext, fingerprint };

--- a/src/support/deploy-helpers.ts
+++ b/src/support/deploy-helpers.ts
@@ -6,6 +6,9 @@ import { GhostableClient } from '../services/GhostableClient.js';
 import { config } from '../config/index.js';
 
 import { sha256 } from '@noble/hashes/sha256';
+import { hkdf } from '@noble/hashes/hkdf';
+import { x25519 } from '@noble/curves/ed25519';
+import { xchacha20poly1305 } from '@noble/ciphers/chacha';
 
 import { initSodium, deriveKeys, aeadDecrypt, scopeFromAAD, hmacSHA256 } from '../crypto.js';
 import { deriveEnvKEK, deriveOrgKEK, deriveProjKEK } from '@/crypto';
@@ -118,18 +121,136 @@ export async function decryptBundle(
 	bundle: EnvironmentSecretBundle,
 	options?: DecryptOptions,
 ): Promise<DecryptionResult> {
-	await initSodium();
+        await initSodium();
 
-	const masterSeedB64 = await resolveMasterSeed(options?.masterSeedB64);
-	const masterSeed = Buffer.from(masterSeedB64.replace(/^b64:/, ''), 'base64');
+        const masterSeedB64 = await resolveMasterSeed(options?.masterSeedB64);
+        const masterSeed = Buffer.from(masterSeedB64.replace(/^b64:/, ''), 'base64');
+        const masterSeedBytes = new Uint8Array(masterSeed);
 
         const orgKeyCache = new Map<string, Uint8Array>();
         const projKeyCache = new Map<string, Uint8Array>();
         const envKeyCache = new Map<string, { key: Uint8Array; fingerprint: string }>();
+        const envelopeAttemptedScopes = new Set<string>();
+        const envelopeWarningKeys = new Set<string>();
+
+        const secrets: DecryptedSecret[] = [];
+        const warnings: string[] = [];
+
+        const decodeBase64 = (value: string): Uint8Array => {
+                const normalized = value.replace(/^b64:/, '');
+                return new Uint8Array(Buffer.from(normalized, 'base64'));
+        };
 
         const fingerprintOf = (key: Uint8Array): string => {
                 const digest = sha256(key);
                 return Buffer.from(digest).toString('hex');
+        };
+
+        const warnOnce = (key: string, message: string) => {
+                if (envelopeWarningKeys.has(key)) return;
+                envelopeWarningKeys.add(key);
+                warnings.push(message);
+        };
+
+        const hkdfInfo = new TextEncoder().encode('ghostable:edek:v1');
+
+        type DeploymentRecipientPayload = {
+                ciphertext_b64: string;
+                nonce_b64: string;
+                alg?: string | null;
+                aad_b64?: string | null;
+        };
+
+        const tryEnvKeyFromEnvelope = (aad: AAD | undefined): { key: Uint8Array; fingerprint: string } | null => {
+                if (!aad) return null;
+                const { org, project, env } = aad;
+                if (!org || !project || !env) return null;
+
+                const envScope = `${org}/${project}/${env}`;
+                const cachedEnv = envKeyCache.get(envScope);
+                if (cachedEnv) return cachedEnv;
+
+                if (envelopeAttemptedScopes.has(envScope)) return null;
+                envelopeAttemptedScopes.add(envScope);
+
+                const envelope = bundle.environmentKey?.envelope;
+                if (!envelope) return null;
+
+                const ephemeralB64 = envelope.fromEphemeralPublicKey;
+                if (!ephemeralB64) {
+                        warnOnce(
+                                'missing-ephemeral',
+                                'Environment key envelope is missing the ephemeral public key required to decrypt with this deployment token.',
+                        );
+                        return null;
+                }
+
+                const recipient = envelope.recipients.find((item) => item.type === 'deployment');
+                if (!recipient) {
+                        warnOnce(
+                                'missing-recipient',
+                                'Environment key is not yet shared with this deployment token. Re-share it to enable decryption.',
+                        );
+                        return null;
+                }
+
+                let payload: DeploymentRecipientPayload;
+                try {
+                        const raw = Buffer.from(recipient.edekB64.replace(/^b64:/, ''), 'base64').toString('utf8');
+                        payload = JSON.parse(raw) as DeploymentRecipientPayload;
+                } catch (error) {
+                        const reason = error instanceof Error ? error.message : String(error);
+                        warnOnce('payload-decode', `Failed to decode deployment token envelope payload: ${reason}.`);
+                        return null;
+                }
+
+                if (!payload?.ciphertext_b64 || !payload?.nonce_b64) {
+                        warnOnce('payload-missing', 'Deployment token envelope payload is missing ciphertext or nonce.');
+                        return null;
+                }
+
+                const alg = (payload.alg ?? envelope.alg ?? '').toLowerCase();
+                if (alg && alg !== 'xchacha20-poly1305') {
+                        const originalAlg = payload.alg ?? envelope.alg ?? alg;
+                        warnOnce('payload-alg', `Unsupported deployment token envelope algorithm "${originalAlg}".`);
+                        return null;
+                }
+
+                let sharedSecret: Uint8Array;
+                try {
+                        const pubKey = decodeBase64(ephemeralB64);
+                        sharedSecret = x25519.getSharedSecret(masterSeedBytes, pubKey);
+                } catch {
+                        warnOnce('shared-secret', 'Failed to derive shared secret for deployment token envelope.');
+                        return null;
+                }
+
+                let edekKey: Uint8Array;
+                try {
+                        edekKey = hkdf(sha256, sharedSecret, undefined, hkdfInfo, 32);
+                } catch {
+                        warnOnce('hkdf', 'Failed to derive deployment token EDEK key.');
+                        return null;
+                }
+
+                const nonce = decodeBase64(payload.nonce_b64);
+                const ciphertext = decodeBase64(payload.ciphertext_b64);
+                const aad = payload.aad_b64 ? decodeBase64(payload.aad_b64) : undefined;
+
+                try {
+                        const cipher = xchacha20poly1305(edekKey, nonce, aad);
+                        const plaintext = cipher.decrypt(ciphertext);
+                        const fingerprint = fingerprintOf(plaintext);
+                        const cached = { key: plaintext, fingerprint };
+                        envKeyCache.set(envScope, cached);
+                        return cached;
+                } catch {
+                        warnOnce(
+                                'decrypt',
+                                'Failed to decrypt environment key for deployment token; falling back to keychain derivation.',
+                        );
+                        return null;
+                }
         };
 
         const resolveEnvKey = (aad: AAD | undefined): { key: Uint8Array; fingerprint: string } | null => {
@@ -141,18 +262,21 @@ export async function decryptBundle(
                 const cachedEnv = envKeyCache.get(envScope);
                 if (cachedEnv) return cachedEnv;
 
+                const envelopeKey = tryEnvKeyFromEnvelope(aad);
+                if (envelopeKey) return envelopeKey;
+
                 let orgKey = orgKeyCache.get(org);
                 if (!orgKey) {
                         orgKey = deriveOrgKEK(masterSeed, org);
-			orgKeyCache.set(org, orgKey);
-		}
+                        orgKeyCache.set(org, orgKey);
+                }
 
-		const projScope = `${org}/${project}`;
-		let projKey = projKeyCache.get(projScope);
-		if (!projKey) {
-			projKey = deriveProjKEK(orgKey, project);
-			projKeyCache.set(projScope, projKey);
-		}
+                const projScope = `${org}/${project}`;
+                let projKey = projKeyCache.get(projScope);
+                if (!projKey) {
+                        projKey = deriveProjKEK(orgKey, project);
+                        projKeyCache.set(projScope, projKey);
+                }
 
                 const envKey = deriveEnvKEK(projKey, env);
                 const fingerprint = fingerprintOf(envKey);
@@ -161,12 +285,9 @@ export async function decryptBundle(
                 return cached;
         };
 
-	const secrets: DecryptedSecret[] = [];
-	const warnings: string[] = [];
-
-	// reuse encoders
-	const encoder = new TextEncoder();
-	const decoder = new TextDecoder();
+        // reuse encoders
+        const encoder = new TextEncoder();
+        const decoder = new TextDecoder();
 
 	for (const entry of bundle.secrets) {
                 const envKey = resolveEnvKey(entry.aad);

--- a/src/types/api/environment.ts
+++ b/src/types/api/environment.ts
@@ -106,14 +106,20 @@ export type EnvironmentSecretJson = EnvironmentSecretCommon & {
  * Bundle of environment secrets merged across inheritance layers.
  */
 export type EnvironmentSecretBundleJson = {
-	/** Target environment name (e.g., "local"). */
-	env: string;
+        /** Target environment name (e.g., "local"). */
+        env: string;
 
-	/** Chain of inherited environments (parent → child). */
-	chain: string[];
+        /** Chain of inherited environments (parent → child). */
+        chain: string[];
 
-	/** List of encrypted secrets across the chain. */
-	secrets: EnvironmentSecretJson[];
+        /** List of encrypted secrets across the chain. */
+        secrets: EnvironmentSecretJson[];
+
+        /** Optional environment key metadata (fingerprint, envelope, recipients, etc.). */
+        environment_key?: EnvironmentKeyResourceJson | null;
+
+        /** Optional camel-cased variant returned by some APIs. */
+        environmentKey?: EnvironmentKey | null;
 };
 
 /**
@@ -185,13 +191,14 @@ export type EnvironmentKeyEnvelopeRecipientJson = {
 };
 
 export type EnvironmentKeyEnvelopeAttributesJson = {
-	ciphertext_b64: string;
-	nonce_b64: string;
-	alg?: string | null;
-	created_at?: string | null;
-	updated_at?: string | null;
-	revoked_at?: string | null;
-	recipients?: EnvironmentKeyEnvelopeRecipientJson[] | null;
+        ciphertext_b64: string;
+        nonce_b64: string;
+        alg?: string | null;
+        created_at?: string | null;
+        updated_at?: string | null;
+        revoked_at?: string | null;
+        recipients?: EnvironmentKeyEnvelopeRecipientJson[] | null;
+        from_ephemeral_public_key?: string | null;
 };
 
 export type EnvironmentKeyEnvelopeResourceJson = {
@@ -225,14 +232,15 @@ export type EnvironmentKeyRecipient = {
 };
 
 export type EnvironmentKeyEnvelope = {
-	id: string;
-	ciphertextB64: string;
-	nonceB64: string;
-	alg: string | null;
-	createdAtIso: string | null;
-	updatedAtIso: string | null;
-	revokedAtIso: string | null;
-	recipients: EnvironmentKeyRecipient[];
+        id: string;
+        ciphertextB64: string;
+        nonceB64: string;
+        alg: string | null;
+        createdAtIso: string | null;
+        updatedAtIso: string | null;
+        revokedAtIso: string | null;
+        recipients: EnvironmentKeyRecipient[];
+        fromEphemeralPublicKey: string | null;
 };
 
 export type EnvironmentKey = {
@@ -307,19 +315,20 @@ function environmentKeyRecipientFromJSON(
 }
 
 function environmentKeyEnvelopeFromJSON(
-	resource: EnvironmentKeyEnvelopeResourceJson,
+        resource: EnvironmentKeyEnvelopeResourceJson,
 ): EnvironmentKeyEnvelope {
-	const attrs = resource.attributes;
-	return {
-		id: resource.id,
-		ciphertextB64: attrs.ciphertext_b64,
-		nonceB64: attrs.nonce_b64,
-		alg: attrs.alg ?? null,
-		createdAtIso: attrs.created_at ?? null,
-		updatedAtIso: attrs.updated_at ?? null,
-		revokedAtIso: attrs.revoked_at ?? null,
-		recipients: (attrs.recipients ?? []).map(environmentKeyRecipientFromJSON),
-	};
+        const attrs = resource.attributes;
+        return {
+                id: resource.id,
+                ciphertextB64: attrs.ciphertext_b64,
+                nonceB64: attrs.nonce_b64,
+                alg: attrs.alg ?? null,
+                createdAtIso: attrs.created_at ?? null,
+                updatedAtIso: attrs.updated_at ?? null,
+                revokedAtIso: attrs.revoked_at ?? null,
+                recipients: (attrs.recipients ?? []).map(environmentKeyRecipientFromJSON),
+                fromEphemeralPublicKey: attrs.from_ephemeral_public_key ?? null,
+        };
 }
 
 export function environmentKeyFromJSON(resource: EnvironmentKeyResourceJson): EnvironmentKey {


### PR DESCRIPTION
## Summary
- add noble cipher/curve dependencies required for client-side envelope decryption
- expose environment key envelope metadata on EnvironmentSecretBundle
- decrypt environment bundles via deployment token envelopes before falling back to derived KEKs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690904463b9c833398325425ae08610d