### PR TITLE
add encrypted bundle cache fallback and strict conflict defaults

### DIFF
--- a/src/commands/deploy/cache.ts
+++ b/src/commands/deploy/cache.ts
@@ -1,0 +1,57 @@
+import { Command } from 'commander';
+import ora from 'ora';
+
+import { createGhostableClient, resolveToken } from '../../support/deploy-helpers.js';
+import { warmDeployBundleCache } from '../../support/deploy-cache.js';
+import { log } from '../../support/logger.js';
+import { toErrorMessage } from '../../support/errors.js';
+
+type DeployCacheWarmOptions = {
+	token?: string;
+	only?: string[];
+};
+
+function attachDeployCacheWarmCommand(command: Command): Command {
+	return command
+		.command('warm')
+		.description('Fetch and cache the encrypted deploy bundle for this deployment token scope')
+		.option('--token <TOKEN>', 'Ghostable CI token (or env GHOSTABLE_CI_TOKEN)')
+		.option('--only <KEY...>', 'Limit cached scope to specific keys')
+		.action(async (opts: DeployCacheWarmOptions) => {
+			let token: string;
+			try {
+				token = await resolveToken(opts.token, { allowSession: false });
+			} catch (error) {
+				log.error(toErrorMessage(error));
+				process.exit(1);
+				return;
+			}
+
+			const client = createGhostableClient(token);
+			const spin = ora('Fetching encrypted deploy bundle for cache warm-up…').start();
+
+			try {
+				const warmed = await warmDeployBundleCache({
+					client,
+					token,
+					only: opts.only,
+				});
+				spin.succeed('Deploy bundle cached.');
+				log.ok(`✅ Cached ${warmed.secretsCount} encrypted secrets.`);
+				log.info(`Cache path: ${warmed.cachePath}`);
+				log.info(`Expires at: ${warmed.expiresAtIso}`);
+			} catch (error) {
+				spin.fail('Deploy cache warm-up failed.');
+				log.error(toErrorMessage(error));
+				process.exit(1);
+			}
+		});
+}
+
+export function configureDeployCacheCommand(deploy: Command) {
+	const cache = deploy
+		.command('cache')
+		.description('Manage encrypted deploy bundle cache entries');
+
+	attachDeployCacheWarmCommand(cache);
+}

--- a/src/commands/deploy/cloud.ts
+++ b/src/commands/deploy/cloud.ts
@@ -13,6 +13,7 @@ import {
 	resolveDeployMasterSeed,
 	resolveToken,
 } from '../../support/deploy-helpers.js';
+import { fetchDeployBundleWithCache, formatCacheAge } from '../../support/deploy-cache.js';
 import { log } from '../../support/logger.js';
 import { toErrorMessage } from '../../support/errors.js';
 import { resolveWorkDir } from '../../support/workdir.js';
@@ -23,6 +24,7 @@ type DeployCloudOptions = {
 	token?: string;
 	out?: string;
 	only?: string[];
+	allowStaleCache?: boolean;
 };
 
 async function runDeployCloud(opts: DeployCloudOptions): Promise<void> {
@@ -50,12 +52,23 @@ async function runDeployCloud(opts: DeployCloudOptions): Promise<void> {
 	const spin = ora('Fetching environment secret bundle…').start();
 	let bundle: EnvironmentSecretBundle;
 	try {
-		bundle = await client.deploy({
-			includeMeta: true,
-			includeVersions: true,
+		const fetched = await fetchDeployBundleWithCache({
+			client,
+			token,
 			only: opts.only,
+			allowStaleCache: opts.allowStaleCache,
 		});
-		spin.succeed('Bundle fetched.');
+		bundle = fetched.bundle;
+		if (fetched.source === 'live') {
+			spin.succeed('Bundle fetched.');
+		} else {
+			spin.succeed(
+				`Bundle loaded from stale cache (${formatCacheAge(fetched.cacheAgeSeconds ?? 0)} old).`,
+			);
+			log.warn(
+				`⚠️ Using stale encrypted cache due to Ghostable availability issue. Cache: ${fetched.cachePath}`,
+			);
+		}
 	} catch (error) {
 		spin.fail('Failed to fetch bundle.');
 		log.error(toErrorMessage(error));
@@ -94,6 +107,11 @@ function attachCloudCommand(command: Command): Command {
 		.option('--token <TOKEN>', 'Ghostable CI token (or env GHOSTABLE_CI_TOKEN)')
 		.option('--out <PATH>', 'Where to write the encrypted blob (default: .env.encrypted)')
 		.option('--only <KEY...>', 'Limit to specific keys')
+		.option(
+			'--allow-stale-cache',
+			'Allow stale encrypted cache fallback (<=24h) when Ghostable is unavailable',
+			false,
+		)
 		.action(async (opts: DeployCloudOptions) => {
 			await runDeployCloud(opts);
 		});

--- a/src/commands/deploy/forge.ts
+++ b/src/commands/deploy/forge.ts
@@ -16,6 +16,7 @@ import {
 	resolveDeployMasterSeed,
 	resolveToken,
 } from '../../support/deploy-helpers.js';
+import { fetchDeployBundleWithCache, formatCacheAge } from '../../support/deploy-cache.js';
 import { log } from '../../support/logger.js';
 import { toErrorMessage } from '../../support/errors.js';
 import { resolveWorkDir } from '../../support/workdir.js';
@@ -26,6 +27,7 @@ type DeployForgeOptions = {
 	encrypted?: boolean;
 	out?: string;
 	only?: string[];
+	allowStaleCache?: boolean;
 };
 
 async function runDeployForge(opts: DeployForgeOptions): Promise<void> {
@@ -53,12 +55,23 @@ async function runDeployForge(opts: DeployForgeOptions): Promise<void> {
 	const deploySpin = ora('Fetching environment secret bundle…').start();
 	let bundle: EnvironmentSecretBundle;
 	try {
-		bundle = await client.deploy({
-			includeMeta: true,
-			includeVersions: true,
+		const fetched = await fetchDeployBundleWithCache({
+			client,
+			token,
 			only: opts.only,
+			allowStaleCache: opts.allowStaleCache,
 		});
-		deploySpin.succeed('Bundle fetched.');
+		bundle = fetched.bundle;
+		if (fetched.source === 'live') {
+			deploySpin.succeed('Bundle fetched.');
+		} else {
+			deploySpin.succeed(
+				`Bundle loaded from stale cache (${formatCacheAge(fetched.cacheAgeSeconds ?? 0)} old).`,
+			);
+			log.warn(
+				`⚠️ Using stale encrypted cache due to Ghostable availability issue. Cache: ${fetched.cachePath}`,
+			);
+		}
 	} catch (error) {
 		deploySpin.fail('Failed to fetch bundle.');
 		log.error(toErrorMessage(error));
@@ -140,6 +153,11 @@ function attachForgeCommand(command: Command): Command {
 		.option('--encrypted', 'Also produce an encrypted blob via php artisan env:encrypt', false)
 		.option('--out <PATH>', 'Where to write the encrypted blob (default: .env.encrypted)')
 		.option('--only <KEY...>', 'Limit to specific keys')
+		.option(
+			'--allow-stale-cache',
+			'Allow stale encrypted cache fallback (<=24h) when Ghostable is unavailable',
+			false,
+		)
 		.action(async (opts: DeployForgeOptions) => {
 			await runDeployForge(opts);
 		});

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 
 import { configureDeployCloudCommand } from './cloud.js';
+import { configureDeployCacheCommand } from './cache.js';
 import { configureDeployForgeCommand } from './forge.js';
 import { configureDeployVaporCommand } from './vapor.js';
 import { configureDeployTokenCommands } from './token/index.js';
@@ -10,6 +11,7 @@ export function registerDeployCommands(program: Command) {
 		.command('deploy')
 		.description('Deploy Ghostable secrets to managed platforms or CI tokens');
 
+	configureDeployCacheCommand(deploy);
 	configureDeployCloudCommand(deploy);
 	configureDeployForgeCommand(deploy);
 	configureDeployVaporCommand(deploy);

--- a/src/commands/deploy/vapor.ts
+++ b/src/commands/deploy/vapor.ts
@@ -16,6 +16,7 @@ import {
 	resolveDeployMasterSeed,
 	resolveToken,
 } from '../../support/deploy-helpers.js';
+import { fetchDeployBundleWithCache, formatCacheAge } from '../../support/deploy-cache.js';
 import { vapor } from '../../support/vapor.js';
 import { log } from '../../support/logger.js';
 import { toErrorMessage } from '../../support/errors.js';
@@ -27,6 +28,7 @@ type DeployVaporOptions = {
 	token?: string;
 	vaporEnv?: string;
 	only?: string[];
+	allowStaleCache?: boolean;
 };
 
 async function runDeployVapor(opts: DeployVaporOptions): Promise<void> {
@@ -54,12 +56,23 @@ async function runDeployVapor(opts: DeployVaporOptions): Promise<void> {
 	const deploySpin = ora('Fetching environment secret bundle…').start();
 	let bundle: EnvironmentSecretBundle;
 	try {
-		bundle = await client.deploy({
-			includeMeta: true,
-			includeVersions: true,
+		const fetched = await fetchDeployBundleWithCache({
+			client,
+			token,
 			only: opts.only,
+			allowStaleCache: opts.allowStaleCache,
 		});
-		deploySpin.succeed('Bundle fetched.');
+		bundle = fetched.bundle;
+		if (fetched.source === 'live') {
+			deploySpin.succeed('Bundle fetched.');
+		} else {
+			deploySpin.succeed(
+				`Bundle loaded from stale cache (${formatCacheAge(fetched.cacheAgeSeconds ?? 0)} old).`,
+			);
+			log.warn(
+				`⚠️ Using stale encrypted cache due to Ghostable availability issue. Cache: ${fetched.cachePath}`,
+			);
+		}
 	} catch (error) {
 		deploySpin.fail('Failed to fetch bundle.');
 		log.error(toErrorMessage(error));
@@ -128,6 +141,11 @@ function attachVaporCommand(command: Command): Command {
 		.option('--token <TOKEN>', 'Ghostable CI token (or env GHOSTABLE_CI_TOKEN)')
 		.option('--vapor-env <ENV>', 'Target Vapor environment')
 		.option('--only <KEY...>', 'Limit to specific keys')
+		.option(
+			'--allow-stale-cache',
+			'Allow stale encrypted cache fallback (<=24h) when Ghostable is unavailable',
+			false,
+		)
 		.action(async (opts: DeployVaporOptions) => {
 			await runDeployVapor(opts);
 		});

--- a/src/commands/environment/deploy.ts
+++ b/src/commands/environment/deploy.ts
@@ -13,6 +13,7 @@ import {
 	resolveDeployMasterSeed,
 	resolveToken,
 } from '../../support/deploy-helpers.js';
+import { fetchDeployBundleWithCache, formatCacheAge } from '../../support/deploy-cache.js';
 import { log } from '../../support/logger.js';
 import { toErrorMessage } from '../../support/errors.js';
 import { resolveWorkDir } from '../../support/workdir.js';
@@ -24,6 +25,7 @@ type EnvDeployOptions = {
 	token?: string;
 	file?: string; // default: .env
 	only?: string[]; // limit to specific keys
+	allowStaleCache?: boolean;
 };
 
 export function registerEnvDeployCommand(program: Command) {
@@ -39,6 +41,11 @@ export function registerEnvDeployCommand(program: Command) {
 				.option('--token <TOKEN>', 'Ghostable CI token (or env GHOSTABLE_CI_TOKEN)')
 				.option('--file <PATH>', 'Output file (default: .env)')
 				.option('--only <KEY...>', 'Only include these keys')
+				.option(
+					'--allow-stale-cache',
+					'Allow stale encrypted cache fallback (<=24h) when Ghostable is unavailable',
+					false,
+				)
 				.action(async (opts: EnvDeployOptions) => {
 					let masterSeedB64: string;
 					try {
@@ -64,12 +71,23 @@ export function registerEnvDeployCommand(program: Command) {
 					const spin = ora('Fetching environment secret bundle…').start();
 					let bundle: EnvironmentSecretBundle;
 					try {
-						bundle = await client.deploy({
-							includeMeta: true,
-							includeVersions: true,
+						const fetched = await fetchDeployBundleWithCache({
+							client,
+							token,
 							only: opts.only,
+							allowStaleCache: opts.allowStaleCache,
 						});
-						spin.succeed('Bundle fetched.');
+						bundle = fetched.bundle;
+						if (fetched.source === 'live') {
+							spin.succeed('Bundle fetched.');
+						} else {
+							spin.succeed(
+								`Bundle loaded from stale cache (${formatCacheAge(fetched.cacheAgeSeconds ?? 0)} old).`,
+							);
+							log.warn(
+								`⚠️ Using stale encrypted cache due to Ghostable availability issue. Cache: ${fetched.cachePath}`,
+							);
+						}
 					} catch (error) {
 						spin.fail('Failed to fetch bundle.');
 						log.error(toErrorMessage(error));

--- a/src/commands/environment/push.ts
+++ b/src/commands/environment/push.ts
@@ -50,7 +50,7 @@ type ApiVersionConflict = {
 type WarnConflictAction = 'pull-and-cancel' | 'continue-overwrite' | 'cancel';
 
 function resolveConflictMode(input?: string): ConflictMode {
-	const normalized = (input ?? 'warn').trim().toLowerCase();
+	const normalized = (input ?? 'strict').trim().toLowerCase();
 
 	if (normalized === 'warn' || normalized === 'strict') {
 		return normalized;
@@ -60,7 +60,7 @@ function resolveConflictMode(input?: string): ConflictMode {
 		`❌ Invalid --conflict-mode "${input}". Valid options: ${VALID_CONFLICT_MODES.join(', ')}`,
 	);
 	process.exit(1);
-	return 'warn';
+	return 'strict';
 }
 
 function formatVersion(value: number | null): string {
@@ -201,8 +201,8 @@ export function registerEnvPushCommand(program: Command) {
 				.option('--prune-server', 'Alias for --sync', false)
 				.option(
 					'--conflict-mode <MODE>',
-					'Conflict handling mode: warn (default) or strict',
-					'warn',
+					'Conflict handling mode: strict (default) or warn',
+					'strict',
 				)
 				.option(
 					'--force-overwrite',

--- a/src/commands/environment/sync.ts
+++ b/src/commands/environment/sync.ts
@@ -18,8 +18,8 @@ export function registerEnvSyncCommand(program: Command) {
 				.option('-y, --assume-yes', 'Skip confirmation prompts', false)
 				.option(
 					'--conflict-mode <MODE>',
-					'Conflict handling mode: warn (default) or strict',
-					'warn',
+					'Conflict handling mode: strict (default) or warn',
+					'strict',
 				)
 				.option(
 					'--force-overwrite',

--- a/src/commands/vars/push.ts
+++ b/src/commands/vars/push.ts
@@ -48,7 +48,7 @@ type ApiVersionConflict = {
 type WarnConflictAction = 'pull-and-cancel' | 'continue-overwrite' | 'cancel';
 
 function resolveConflictMode(input?: string): ConflictMode {
-	const normalized = (input ?? 'warn').trim().toLowerCase();
+	const normalized = (input ?? 'strict').trim().toLowerCase();
 
 	if (normalized === 'warn' || normalized === 'strict') {
 		return normalized;
@@ -58,7 +58,7 @@ function resolveConflictMode(input?: string): ConflictMode {
 		`❌ Invalid --conflict-mode "${input}". Valid options: ${VALID_CONFLICT_MODES.join(', ')}`,
 	);
 	process.exit(1);
-	return 'warn';
+	return 'strict';
 }
 
 function formatVersion(value: number | null): string {
@@ -205,8 +205,8 @@ export function registerVarPushCommand(program: Command) {
 				.option('--token <TOKEN>', 'API token (or stored session / GHOSTABLE_TOKEN)')
 				.option(
 					'--conflict-mode <MODE>',
-					'Conflict handling mode: warn (default) or strict',
-					'warn',
+					'Conflict handling mode: strict (default) or warn',
+					'strict',
 				)
 				.option(
 					'--force-overwrite',

--- a/src/support/deploy-cache.ts
+++ b/src/support/deploy-cache.ts
@@ -1,0 +1,314 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash, createHmac } from 'node:crypto';
+
+import { config } from '@/config/index.js';
+import { EnvironmentSecretBundle } from '@/entities';
+import { HttpError } from '@/ghostable/http/errors.js';
+import type { EnvironmentSecretBundleJson } from '@/ghostable/types/environment.js';
+import type { GhostableClient } from '@/ghostable';
+import { resolveWorkDir } from './workdir.js';
+
+const DEPLOY_CACHE_SCHEMA = 'ghostable.deploy-cache.v1';
+const DEPLOY_CACHE_TTL_SECONDS = 24 * 60 * 60;
+
+type DeployBundleCacheDocument = {
+	schema: string;
+	saved_at: string;
+	expires_at: string;
+	cache_key: {
+		api_base: string;
+		token_fingerprint: string;
+		only: string[];
+	};
+	bundle: EnvironmentSecretBundleJson;
+	integrity: {
+		alg: 'hmac-sha256';
+		digest_b64: string;
+	};
+};
+
+type DeployCacheScope = {
+	apiBase: string;
+	token: string;
+	only: string[];
+};
+
+export type DeployCacheFetchResult = {
+	bundle: EnvironmentSecretBundle;
+	source: 'live' | 'stale-cache';
+	cachePath: string;
+	cacheAgeSeconds?: number;
+	expiresAtIso?: string;
+};
+
+export type DeployCacheWarmResult = {
+	cachePath: string;
+	expiresAtIso: string;
+	secretsCount: number;
+};
+
+type LoadDeployCacheResult = {
+	bundle: EnvironmentSecretBundle;
+	cachePath: string;
+	cacheAgeSeconds: number;
+	expiresAtIso: string;
+};
+
+type DeployCacheFetchOptions = {
+	client: GhostableClient;
+	token: string;
+	only?: string[];
+	allowStaleCache?: boolean;
+	apiBase?: string;
+};
+
+type DeployCacheWarmOptions = {
+	client: GhostableClient;
+	token: string;
+	only?: string[];
+	apiBase?: string;
+};
+
+function normalizeOnly(only?: string[]): string[] {
+	if (!only?.length) return [];
+	return [...new Set(only.map((value) => value.trim()).filter(Boolean))].sort((a, b) =>
+		a.localeCompare(b),
+	);
+}
+
+function tokenFingerprint(token: string): string {
+	return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+function scopeHash(scope: DeployCacheScope): string {
+	const key = stableStringify({
+		api_base: scope.apiBase,
+		token_fingerprint: tokenFingerprint(scope.token),
+		only: scope.only,
+	});
+	return createHash('sha256').update(key, 'utf8').digest('hex');
+}
+
+function resolveCachePath(scope: DeployCacheScope): string {
+	const workDir = resolveWorkDir();
+	const fileName = `${scopeHash(scope)}.json`;
+	return path.resolve(workDir, '.ghostable', 'deploy-cache', fileName);
+}
+
+function deriveIntegrityKey(token: string): Buffer {
+	return createHash('sha256')
+		.update('ghostable-deploy-cache:v1:', 'utf8')
+		.update(token, 'utf8')
+		.digest();
+}
+
+function integrityInput(doc: Omit<DeployBundleCacheDocument, 'integrity'>): string {
+	return stableStringify(doc);
+}
+
+function computeIntegrityDigest(
+	doc: Omit<DeployBundleCacheDocument, 'integrity'>,
+	token: string,
+): string {
+	return createHmac('sha256', deriveIntegrityKey(token))
+		.update(integrityInput(doc), 'utf8')
+		.digest('base64');
+}
+
+function stableStringify(value: unknown): string {
+	return JSON.stringify(sortValue(value));
+}
+
+function sortValue(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(sortValue);
+	}
+
+	if (value && typeof value === 'object') {
+		const record = value as Record<string, unknown>;
+		return Object.keys(record)
+			.sort((a, b) => a.localeCompare(b))
+			.reduce<Record<string, unknown>>((carry, key) => {
+				carry[key] = sortValue(record[key]);
+				return carry;
+			}, {});
+	}
+
+	return value;
+}
+
+function writeCacheDocument(
+	scope: DeployCacheScope,
+	bundle: EnvironmentSecretBundle,
+): DeployCacheWarmResult {
+	const now = new Date();
+	const expiresAt = new Date(now.getTime() + DEPLOY_CACHE_TTL_SECONDS * 1000);
+	const cachePath = resolveCachePath(scope);
+
+	const plainBundle = JSON.parse(JSON.stringify(bundle)) as EnvironmentSecretBundleJson;
+	const unsignedDoc: Omit<DeployBundleCacheDocument, 'integrity'> = {
+		schema: DEPLOY_CACHE_SCHEMA,
+		saved_at: now.toISOString(),
+		expires_at: expiresAt.toISOString(),
+		cache_key: {
+			api_base: scope.apiBase,
+			token_fingerprint: tokenFingerprint(scope.token),
+			only: scope.only,
+		},
+		bundle: plainBundle,
+	};
+	const signedDoc: DeployBundleCacheDocument = {
+		...unsignedDoc,
+		integrity: {
+			alg: 'hmac-sha256',
+			digest_b64: computeIntegrityDigest(unsignedDoc, scope.token),
+		},
+	};
+
+	fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+	fs.writeFileSync(cachePath, JSON.stringify(signedDoc, null, 2), 'utf8');
+
+	return {
+		cachePath,
+		expiresAtIso: expiresAt.toISOString(),
+		secretsCount: bundle.secrets.length,
+	};
+}
+
+function readCacheDocument(scope: DeployCacheScope): LoadDeployCacheResult {
+	const cachePath = resolveCachePath(scope);
+	if (!fs.existsSync(cachePath)) {
+		throw new Error('No deploy cache entry exists for this token/scope.');
+	}
+
+	let parsed: DeployBundleCacheDocument;
+	try {
+		const raw = fs.readFileSync(cachePath, 'utf8');
+		parsed = JSON.parse(raw) as DeployBundleCacheDocument;
+	} catch {
+		throw new Error('Deploy cache entry is unreadable.');
+	}
+
+	if (parsed.schema !== DEPLOY_CACHE_SCHEMA) {
+		throw new Error(`Unsupported deploy cache schema "${parsed.schema}".`);
+	}
+
+	const expectedFingerprint = tokenFingerprint(scope.token);
+	if (parsed.cache_key.api_base !== scope.apiBase) {
+		throw new Error('Deploy cache api base does not match current CLI config.');
+	}
+	if (parsed.cache_key.token_fingerprint !== expectedFingerprint) {
+		throw new Error('Deploy cache token fingerprint does not match the current token.');
+	}
+	if (stableStringify(parsed.cache_key.only ?? []) !== stableStringify(scope.only)) {
+		throw new Error('Deploy cache scope does not match requested keys.');
+	}
+
+	const unsignedDoc: Omit<DeployBundleCacheDocument, 'integrity'> = {
+		schema: parsed.schema,
+		saved_at: parsed.saved_at,
+		expires_at: parsed.expires_at,
+		cache_key: parsed.cache_key,
+		bundle: parsed.bundle,
+	};
+
+	const expectedDigest = computeIntegrityDigest(unsignedDoc, scope.token);
+	if (
+		parsed.integrity?.alg !== 'hmac-sha256' ||
+		parsed.integrity?.digest_b64 !== expectedDigest
+	) {
+		throw new Error('Deploy cache integrity verification failed.');
+	}
+
+	const savedAtMs = Date.parse(parsed.saved_at);
+	const expiresAtMs = Date.parse(parsed.expires_at);
+	if (!Number.isFinite(savedAtMs) || !Number.isFinite(expiresAtMs)) {
+		throw new Error('Deploy cache timestamp metadata is invalid.');
+	}
+
+	const nowMs = Date.now();
+	if (nowMs > expiresAtMs) {
+		throw new Error('Deploy cache entry is expired.');
+	}
+
+	return {
+		bundle: EnvironmentSecretBundle.fromJSON(parsed.bundle),
+		cachePath,
+		cacheAgeSeconds: Math.max(0, Math.floor((nowMs - savedAtMs) / 1000)),
+		expiresAtIso: parsed.expires_at,
+	};
+}
+
+function fallbackAllowed(error: unknown): boolean {
+	if (!(error instanceof HttpError)) return true;
+
+	if (error.status === 401 || error.status === 403) return false;
+
+	if (error.status >= 400 && error.status < 500 && error.status !== 408 && error.status !== 429) {
+		return false;
+	}
+
+	return true;
+}
+
+export function formatCacheAge(ageSeconds: number): string {
+	if (ageSeconds < 60) return `${ageSeconds}s`;
+	if (ageSeconds < 3600) return `${Math.floor(ageSeconds / 60)}m ${ageSeconds % 60}s`;
+	const hours = Math.floor(ageSeconds / 3600);
+	const mins = Math.floor((ageSeconds % 3600) / 60);
+	return `${hours}h ${mins}m`;
+}
+
+export async function fetchDeployBundleWithCache(
+	options: DeployCacheFetchOptions,
+): Promise<DeployCacheFetchResult> {
+	const scope: DeployCacheScope = {
+		apiBase: options.apiBase ?? config.apiBase,
+		token: options.token,
+		only: normalizeOnly(options.only),
+	};
+	const allowStaleCache = Boolean(options.allowStaleCache);
+
+	try {
+		const bundle = await options.client.deploy({
+			includeMeta: true,
+			includeVersions: true,
+			only: scope.only.length ? scope.only : undefined,
+		});
+		const warmed = writeCacheDocument(scope, bundle);
+
+		return {
+			bundle,
+			source: 'live',
+			cachePath: warmed.cachePath,
+		};
+	} catch (error) {
+		if (!allowStaleCache || !fallbackAllowed(error)) {
+			throw error;
+		}
+
+		return {
+			...readCacheDocument(scope),
+			source: 'stale-cache',
+		};
+	}
+}
+
+export async function warmDeployBundleCache(
+	options: DeployCacheWarmOptions,
+): Promise<DeployCacheWarmResult> {
+	const scope: DeployCacheScope = {
+		apiBase: options.apiBase ?? config.apiBase,
+		token: options.token,
+		only: normalizeOnly(options.only),
+	};
+
+	const bundle = await options.client.deploy({
+		includeMeta: true,
+		includeVersions: true,
+		only: scope.only.length ? scope.only : undefined,
+	});
+
+	return writeCacheDocument(scope, bundle);
+}

--- a/test/deploy-cache.test.ts
+++ b/test/deploy-cache.test.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { EnvironmentSecretBundle } from '@/entities';
+import { HttpError } from '@/ghostable/http/errors.js';
+import { fetchDeployBundleWithCache } from '@/support/deploy-cache.js';
+
+describe('deploy cache', () => {
+	const createdDirs: string[] = [];
+	const previousWorkDir = process.env.GHOSTABLE_WORKDIR;
+
+	afterEach(() => {
+		for (const dir of createdDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+
+		if (previousWorkDir === undefined) {
+			delete process.env.GHOSTABLE_WORKDIR;
+		} else {
+			process.env.GHOSTABLE_WORKDIR = previousWorkDir;
+		}
+	});
+
+	it('writes cache on live fetch and falls back to stale cache on availability failures', async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghostable-deploy-cache-'));
+		createdDirs.push(tempDir);
+		process.env.GHOSTABLE_WORKDIR = tempDir;
+
+		const bundle = EnvironmentSecretBundle.fromJSON({
+			env: 'production',
+			chain: ['production'],
+			secrets: [],
+		});
+		const client = {
+			deploy: async () => bundle,
+		};
+
+		const live = await fetchDeployBundleWithCache({
+			client: client as never,
+			token: 'ci-token-1',
+			allowStaleCache: false,
+		});
+
+		expect(live.source).toBe('live');
+		expect(fs.existsSync(live.cachePath)).toBe(true);
+
+		const unavailableClient = {
+			deploy: async () => {
+				throw new HttpError(503, 'upstream unavailable');
+			},
+		};
+
+		const stale = await fetchDeployBundleWithCache({
+			client: unavailableClient as never,
+			token: 'ci-token-1',
+			allowStaleCache: true,
+		});
+
+		expect(stale.source).toBe('stale-cache');
+		expect(stale.cacheAgeSeconds).toBeGreaterThanOrEqual(0);
+		expect(stale.bundle.env).toBe('production');
+	});
+
+	it('rejects stale fallback when cache integrity is tampered', async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghostable-deploy-cache-'));
+		createdDirs.push(tempDir);
+		process.env.GHOSTABLE_WORKDIR = tempDir;
+
+		const bundle = EnvironmentSecretBundle.fromJSON({
+			env: 'production',
+			chain: ['production'],
+			secrets: [],
+		});
+		const client = {
+			deploy: async () => bundle,
+		};
+
+		const live = await fetchDeployBundleWithCache({
+			client: client as never,
+			token: 'ci-token-2',
+		});
+		const parsed = JSON.parse(fs.readFileSync(live.cachePath, 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		parsed['saved_at'] = new Date(Date.now() - 60_000).toISOString();
+		fs.writeFileSync(live.cachePath, JSON.stringify(parsed, null, 2), 'utf8');
+
+		const unavailableClient = {
+			deploy: async () => {
+				throw new HttpError(503, 'upstream unavailable');
+			},
+		};
+
+		await expect(
+			fetchDeployBundleWithCache({
+				client: unavailableClient as never,
+				token: 'ci-token-2',
+				allowStaleCache: true,
+			}),
+		).rejects.toThrow('integrity');
+	});
+});


### PR DESCRIPTION
Add deploy cache warm plus --allow-stale-cache fallback for deploy commands using a signed 24h cache, and switch env/vars push + env sync default conflict mode to strict.